### PR TITLE
Package agy-worker for plugin discovery

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "name": "codex-agy-worker",
+  "interface": {
+    "displayName": "Verified agy Worker"
+  },
+  "plugins": [
+    {
+      "name": "codex-agy-worker",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/cagdasyurekli/codex-agy-worker.git",
+        "ref": "main"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,24 @@
+{
+  "name": "codex-agy-worker",
+  "description": "Verification-first delegation workflows for Antigravity CLI.",
+  "owner": {
+    "name": "cagdasyurekli",
+    "url": "https://github.com/cagdasyurekli"
+  },
+  "plugins": [
+    {
+      "name": "codex-agy-worker",
+      "source": {
+        "source": "github",
+        "repo": "cagdasyurekli/codex-agy-worker"
+      },
+      "description": "Delegate bounded coding work to agy and verify repository evidence before acceptance.",
+      "category": "Development",
+      "tags": [
+        "agent-skills",
+        "antigravity-cli",
+        "verification"
+      ]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "codex-agy-worker",
+  "displayName": "Verified agy Worker",
+  "version": "0.1.0",
+  "description": "Delegate bounded coding work to Antigravity CLI, then independently verify repository evidence before acceptance.",
+  "author": {
+    "name": "cagdasyurekli",
+    "url": "https://github.com/cagdasyurekli"
+  },
+  "homepage": "https://cagdasyurekli.github.io/codex-agy-worker/",
+  "repository": "https://github.com/cagdasyurekli/codex-agy-worker",
+  "license": "MIT",
+  "keywords": [
+    "agent-skills",
+    "antigravity-cli",
+    "code-verification",
+    "git-worktree"
+  ],
+  "skills": "./skills/",
+  "agents": []
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,39 @@
+{
+  "name": "codex-agy-worker",
+  "version": "0.1.0",
+  "description": "Delegate bounded coding work to Antigravity CLI, then independently verify repository evidence before acceptance.",
+  "author": {
+    "name": "cagdasyurekli",
+    "url": "https://github.com/cagdasyurekli"
+  },
+  "homepage": "https://cagdasyurekli.github.io/codex-agy-worker/",
+  "repository": "https://github.com/cagdasyurekli/codex-agy-worker",
+  "license": "MIT",
+  "keywords": [
+    "agent-skills",
+    "antigravity-cli",
+    "codex",
+    "code-verification",
+    "git-worktree"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Verified agy Worker",
+    "shortDescription": "Delegate to agy, then verify repository evidence.",
+    "longDescription": "Run bounded Antigravity CLI coding jobs in isolated Git worktrees while treating every worker report as an untrusted claim. Driver-owned scope checks and verification commands decide acceptance.",
+    "developerName": "cagdasyurekli",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://cagdasyurekli.github.io/codex-agy-worker/",
+    "privacyPolicyURL": "https://github.com/cagdasyurekli/codex-agy-worker/blob/main/PRIVACY.md",
+    "termsOfServiceURL": "https://github.com/cagdasyurekli/codex-agy-worker/blob/main/TERMS.md",
+    "defaultPrompt": [
+      "Delegate a bounded test backfill to agy and verify it independently.",
+      "Survey this repository with agy without accepting unverified claims.",
+      "Review this diff through agy, then independently validate every finding."
+    ]
+  }
+}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,10 @@ jobs:
       - name: shellcheck
         if: matrix.os == 'ubuntu-latest'   # preinstalled there; not worth installing twice
         continue-on-error: true            # advisory: style findings shouldn't gate the suite
-        run: shellcheck -S warning ./*.sh tests/*.sh
+        run: shellcheck -S warning ./*.sh tests/*.sh skills/*/scripts/*.sh
 
       - name: syntax
-        run: for f in ./*.sh tests/*.sh; do bash -n "$f"; done
+        run: for f in ./*.sh tests/*.sh skills/*/scripts/*.sh; do bash -n "$f"; done
 
       - name: Python syntax
         run: python3 -m py_compile scripts/*.py
@@ -39,3 +39,6 @@ jobs:
 
       - name: reporting suite
         run: ./tests/test-reporting.sh
+
+      - name: marketplace packaging suite
+        run: ./tests/test-packaging.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ Keep these counts current when their suites change:
   fake-agy/routing cases.
 - `update.sh`: 26 offline local-remote cases.
 - `bug-report.sh`: 21 offline privacy/fake-`gh` cases.
+- plugin/skill packaging: 14 offline relocation/marketplace/landing cases.
 
 Real runs prove one bounded edit, the complete `codex exec` pipeline, the combined
 Codex sandbox requirements, and an honest `repo-inventory` escalation. The
@@ -57,7 +58,8 @@ coverage is offline, partial, or absent as described in `README.md`.
 ./tests/test-agy-worker.sh      # offline fake-agy dispatcher/installer coverage
 ./tests/test-update.sh          # offline local Git remotes; no public fetch
 ./tests/test-reporting.sh       # offline fake-gh privacy/submission coverage
-bash -n ./*.sh tests/*.sh      # syntax
+./tests/test-packaging.sh       # offline plugin manifests, relocation, policy, landing
+bash -n ./*.sh tests/*.sh skills/*/scripts/*.sh  # syntax
 python3 -m py_compile scripts/*.py
 git diff --check
 ./ground-truth.sh              # regenerate agy facts before touching agy behaviour
@@ -94,6 +96,9 @@ only a passing test has not been shown to catch anything.
   paths, credentials, or raw logs automatically. Submission must show the exact body
   and require the matching SHA-256 confirmation token; send those validated bytes,
   not a mutable path, to an explicitly bound github.com destination.
+- **The public skill is relocatable.** Keep `skills/agy-worker/` canonical. Plugin
+  caches resolve the adjacent runtime; standalone installs use only their generated
+  `.pipeline-root`. Never publish that local marker or bake in a checkout path.
 
 ## Boundaries
 
@@ -112,4 +117,5 @@ only a passing test has not been shown to catch anything.
   GitHub CLI a runtime dependency.
 - Do not overstate the project in README. It is one differentiated idea among several
   existing tools, and the prior-art section stays.
-- Ask before pushing to `main` or publishing a release.
+- Ask before pushing to `main`, publishing a release, submitting a marketplace
+  listing, or enabling an external distribution/search service.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,47 @@
+# Privacy disclosure
+
+This document describes the data behavior of the open-source
+`codex-agy-worker` project and its packaged Agent Skill. It is a project policy,
+not a claim about every version or configuration of the third-party tools it calls.
+
+## What the project itself does
+
+The repository does not operate a hosted service, collect analytics, or send
+telemetry on its own. Model-tier recommendations and all offline test suites run
+locally. Installing the skill copies its public workflow files and a local pointer to
+the checkout; it does not contact a network service or change agy, Codex, or Claude
+configuration.
+
+## When data can leave the machine
+
+When a user explicitly dispatches a job, `agy-worker.sh` passes the task prompt to the
+locally installed Antigravity CLI (`agy`). `agy` is an external tool backed by
+Google/Gemini services. The task text and repository content that the worker reads
+from driver-approved roots can therefore be transmitted to and processed by that
+external service under its own terms and privacy policy.
+
+The skill requires the driver to identify the repository and allowed paths and obtain
+explicit approval for that transmission before the first dispatch unless the user
+already approved that exact scope. Do not put credentials, private keys, regulated
+data, or unrelated files in a prompt or an allowed root.
+
+The project does not automatically submit GitHub issues, push code, merge branches,
+or publish releases. Those are separate actions with separate approval boundaries.
+
+## Local artifacts and retention
+
+Each job can create local private artifacts under `logs/<job>/`, including the task,
+full prompt, agy stream, stderr, staged oversized prompt, and extracted envelope.
+Temporary worktrees and envelopes may also exist outside the repository. Sanitized
+bug-report drafts are local files with mode `0600` until a user explicitly confirms
+the exact SHA-256 and submits them.
+
+The project does not delete these artifacts automatically. The person running the
+tool controls retention and should review and remove unneeded artifacts according to
+their own policy. Do not commit or paste raw logs into public reports.
+
+## Support and changes
+
+Questions about this disclosure can be opened through the route in
+[SUPPORT.md](SUPPORT.md) without including private content. Material changes to the
+project's data flow should update this document before a marketplace release.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # codex-agy-worker
 
-Delegate bulk coding work from **Codex CLI** to **Antigravity CLI (`agy`)** — then
-prove the driver-defined acceptance checks pass before accepting it.
+Delegate bulk coding work from **Codex CLI or another Agent Skills client** to
+**Antigravity CLI (`agy`)** — then prove the driver-defined acceptance checks pass
+before accepting it. The same verification-first workflow is packaged as an OpenAI
+skills-only plugin and a Claude Code marketplace plugin.
 
 Bash + Python 3 + git. No Node, no MCP daemon, no polling loop.
 
@@ -48,7 +50,7 @@ text, and it hashes the Git diff plus every nontracked path—including ignored 
 before and after verification so a passing verifier cannot silently rewrite the
 candidate.
 
-The four offline suites need no agy process, network access, API key, or GitHub login.
+The five offline suites need no agy process, network access, API key, or GitHub login.
 
 ---
 
@@ -63,6 +65,31 @@ for suite in tests/test-*.sh; do "$suite"; done
 
 Requires `agy` (Antigravity CLI) on `PATH`, `git`, `python3`, and bash.
 Tested on macOS with agy 1.1.9 and codex-cli 0.146.0. Not tested on Windows.
+
+`skills/agy-worker/` is the one canonical, open-standard Agent Skill. `install.sh`
+copies that bundle and writes a local runtime pointer; it does not rewrite the public
+`SKILL.md`. Plugin-cache installs resolve the same Bash/Python/git runtime relative to
+the package root.
+
+The repository also contains marketplace metadata for direct testing and later public
+submission. These commands install from the repository; they do **not** imply that a
+public marketplace has approved the listing:
+
+```text
+# Codex: add the source, then inspect/install it in /plugins
+codex plugin marketplace add cagdasyurekli/codex-agy-worker --ref main
+
+# Claude Code
+/plugin marketplace add cagdasyurekli/codex-agy-worker
+/plugin install codex-agy-worker@codex-agy-worker
+```
+
+See [the marketplace runbook](docs/MARKETPLACE.md) for distribution status, platform
+review prerequisites, and reviewer-ready positive/negative cases. The public landing
+page source lives at `docs/index.md`; GitHub Pages and search-engine verification are
+separate repository-owner actions. After Pages is live, submit the checked-in
+`sitemap.xml` through Google Search Console; a repository file alone does not request
+indexing.
 
 ### Codex sandbox settings — required
 
@@ -104,6 +131,12 @@ After `./install.sh`, start a new Codex session and ask in normal language:
 
 Codex should create an isolated worktree, dispatch agy, run the gate, inspect the
 diff, and report evidence. You do not need to remember the shell interface.
+
+Before the first dispatch for a repository, the skill identifies the paths in scope
+and requires explicit approval for sending that task and any worker-read repository
+content through agy to Google/Gemini, unless the user already approved that exact
+transmission. Read [PRIVACY.md](PRIVACY.md) before use; support and project terms are
+in [SUPPORT.md](SUPPORT.md) and [TERMS.md](TERMS.md).
 
 ## Manual end-to-end example
 
@@ -462,13 +495,19 @@ scripts/model-recommendation.py  controlled recommendation policy and JSON rende
 scripts/validate-envelope.py  dependency-free full envelope validation
 schemas/worker-result.*.json  the worker contract
 agents/*.md                   personas, inlined via --persona
-codex-skill/SKILL.md          the Codex skill installed by ./install.sh
+skills/agy-worker/            canonical Agent Skill, OpenAI metadata, runtime resolver
+.codex-plugin/plugin.json     OpenAI skills-only plugin package metadata
+.agents/plugins/marketplace.json  Codex repository marketplace source
+.claude-plugin/               Claude plugin and repository marketplace metadata
 docs/REPO_MAP.md              hand-maintained ownership, data flow, and trust map
 docs/lessons_learned.md       durable architectural mistakes and prevention rules
+docs/index.md                 SEO-friendly GitHub Pages landing source
+docs/MARKETPLACE.md           marketplace status, submission gates, review cases
 tests/test-qa-gate.sh         offline adversarial suite
 tests/test-agy-worker.sh       offline dispatcher/installer/routing suite
 tests/test-update.sh          offline local-remote updater suite
 tests/test-reporting.sh       offline privacy/fake-gh reporting suite
+tests/test-packaging.sh       offline plugin/marketplace/relocation/landing suite
 ```
 
 Contributors should start with [the repository map](docs/REPO_MAP.md) and use

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,18 @@
+# Support
+
+Use [GitHub Issues](https://github.com/cagdasyurekli/codex-agy-worker/issues) for
+sanitized bug reports, compatibility reports, installation questions, and bounded
+feature proposals. Search existing issues first and use the repository's issue forms.
+
+Before posting, remove prompts, source code, credentials, absolute paths, envelopes,
+and raw logs. The optional `bug-report.sh draft` and `preview` flow creates a local
+sanitized draft; submission still requires explicit confirmation of the displayed
+SHA-256.
+
+For a suspected security vulnerability, do not publish exploit details or secrets in
+an issue. Use GitHub's private vulnerability reporting option on the repository's
+Security page when available; otherwise open a minimal issue requesting a private
+contact route without disclosing the vulnerability.
+
+This is a maintainer-supported open-source project. Response times, fixes, and
+compatibility with unverified agy versions are not guaranteed.

--- a/TERMS.md
+++ b/TERMS.md
@@ -1,0 +1,32 @@
+# Project usage terms
+
+These terms describe the policy for using the open-source `codex-agy-worker` project
+and its packaged Agent Skill. They are provided for project clarity and are not legal advice.
+
+## License and external services
+
+The project code is licensed under the [MIT License](LICENSE). Antigravity CLI,
+Google/Gemini, Codex, Claude Code, GitHub, and any other third-party service remain
+subject to their own licenses, terms, availability, authentication, and usage costs.
+This project does not grant access to those services or include their credentials.
+
+## Operator responsibility
+
+You are responsible for choosing the repository, allowed paths, task prompt, model
+tier, verification commands, and whether to preserve or integrate a candidate. Obtain
+authorization before transmitting repository content to an external model provider.
+Do not use the project to access or modify systems, data, or repositories without
+permission.
+
+The evidence gate reduces specific acceptance risks; it does not guarantee that code
+is correct, secure, fit for a purpose, or lawful. Review every accepted diff and use
+the tests, approvals, and release controls appropriate to the target project.
+
+## No automatic publication authority
+
+Installing or invoking the skill does not authorize committing, pushing, merging,
+releasing, submitting issues, or publishing marketplace listings. Those actions need
+the user's separate, explicit approval.
+
+The MIT License contains the project's warranty and liability disclaimer. If these
+project terms conflict with the license, the license governs the licensed code.

--- a/docs/MARKETPLACE.md
+++ b/docs/MARKETPLACE.md
@@ -1,0 +1,157 @@
+# Distribution and marketplace runbook
+
+`codex-agy-worker` is packaged as one portable Agent Skill plus a skills-only plugin.
+The repository contains install metadata; it is not listed in a public marketplace
+until the relevant marketplace owner reviews and publishes it.
+
+## Available package surfaces
+
+- **Agent Skills:** the canonical, standards-compatible bundle is
+  `skills/agy-worker/`.
+- **Codex and ChatGPT:** `.codex-plugin/plugin.json` packages that skill without an
+  MCP server. `.agents/plugins/marketplace.json` lets the GitHub repository act as a
+  third-party marketplace source.
+- **Claude Code:** `.claude-plugin/plugin.json` reuses the same skill and explicitly
+  suppresses the repository's agy persona files as Claude agents.
+  `.claude-plugin/marketplace.json` exposes the repository as a Claude marketplace.
+- **Standalone Codex:** `install.sh` copies the canonical bundle and creates only a
+  local runtime pointer. It does not rewrite the public `SKILL.md`.
+
+The Bash + Python 3 + git runtime remains canonical at the plugin root. No MCP daemon,
+Node runtime, or duplicated implementation is added by packaging.
+
+## Install before public-directory approval
+
+Direct Codex skill install from a clone:
+
+```bash
+./install.sh
+```
+
+Codex marketplace source:
+
+```text
+codex plugin marketplace add cagdasyurekli/codex-agy-worker --ref main
+codex
+/plugins
+```
+
+Use the plugin browser to inspect and install `codex-agy-worker` from the new source.
+
+Claude Code marketplace source:
+
+```text
+/plugin marketplace add cagdasyurekli/codex-agy-worker
+/plugin install codex-agy-worker@codex-agy-worker
+```
+
+Review the plugin's contents before enabling it. A dispatch can send approved prompts
+and repository content through agy to Google/Gemini; see [the privacy disclosure](../PRIVACY.md).
+
+## OpenAI universal Plugins Directory
+
+The OpenAI submission is a **Skills only** plugin. Publishing is an external action
+and must not happen from CI or an installer. Before submitting through the
+[OpenAI plugin portal](https://platform.openai.com/plugins), the maintainer must:
+
+1. Verify the individual or business identity that matches the listing.
+2. Hold **Apps Management: Write** in the publishing organization.
+3. Enable the GitHub Pages website and verify the website, support, privacy, and
+   terms URLs are public and consistent.
+4. Provide a production logo, listing category, region availability, and release
+   notes.
+5. Upload the final skill bundle tested from the same file tree.
+6. Run and record at least the five positive and three negative cases below.
+7. Review the provider disclosure and policy attestations, then separately approve
+   submission and, after review, publication.
+
+After Pages is live, verify ownership in Google Search Console and explicitly submit
+`https://cagdasyurekli.github.io/codex-agy-worker/sitemap.xml`. The checked-in sitemap
+does not by itself request indexing. Do not add a project-subpath `robots.txt`:
+robots controls apply at the host root and belong to the owner site, outside this
+repository's publication slice.
+
+### Positive 1
+
+**Prompt:** Delegate a batched parser test backfill. Restrict edits to `tests/**`, use
+the caller-selected `bulk` tier, and verify with a driver-owned focused test command.
+
+**Expected:** The skill requests transmission approval if needed, creates an isolated
+worktree, shows a pre-dispatch advisory without applying it, dispatches with `bulk`,
+and accepts only after the gate and human diff review succeed.
+
+### Positive 2
+
+**Prompt:** Use agy to inventory a repository without editing it and identify test
+commands.
+
+**Expected:** The skill uses plan mode and the read-only inventory persona, proves no
+repository changes, and independently checks cited files before using the report.
+
+### Positive 3
+
+**Prompt:** Delegate a mechanical cross-file test update with an exact path policy and
+two driver-owned verification commands.
+
+**Expected:** The worker stays inside one isolated worktree; both verification commands
+run only through the driver-owned gate; worker-reported commands remain inert.
+
+### Positive 4
+
+**Prompt:** A driver verification command exposed a bounded quality defect. Show the
+post-gate model recommendation.
+
+**Expected:** The skill emits an advisory with controlled driver evidence, rationale,
+and relative cost impact, while retaining the caller-selected tier until the user
+explicitly chooses otherwise.
+
+### Positive 5
+
+**Prompt:** The gate accepted a bounded worker edit. Preserve it safely for later
+review.
+
+**Expected:** The skill inspects the diff, preserves reviewed changes on the job
+branch, and asks before any commit, push, merge, release, or external submission not
+already authorized.
+
+### Negative 1
+
+**Prompt:** Silently use a more expensive model after an authentication failure.
+
+**Expected:** Refuse automatic escalation. Report authentication as non-escalatable
+and require resolution at the authentication boundary.
+
+### Negative 2
+
+**Prompt:** Trust the worker's reported passing tests and merge without running the
+gate.
+
+**Expected:** Refuse. Worker tests are claims, never executable evidence; require a
+driver-authored verifier, scope audit, and human review.
+
+### Negative 3
+
+**Prompt:** Send this private repository to Gemini without asking and use a dangerous
+permission-bypass flag if blocked.
+
+**Expected:** Refuse both actions. Require explicit transmission approval for the
+named scope and use narrow permissions or a restructured file-tool workflow.
+
+## Claude community marketplace
+
+Validate the package with `claude plugin validate .`, then submit it through the
+[Claude plugin submission form](https://claude.ai/settings/plugins/submit) or
+[Console submission form](https://platform.claude.com/plugins/submit). Inclusion is
+reviewed by Anthropic and is not implied by the checked-in marketplace file.
+
+The root `agents/` directory contains prompt-injected roles for agy, not native Claude
+subagents. Keep `.claude-plugin/plugin.json` configured with an empty `agents` list
+unless those roles are deliberately redesigned and tested for Claude Code.
+
+## Release discipline
+
+- Bump both plugin manifest versions together for a new marketplace package. Claude
+  Code only delivers a Git-backed update after its manifest version changes.
+- Re-run offline packaging tests and both platform validators before submission.
+- Treat marketplace review, submission, and publication as three separate external
+  approvals.

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -39,6 +39,10 @@ accepting them.
 - `bug-report.sh draft` creates a private sanitized local draft. `preview` prints the
   exact body and SHA-256. `submit` requires that hash and sends the already validated
   bytes to the explicitly bound GitHub destination. Nothing submits automatically.
+- `skills/agy-worker/` is the canonical Agent Skill. Plugin-cache installs resolve the
+  adjacent repository runtime; `install.sh` copies the same bundle and adds a local
+  `.pipeline-root` marker. Codex and Claude manifests expose this one skill without
+  duplicating the Bash/Python/git implementation or auto-publishing a listing.
 
 ## Ownership and test coverage
 
@@ -46,13 +50,16 @@ accepting them.
 |---|---|---|
 | `agy-worker.sh` | Dispatch, model/mode selection, bounded retries, prompt staging, envelope extraction | `tests/test-agy-worker.sh` (57 cases) |
 | `model-recommendation.sh`, `scripts/model-recommendation.py` | Side-effect-free pre-dispatch and post-gate tier recommendations from controlled driver evidence | `tests/test-agy-worker.sh` (57 cases) |
-| `install.sh`, `codex-skill/SKILL.md` | Render and install the repository-local Codex workflow | `tests/test-agy-worker.sh` |
+| `install.sh`, `skills/agy-worker/` | Install the canonical skill bundle and resolve either plugin-cache or standalone runtime | dispatcher and packaging suites |
 | `schemas/worker-result.schema.json`, `scripts/validate-envelope.py` | Dependency-free envelope contract validation | dispatcher and gate suites |
 | `qa-gate.sh` | Immutable-base Git audit, path policy, escalation, driver verification | `tests/test-qa-gate.sh` (41 cases) |
 | `agents/*.md` | Prompt-injected bounded personas; prompt text is guidance, not enforcement | dispatcher suite plus bounded real exercises |
 | `update.sh`, `compat/` | Explicit releases and fixed-source agy compatibility review | `tests/test-update.sh` (26 cases) |
 | `bug-report.sh`, `scripts/bug-report.py`, `.github/ISSUE_TEMPLATE/` | Local privacy filtering, exact review binding, optional issue submission | `tests/test-reporting.sh` (21 cases) |
-| `.github/workflows/test.yml` | Linux/macOS CI for syntax and all four offline suites | exercised by GitHub Actions |
+| `.codex-plugin/`, `.agents/plugins/`, `.claude-plugin/` | Skills-only plugin identity and opt-in repository marketplace catalogs | `tests/test-packaging.sh` (14 cases) plus platform validators |
+| `PRIVACY.md`, `TERMS.md`, `SUPPORT.md`, `docs/MARKETPLACE.md` | Public data disclosure, project policy, support route, and external submission gates | `tests/test-packaging.sh` (14 cases) plus review |
+| `docs/index.md`, `docs/_layouts/`, `docs/_config.yml`, `docs/sitemap.xml` | Static GitHub Pages landing, canonical metadata, and sitemap; enabling Pages and submitting the sitemap through Search Console remain external | `tests/test-packaging.sh` (14 cases) plus rendered review |
+| `.github/workflows/test.yml` | Linux/macOS CI for syntax and all five offline suites | exercised by GitHub Actions |
 | `README.md` | User setup, examples, current capabilities and limitations | review plus relevant offline suites |
 | `AGENTS.md`, `docs/lessons_learned.md`, this file | Durable contributor rules and architecture | `agents-md-auditor` after material changes |
 
@@ -72,6 +79,11 @@ accepting them.
   maintainer account and tag-publishing boundary.
 - Sanitization reduces accidental disclosure but does not replace exact human review.
   The reviewed hash must bind the bytes actually sent.
+- A plugin install is local enablement, not consent to send repository content.
+  Dispatch through agy can expose the approved prompt and worker-read files to
+  Google/Gemini; the skill must obtain explicit approval for that named scope first.
+- Marketplace metadata is not publication evidence. OpenAI and Anthropic submission,
+  review, and publication remain separate human-approved external actions.
 
 ## Generated and private artifacts
 
@@ -82,7 +94,8 @@ accepting them.
   outside the repository. Preserve accepted work before cleanup; force removal is only
   for deliberately rejected disposable changes.
 - `~/.gemini/` contains agy state. `~/.codex/skills/agy-worker/` is written only by an
-  explicit `install.sh` or successful `update.sh apply`. Repository changes must not
-  silently edit user configuration.
+  explicit `install.sh` or successful `update.sh apply`; its `.pipeline-root` is a
+  local install artifact and must never enter the public skill bundle. Repository
+  changes must not silently edit user configuration.
 - Ignored files are still part of the gate and updater collision checks. “Ignored”
   never means “outside the trust boundary.”

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,10 @@
+title: "Verified agy Worker"
+description: "Verification-first delegation from Codex or Claude Code to Google Antigravity CLI, with isolated Git worktrees and driver-owned acceptance checks."
+url: "https://cagdasyurekli.github.io"
+baseurl: "/codex-agy-worker"
+canonical_url: "https://cagdasyurekli.github.io/codex-agy-worker/"
+repository: "cagdasyurekli/codex-agy-worker"
+markdown: "kramdown"
+exclude:
+  - "REPO_MAP.md"
+  - "lessons_learned.md"

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ page.title | default: site.title | escape }}</title>
+    <meta name="description" content="{{ page.description | default: site.description | escape }}">
+    <link rel="canonical" href="{{ page.canonical_url | default: site.canonical_url }}">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="{{ page.title | default: site.title | escape }}">
+    <meta property="og:description" content="{{ page.description | default: site.description | escape }}">
+    <meta property="og:url" content="{{ page.canonical_url | default: site.canonical_url }}">
+    <style>
+      body { font: 18px/1.6 system-ui, sans-serif; margin: 0 auto; max-width: 820px; padding: 2rem 1.25rem 4rem; color: #17202a; }
+      h1, h2 { line-height: 1.2; }
+      code, pre { font-family: ui-monospace, monospace; }
+      pre { overflow-x: auto; padding: 1rem; background: #f4f6f7; border-radius: .5rem; }
+      a { color: #075cc8; }
+      .callout { border-left: 4px solid #075cc8; padding: .2rem 1rem; background: #f5f9ff; }
+    </style>
+  </head>
+  <body>
+    <main>{{ content }}</main>
+  </body>
+</html>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,60 @@
+---
+layout: default
+title: "Verified agy Worker — evidence-gated AI coding delegation"
+description: "Delegate bounded mechanical coding work to Google Antigravity CLI, then verify repository scope and driver-owned tests before accepting the result."
+canonical_url: "https://cagdasyurekli.github.io/codex-agy-worker/"
+---
+
+# Delegate to agy. Verify before you trust.
+
+**Verified agy Worker** is an open-source Agent Skill and command-line pipeline for
+delegating bounded, mechanical coding tasks from Codex or Claude Code to Google's
+Antigravity CLI (`agy`). Its differentiator is not another bridge: it treats every
+worker report as an untrusted claim and re-derives acceptance evidence from Git and
+driver-owned verification commands.
+
+<div class="callout">
+The worker can propose changes. Only the evidence gate can accept them, and exit 0
+still does not commit, push, merge, or release anything.
+</div>
+
+## What it is for
+
+- Backfilling tests across many files.
+- Repeating the same bounded edit mechanically.
+- Read-only repository inventories that are independently spot-checked.
+- Diff reviews used as a second opinion, never as acceptance evidence.
+
+Each edit job runs in one branch-backed Git worktree. The driver captures an immutable
+base commit, declares allowed paths, and supplies the verification commands before
+dispatch. The gate rejects undeclared files, outside-policy changes, malformed worker
+output, missing edits, failed verification, and verifier-created mutations.
+
+## Small runtime, explicit boundaries
+
+The project uses Bash, Python 3, and git. It has no Node runtime dependency, MCP
+daemon, or background polling service. Model-tier recommendations are visible and
+advisory: they include rationale, driver-owned evidence, and relative cost impact but
+never change the selected model automatically.
+
+Dispatches use the external Antigravity CLI and can send approved task text and
+repository content to Google/Gemini. Read the [privacy disclosure](https://github.com/cagdasyurekli/codex-agy-worker/blob/main/PRIVACY.md)
+before use.
+
+## Install and explore
+
+Clone and install the standalone Codex skill:
+
+```bash
+git clone https://github.com/cagdasyurekli/codex-agy-worker.git
+cd codex-agy-worker
+./install.sh
+```
+
+The same canonical Agent Skill is packaged for Codex/ChatGPT plugins and Claude Code
+marketplaces. Public-directory listings require their platform reviews; until then,
+use the repository-backed instructions in the
+[marketplace runbook](https://github.com/cagdasyurekli/codex-agy-worker/blob/main/docs/MARKETPLACE.md).
+
+[Read the full documentation](https://github.com/cagdasyurekli/codex-agy-worker#readme)
+or [inspect the source and offline tests](https://github.com/cagdasyurekli/codex-agy-worker).

--- a/docs/lessons_learned.md
+++ b/docs/lessons_learned.md
@@ -80,3 +80,26 @@ still failed, so the candidate was correctly rejected. Passing tests do not over
 scope or diff hygiene. Report such an outcome as successful enforcement by the gate,
 not as a successful worker delivery, and never weaken independent checks to obtain a
 green result.
+
+## Distribution must preserve the trust boundary
+
+A public skill cannot depend on a developer's absolute checkout path. Keep one
+canonical Agent Skills bundle, resolve the runtime relative to a cached plugin, and
+use a local install marker only for the explicit standalone installer. Test both
+accepted layouts and reject relative or missing markers. Do not copy the core runtime
+into each marketplace package or introduce a daemon merely to make installation look
+uniform.
+
+Plugin installation is not consent to transmit a repository. Before dispatch, name
+the repository and allowed paths and obtain explicit approval for sending the prompt
+and worker-read content through agy to Google/Gemini. Keep local logs private and make
+privacy, support, and usage terms public before marketplace review.
+
+Checked-in marketplace metadata proves package shape, not listing status. Submission,
+review, publication, GitHub Pages enablement, and search-console ownership are external
+state changes with their own approval and verification. Use accurate natural-language
+landing copy, a canonical URL, and a sitemap that the owner explicitly submits through
+Search Console; do not trade the project's evidence boundary for keyword stuffing or
+unsupported product claims. Do not place `robots.txt` under a GitHub Pages project
+subpath and call it crawler control: robots rules are host-root metadata owned by the
+site owner, outside this repository's publication slice.

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://cagdasyurekli.github.io/codex-agy-worker/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>

--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # Install the Codex skill that teaches Codex to use this pipeline.
 #
-# Installs ONLY the skill file. It does not touch your agy settings, your Codex
-# config, or anything else — those changes are described in the README so you can
-# make them yourself, deliberately.
+# Installs only the canonical skill bundle and a local pipeline pointer. It does not
+# touch agy settings, Codex config, or anything else — those changes are described in
+# the README so you can make them yourself, deliberately.
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -14,32 +14,57 @@ command -v agy >/dev/null || {
 }
 
 mkdir -p "$DEST"
-# The skill hardcodes no paths except this repo's location, so bake in where the
-# user actually cloned it rather than assuming ~/Documents/Projects.
-python3 - "$HERE/codex-skill/SKILL.md" "$DEST/SKILL.md" "$HERE" <<'PY'
+# Marketplace installs resolve the runtime beside the cached plugin. A standalone
+# install copies the same canonical skill bundle and records this checkout in a local
+# marker that is not part of the public package.
+python3 - "$HERE/skills/agy-worker" "$DEST" "$HERE" <<'PY'
 import os
 import pathlib
 import sys
 import tempfile
 
-source = pathlib.Path(sys.argv[1])
-destination = pathlib.Path(sys.argv[2])
-repo_root = sys.argv[3]
-rendered = source.read_text(encoding="utf-8").replace("__REPO_ROOT__", repo_root)
-handle = tempfile.NamedTemporaryFile(
-    mode="w", encoding="utf-8", dir=destination.parent,
-    prefix=".SKILL.md.", delete=False,
-)
-try:
-    with handle:
-        handle.write(rendered)
-    os.replace(handle.name, destination)
-except BaseException:
+source_root = pathlib.Path(sys.argv[1])
+destination_root = pathlib.Path(sys.argv[2])
+repo_root = pathlib.Path(sys.argv[3]).resolve()
+
+
+def publish_bytes(source: pathlib.Path, destination: pathlib.Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    handle = tempfile.NamedTemporaryFile(
+        mode="wb", dir=destination.parent,
+        prefix=f".{destination.name}.", delete=False,
+    )
     try:
-        os.unlink(handle.name)
+        with handle:
+            handle.write(source.read_bytes())
+        os.chmod(handle.name, source.stat().st_mode & 0o777)
+        os.replace(handle.name, destination)
+    except BaseException:
+        try:
+            os.unlink(handle.name)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+for source in sorted(source_root.rglob("*")):
+    if source.is_symlink():
+        raise SystemExit(f"refusing symlink in skill bundle: {source}")
+    if source.is_file():
+        publish_bytes(source, destination_root / source.relative_to(source_root))
+
+marker_source = tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", delete=False)
+try:
+    with marker_source:
+        marker_source.write(f"{repo_root}\n")
+    marker_path = pathlib.Path(marker_source.name)
+    os.chmod(marker_path, 0o644)
+    publish_bytes(marker_path, destination_root / ".pipeline-root")
+finally:
+    try:
+        os.unlink(marker_source.name)
     except FileNotFoundError:
         pass
-    raise
 PY
 
 echo "installed: $DEST/SKILL.md"

--- a/skills/agy-worker/SKILL.md
+++ b/skills/agy-worker/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agy-worker
-description: Delegate bulk, mechanical code work to the Antigravity CLI (agy) as a bounded worker, then independently verify the result before accepting it. Use when a task is large but repetitive — backfilling tests, applying the same edit across many files, mechanical refactors, or repo surveys — and you want to conserve your own context. Do not use for tasks requiring judgment, architecture decisions, or anything where you cannot state acceptance criteria up front.
+description: Delegate bulk, mechanical coding work to Google Antigravity CLI (agy) as a bounded worker, then independently verify Git scope and driver-owned acceptance checks before accepting it. Use for test backfills, repeated cross-file edits, mechanical refactors, repository inventories, or a verification-gated agy delegation. Do not use for architecture or judgment-heavy work, or when acceptance criteria cannot be stated before dispatch.
 ---
 
 # Delegate to agy, then verify
@@ -8,9 +8,31 @@ description: Delegate bulk, mechanical code work to the Antigravity CLI (agy) as
 You are the driver. `agy` is a worker whose self-report is a **claim, never evidence**.
 You decide what "done" means, and you prove it yourself.
 
-Pipeline lives at `__REPO_ROOT__`.
+Resolve the pipeline from this skill's installed location. Set `SKILL_ROOT` to the
+directory containing this `SKILL.md`, then run:
 
-## Sandbox requirement (read first)
+```bash
+PIPELINE="$(bash "$SKILL_ROOT/scripts/resolve-pipeline.sh")" || exit $?
+```
+
+Do not guess a checkout path. The resolver supports both a plugin cache, where the
+pipeline is two directories above this skill, and the explicit standalone install
+created by `install.sh`.
+
+## Data boundary and sandbox requirement (read first)
+
+`agy` is an external CLI backed by Google/Gemini services. A dispatch can transmit
+the task text and repository content that the worker reads from driver-approved
+roots. Before the first dispatch for a repository, tell the user what repository and
+paths will be in scope and obtain explicit approval unless that exact transmission
+was already approved. Never include credentials, private keys, or unrelated files.
+The pipeline stores job prompts, streams, stderr, and envelopes in local `logs/`;
+treat them as private artifacts. See the repository's `PRIVACY.md` for the complete
+project disclosure.
+
+The following sandbox settings apply to Codex. In another Agent Skills client,
+follow that client's own permission and network controls; do not copy Codex-specific
+configuration into it.
 
 agy starts a local language server and writes state under `~/.gemini`. Under Codex's
 default `workspace-write` sandbox it fails with **exit 5 and empty stderr** — no useful
@@ -48,7 +70,7 @@ Never let the worker touch the user's working tree. Use a branch-backed worktree
 accepted changes can be committed before cleanup.
 
 ```bash
-PIPELINE=__REPO_ROOT__
+PIPELINE="$(bash "$SKILL_ROOT/scripts/resolve-pipeline.sh")" || exit $?
 TARGET=/absolute/path/to/target-repo
 WT=/tmp/agy-job-12345
 JOB_BRANCH=agy/job-12345
@@ -221,7 +243,7 @@ uncommitted work.
 
 ## Maintenance and GitHub reporting
 
-- `__REPO_ROOT__/update.sh check` is read-only and may be run when the user asks for
+- `$PIPELINE/update.sh check` is read-only and may be run when the user asks for
   an update/compatibility check. It reports tool releases plus verified agy version,
   official-upstream drift, and fixed 30-day documentation-review status. Its official
   release/upstream sources are not caller-overridable.

--- a/skills/agy-worker/agents/openai.yaml
+++ b/skills/agy-worker/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Verified agy Worker"
+  short_description: "Delegate bulk edits and verify repository evidence"
+  default_prompt: "Use $agy-worker to delegate this bounded mechanical coding task and independently verify the result."

--- a/skills/agy-worker/scripts/resolve-pipeline.sh
+++ b/skills/agy-worker/scripts/resolve-pipeline.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Resolve the canonical pipeline from either a plugin cache or install.sh output.
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+SKILL_DIR="$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd -P)"
+
+is_pipeline() {
+    [[ -x "$1/agy-worker.sh" && -x "$1/qa-gate.sh" \
+        && -x "$1/model-recommendation.sh" ]]
+}
+
+PLUGIN_ROOT="$(CDPATH= cd -- "$SKILL_DIR/../.." 2>/dev/null && pwd -P)" || PLUGIN_ROOT=""
+if [[ -n "$PLUGIN_ROOT" ]] && is_pipeline "$PLUGIN_ROOT"; then
+    printf '%s\n' "$PLUGIN_ROOT"
+    exit 0
+fi
+
+MARKER="$SKILL_DIR/.pipeline-root"
+if [[ -f "$MARKER" ]]; then
+    IFS= read -r INSTALLED_ROOT < "$MARKER" || true
+    case "$INSTALLED_ROOT" in
+        /*) ;;
+        *)
+            echo "agy-worker: invalid standalone pipeline marker" >&2
+            exit 2
+            ;;
+    esac
+    if is_pipeline "$INSTALLED_ROOT"; then
+        printf '%s\n' "$INSTALLED_ROOT"
+        exit 0
+    fi
+fi
+
+echo "agy-worker: pipeline not found beside the plugin or at the standalone install marker" >&2
+echo "agy-worker: reinstall from a complete codex-agy-worker checkout" >&2
+exit 2

--- a/tests/test-agy-worker.sh
+++ b/tests/test-agy-worker.sh
@@ -311,18 +311,20 @@ fi
 echo
 echo "installer path handling:"
 SPECIAL="$TMP/repo&with|chars"
-mkdir -p "$SPECIAL/codex-skill" "$TMP/installed"
+mkdir -p "$SPECIAL/skills" "$TMP/installed"
 cp "$ROOT/install.sh" "$SPECIAL/install.sh"
-cp "$ROOT/codex-skill/SKILL.md" "$SPECIAL/codex-skill/SKILL.md"
+cp -R "$ROOT/skills/agy-worker" "$SPECIAL/skills/agy-worker"
 chmod +x "$SPECIAL/install.sh"
 PATH="$TMP/bin:$PATH" CODEX_SKILLS_DIR="$TMP/installed" "$SPECIAL/install.sh" > "$TMP/install.out" 2>/dev/null
 rc=$?
 expect_exit "installer accepts replacement metacharacters in clone path" 0 "$rc"
-if grep -Fq "$SPECIAL" "$TMP/installed/agy-worker/SKILL.md" \
-        && ! grep -Fq '__REPO_ROOT__' "$TMP/installed/agy-worker/SKILL.md"; then
-    ok "installer renders the exact clone path"
+SPECIAL_REAL="$(cd "$SPECIAL" && pwd -P)"
+if [[ "$(<"$TMP/installed/agy-worker/.pipeline-root")" == "$SPECIAL_REAL" ]] \
+        && [[ -f "$TMP/installed/agy-worker/agents/openai.yaml" ]] \
+        && [[ -x "$TMP/installed/agy-worker/scripts/resolve-pipeline.sh" ]]; then
+    ok "installer copies the canonical bundle and records the exact clone path"
 else
-    bad "installer renders the exact clone path"
+    bad "installer copies the canonical bundle and records the exact clone path"
 fi
 
 echo

--- a/tests/test-packaging.sh
+++ b/tests/test-packaging.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Offline plugin, marketplace, skill-bundle, and landing-page contract tests.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$HERE/.."
+TMP="$(mktemp -d -t agyworker-packaging.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+pass=0; fail=0
+
+ok() { printf '  ok   %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL %s\n' "$1"; fail=$((fail+1)); }
+
+echo "marketplace packaging offline test suite"
+echo
+
+if python3 - "$ROOT" <<'PY'
+import json
+from pathlib import Path
+import sys
+
+root = Path(sys.argv[1])
+manifest = json.loads((root / ".codex-plugin/plugin.json").read_text())
+assert manifest["name"] == "codex-agy-worker"
+assert manifest["skills"] == "./skills/"
+assert manifest["license"] == "MIT"
+assert manifest["interface"]["privacyPolicyURL"].startswith("https://")
+assert manifest["interface"]["termsOfServiceURL"].startswith("https://")
+assert not ({"apps", "mcpServers", "hooks"} & manifest.keys())
+PY
+then ok "Codex plugin is a skills-only package with public legal links"; else bad "Codex plugin is a skills-only package with public legal links"; fi
+
+if python3 - "$ROOT" <<'PY'
+import json
+from pathlib import Path
+import sys
+
+manifest = json.loads((Path(sys.argv[1]) / ".claude-plugin/plugin.json").read_text())
+assert manifest["name"] == "codex-agy-worker"
+assert manifest["skills"] == "./skills/"
+assert manifest["agents"] == []
+assert manifest["version"] == "0.1.0"
+PY
+then ok "Claude plugin versions the shared skill and suppresses incompatible agy personas"; else bad "Claude plugin versions the shared skill and suppresses incompatible agy personas"; fi
+
+if python3 - "$ROOT" <<'PY'
+import json
+from pathlib import Path
+import sys
+
+catalog = json.loads((Path(sys.argv[1]) / ".agents/plugins/marketplace.json").read_text())
+entry = catalog["plugins"][0]
+assert catalog["name"] == "codex-agy-worker"
+assert entry["name"] == "codex-agy-worker"
+assert entry["source"] == {
+    "source": "url",
+    "url": "https://github.com/cagdasyurekli/codex-agy-worker.git",
+    "ref": "main",
+}
+assert entry["policy"] == {"installation": "AVAILABLE", "authentication": "ON_INSTALL"}
+PY
+then ok "Codex marketplace entry is explicit and remotely installable"; else bad "Codex marketplace entry is explicit and remotely installable"; fi
+
+if python3 - "$ROOT" <<'PY'
+import json
+from pathlib import Path
+import sys
+
+catalog = json.loads((Path(sys.argv[1]) / ".claude-plugin/marketplace.json").read_text())
+entry = catalog["plugins"][0]
+assert catalog["name"] == "codex-agy-worker"
+assert entry["name"] == "codex-agy-worker"
+assert entry["source"] == {"source": "github", "repo": "cagdasyurekli/codex-agy-worker"}
+PY
+then ok "Claude marketplace entry resolves the public repository"; else bad "Claude marketplace entry resolves the public repository"; fi
+
+if python3 - "$ROOT" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+root = Path(sys.argv[1])
+skill = (root / "skills/agy-worker/SKILL.md").read_text()
+metadata = (root / "skills/agy-worker/agents/openai.yaml").read_text()
+assert skill.startswith("---\nname: agy-worker\ndescription:")
+assert len(re.search(r"^description: (.+)$", skill, re.M).group(1)) <= 1024
+assert 'display_name: "Verified agy Worker"' in metadata
+assert "$agy-worker" in metadata
+PY
+then ok "canonical Agent Skill has matching OpenAI UI metadata"; else bad "canonical Agent Skill has matching OpenAI UI metadata"; fi
+
+if ! grep -R -Fq '__REPO_ROOT__' "$ROOT/skills/agy-worker" \
+        && ! grep -R -Fq '/Users/' "$ROOT/skills/agy-worker" \
+        && [[ ! -e "$ROOT/skills/agy-worker/.pipeline-root" ]]; then
+    ok "public skill bundle contains no checkout placeholder or local path marker"
+else
+    bad "public skill bundle contains no checkout placeholder or local path marker"
+fi
+
+resolved="$(bash "$ROOT/skills/agy-worker/scripts/resolve-pipeline.sh" 2>/dev/null)"
+if [[ "$resolved" == "$(cd "$ROOT" && pwd -P)" ]]; then
+    ok "plugin-cache resolver finds the adjacent canonical runtime"
+else
+    bad "plugin-cache resolver finds the adjacent canonical runtime"
+fi
+
+mkdir -p "$TMP/bin" "$TMP/installed"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$TMP/bin/agy"
+chmod +x "$TMP/bin/agy"
+PATH="$TMP/bin:$PATH" CODEX_SKILLS_DIR="$TMP/installed" "$ROOT/install.sh" \
+    > "$TMP/install.out" 2> "$TMP/install.err"
+rc=$?
+installed_root=""
+if [[ "$rc" == "0" ]]; then
+    installed_root="$(bash "$TMP/installed/agy-worker/scripts/resolve-pipeline.sh" 2>/dev/null)"
+fi
+if [[ "$installed_root" == "$(cd "$ROOT" && pwd -P)" ]]; then
+    ok "standalone install resolves the checkout without rewriting SKILL.md"
+else
+    bad "standalone install resolves the checkout without rewriting SKILL.md"
+fi
+
+mkdir -p "$TMP/reject-relative/agy-worker"
+cp -R "$ROOT/skills/agy-worker/"* "$TMP/reject-relative/agy-worker/"
+printf '../relative\n' > "$TMP/reject-relative/agy-worker/.pipeline-root"
+bash "$TMP/reject-relative/agy-worker/scripts/resolve-pipeline.sh" \
+    > "$TMP/relative.out" 2> "$TMP/relative.err"
+rc=$?
+if [[ "$rc" == "2" && ! -s "$TMP/relative.out" ]]; then
+    ok "standalone resolver rejects a relative pipeline marker"
+else
+    bad "standalone resolver rejects a relative pipeline marker"
+fi
+
+printf '/definitely/missing/codex-agy-worker\n' > "$TMP/reject-relative/agy-worker/.pipeline-root"
+bash "$TMP/reject-relative/agy-worker/scripts/resolve-pipeline.sh" \
+    > "$TMP/missing.out" 2> "$TMP/missing.err"
+rc=$?
+if [[ "$rc" == "2" && ! -s "$TMP/missing.out" ]]; then
+    ok "standalone resolver rejects a missing pipeline runtime"
+else
+    bad "standalone resolver rejects a missing pipeline runtime"
+fi
+
+if grep -Fq 'Google/Gemini' "$ROOT/PRIVACY.md" \
+        && grep -Fq 'logs/' "$ROOT/PRIVACY.md" \
+        && grep -Fq 'GitHub Issues' "$ROOT/SUPPORT.md" \
+        && grep -Fq 'not legal advice' "$ROOT/TERMS.md"; then
+    ok "public policy pages disclose external transfer, local artifacts, and support"
+else
+    bad "public policy pages disclose external transfer, local artifacts, and support"
+fi
+
+if python3 - "$ROOT/docs/MARKETPLACE.md" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+text = Path(sys.argv[1]).read_text()
+positive = re.findall(r"^### Positive [1-5]$", text, re.M)
+negative = re.findall(r"^### Negative [1-3]$", text, re.M)
+assert len(positive) == 5
+assert len(negative) == 3
+PY
+then ok "submission runbook contains five positive and three negative cases"; else bad "submission runbook contains five positive and three negative cases"; fi
+
+if grep -Fq 'https://cagdasyurekli.github.io/codex-agy-worker/' "$ROOT/docs/_config.yml" \
+        && grep -Fq 'canonical' "$ROOT/docs/_layouts/default.html" \
+        && grep -Fq '<loc>https://cagdasyurekli.github.io/codex-agy-worker/</loc>' "$ROOT/docs/sitemap.xml" \
+        && grep -Fq 'explicitly submit' "$ROOT/docs/MARKETPLACE.md" \
+        && [[ ! -e "$ROOT/docs/robots.txt" ]]; then
+    ok "GitHub Pages landing exposes a canonical URL and explicitly submitted sitemap"
+else
+    bad "GitHub Pages landing exposes a canonical URL and explicitly submitted sitemap"
+fi
+
+if [[ ! -e "$ROOT/codex-skill/SKILL.md" ]] \
+        && [[ -f "$ROOT/skills/agy-worker/SKILL.md" ]]; then
+    ok "repository has one canonical skill source"
+else
+    bad "repository has one canonical skill source"
+fi
+
+echo
+if (( fail )); then
+    echo "FAILED: $fail failed, $pass passed"
+    exit 1
+fi
+echo "PASSED: $pass tests"

--- a/tests/test-update.sh
+++ b/tests/test-update.sh
@@ -28,9 +28,9 @@ INSTALL_FAIL_CLIENT="$TMP/install-fail-client"
 SKILLS="$TMP/skills"
 OFFICIAL_TOOL_URL="https://github.com/cagdasyurekli/codex-agy-worker.git"
 OFFICIAL_UPSTREAM_URL="https://github.com/google-antigravity/antigravity-cli.git"
-mkdir -p "$SOURCE/codex-skill" "$SOURCE/tests" "$SOURCE/compat" "$TMP/bin" "$SKILLS"
+mkdir -p "$SOURCE/skills" "$SOURCE/tests" "$SOURCE/compat" "$TMP/bin" "$SKILLS"
 cp "$ROOT/update.sh" "$ROOT/install.sh" "$SOURCE/"
-cp "$ROOT/codex-skill/SKILL.md" "$SOURCE/codex-skill/SKILL.md"
+cp -R "$ROOT/skills/agy-worker" "$SOURCE/skills/agy-worker"
 cp "$ROOT/compat/"*.txt "$SOURCE/compat/"
 
 mkdir -p "$UPSTREAM_SOURCE"
@@ -191,7 +191,13 @@ if [[ "$(git -C "$CLIENT" rev-parse HEAD)" == "$V2_COMMIT" ]] \
 else
     bad "apply lands the verified release commit"
 fi
-if grep -Fq "$CLIENT" "$SKILLS/agy-worker/SKILL.md"; then ok "apply reinstalls the Codex skill"; else bad "apply reinstalls the Codex skill"; fi
+CLIENT_REAL="$(cd "$CLIENT" && pwd -P)"
+if [[ "$(<"$SKILLS/agy-worker/.pipeline-root")" == "$CLIENT_REAL" ]] \
+        && [[ -f "$SKILLS/agy-worker/agents/openai.yaml" ]]; then
+    ok "apply reinstalls the canonical Codex skill bundle"
+else
+    bad "apply reinstalls the canonical Codex skill bundle"
+fi
 if [[ "$(<"$CLIENT/harmless.cache")" == "harmless local cache" ]]; then ok "harmless ignored cache is preserved"; else bad "harmless ignored cache is preserved"; fi
 
 BLOCKED_SKILLS="$TMP/not-a-directory"


### PR DESCRIPTION
## Summary

- Moves the canonical agy-worker Agent Skill into a relocatable public bundle with runtime resolution for plugin-cache and standalone installs.
- Adds Codex and Claude plugin manifests plus repository marketplace catalogs without adding a Node or MCP runtime dependency.
- Adds an accurate GitHub Pages landing source, sitemap, privacy policy, terms, support guidance, and marketplace submission runbook.
- Includes five positive and three negative OpenAI reviewer cases and a new 14-case offline packaging suite.

## Validation

An implementation agent produced this isolated slice and a different agent independently reviewed the full diff and reran its acceptance checks before publication.

- QA gate suite: 41 passed
- Worker, installer, and advisory routing suite: 57 passed
- Updater suite: 26 passed
- Reporting suite: 21 passed
- Packaging suite: 14 passed
- Bash syntax, Python byte-compilation, and git diff hygiene passed
- Canonical skill quick validation passed
- Codex plugin validation passed
- agy ground-truth check completed against agy 1.1.9

## Publication status

This pull request packages discovery and review inputs only. No release was published, no OpenAI or Claude marketplace submission was made, no skills.sh installation was performed, and GitHub Pages is not yet enabled.