### PR TITLE
Add evidence-first product roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ candidate.
 
 The five offline suites need no agy process, network access, API key, or GitHub login.
 
+## Roadmap
+
+[The product roadmap](docs/ROADMAP.md) lists proposed, dependency-ordered feature
+slices. Those items are plans, not current CLI behavior or implementation claims;
+each slice requires its own approval, tests, review, and pull request.
+
 ---
 
 ## Install from GitHub

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -65,6 +65,7 @@ accepting them.
 | `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, `.github/pull_request_template.md` | Contribution workflow, private vulnerability route, conduct enforcement, and review checklist | human review plus relevant offline suites |
 | `.github/workflows/test.yml` | macOS CI for syntax and all five offline suites | exercised by GitHub Actions |
 | `README.md` | User setup, examples, current capabilities and limitations | review plus relevant offline suites |
+| `docs/ROADMAP.md` | Planned dependency-ordered product slices, approval gates, and honest success measures; not current behavior | human review; implementation claims remain prohibited until their slices land |
 | `AGENTS.md`, `docs/lessons_learned.md`, this file | Durable contributor rules and architecture | `agents-md-auditor` after material changes |
 
 ## Trust boundaries

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -127,19 +127,41 @@ an earlier implementation because it shares a schema or helper.
 - **Intended surface:** Add canonical
   `skills/agy-worker/runtime/verify-job.sh`, root `verify-job.sh`,
   `skills/agy-worker/runtime/schemas/evidence-receipt.schema.json`, and a
-  dependency-free receipt validator. The wrapper invokes the existing gate, writes
-  one atomic mode-`0600` receipt outside the audited repository, and returns the gate
-  exit unchanged. Optional `--pre-recommendation FILE` and
-  `--post-recommendation FILE` inputs may bind already-rendered advisory results; the
-  receipt command never generates or applies them.
-- **Receipt v1 minimum:** Version and kind; immutable base; envelope hash; candidate
-  state hash; ordered path-policy hash; verifier labels and command hashes; exact gate
-  exit/outcome; a verdict restricted to `gate-passed`, `rejected`, or `routed`;
-  optional caller-selected tier; optional validated pre/post advisory objects
-  retaining their rationale, controlled driver evidence, relative cost impact,
-  `recommendation_only: true`, and `applied: false`; `gate_authority: qa-gate`; and an
-  explicit statement that the receipt is unsigned and recommendations did not
-  participate in acceptance.
+  dependency-free receipt validator. The wrapper creates a private temporary receipt
+  and pre-opens a driver-owned structured-evidence sink, then invokes the gate with a
+  narrow optional `--evidence-fd FD`. When that option is absent, `qa-gate.sh` output,
+  side effects, and exit behavior remain identical to today. With it, the gate writes
+  exactly one bounded JSON handoff to the already-open descriptor; it never owns or
+  chooses the destination path. Optional `--pre-recommendation FILE` may bind an
+  already-rendered pre-dispatch advisory. The receipt command never generates or
+  applies a recommendation.
+- **Gate evidence handoff:** The structured handoff is the receipt's bounded source
+  for driver-derived facts. It includes the hash of the exact envelope snapshot the
+  gate validated, the resolved immutable base, the gate's internal initial and final
+  candidate-state digests, and its exact outcome and exit. The wrapper validates the
+  complete handoff, cross-checks it against its immutable inputs, and refuses missing,
+  malformed, duplicate, or mismatched evidence. It never parses gate prose or
+  reconstructs candidate truth from outer-wrapper observations alone.
+- **Receipt v1 minimum:** Version and kind; gate-resolved immutable base; hash of the
+  exact envelope snapshot validated by the gate; ordered path-policy hash; verifier
+  labels and command hashes; the gate-supplied initial and final candidate-state
+  digests; actual gate exit/outcome; a verdict restricted to `gate-passed`, `rejected`,
+  or `routed`; optional
+  caller-selected tier; optional validated pre-dispatch advisory retaining its
+  rationale, controlled driver evidence, relative cost impact,
+  `recommendation_only: true`, `applied: false`, and `stage: pre-dispatch`;
+  `gate_authority: qa-gate`; and an explicit statement that the receipt is unsigned
+  and recommendations did not participate in acceptance.
+- **Exit and publication contract:** Wrapper preflight/input errors exit `64` before
+  the gate and publish no receipt. Gate outcomes `0` and `10`–`15` may publish a
+  receipt with the exact `gate_exit`; after successful receipt validation, file
+  `fsync`, atomic publication, and parent-directory durability, the wrapper returns
+  that gate exit. Gate exit `64` publishes no receipt and returns `64`. A missing or
+  mismatched handoff, unknown gate exit, signal, or other internal protocol failure
+  publishes no receipt and returns reserved exit `70`. Receipt validation, `fsync`,
+  or atomic-publication failure removes the private temporary file, publishes no
+  partial receipt, and returns reserved exit `74`. The wrapper never returns `0`
+  unless the gate returned `0` **and** the receipt was durably published.
 - **Exclude:** Diff/source content, prompt, worker summary/confidence, raw verifier
   commands or output, credentials, absolute repository paths, provider pricing, and
   an applied recommendation.
@@ -147,25 +169,51 @@ an earlier implementation because it shares a schema or helper.
 - **Trust boundary:** A receipt records a gate execution. It must not reproduce gate
   acceptance logic, treat its own existence as acceptance, use `accepted` as a
   verdict, or map any nonzero gate result to `gate-passed`. A receipt path inside the
-  audited repository is rejected.
+  audited repository is rejected. Schema validation, canonical serialization, and
+  internal-invariant checks can detect malformed or inconsistent receipts, but an
+  unsigned receipt cannot detect arbitrary schema-valid tampering by an actor who can
+  rewrite the document and recompute its embedded hashes. Validation can detect a
+  mismatch when the caller separately supplies the bound envelope, candidate
+  artifact, pre-dispatch advisory, or a trusted external digest. Receipt v1 makes no
+  self-hash authenticity or signing claim; signing remains deferred to an approved
+  threat model and external signer.
 - **Minimum accept tests:** An honest edit with passing driver verification yields a
-  schema-valid receipt with verdict `gate-passed`; hashes bind the exact base,
-  envelope, policy, verifier order, and candidate state; wrapper and gate exit codes
-  match. The test does not call the candidate accepted before human review.
+  durably published, schema-valid receipt with verdict `gate-passed`, actual
+  `gate_exit: 0`, the gate's exact envelope snapshot hash, resolved base, and internal
+  initial/final state digests; the wrapper returns `0`. Each normal gate result
+  `10`–`14` durably publishes verdict `rejected`, result `15` publishes `routed`, and
+  the wrapper returns that exact gate exit. A valid pre-dispatch advisory is bound
+  without changing the selected tier or gate result. The tests never call a candidate
+  accepted before human review. Direct `qa-gate.sh` calls without `--evidence-fd`
+  retain their current stdout/stderr and exit contract.
 - **Minimum reject tests:** Scope failure, malformed envelope, untrusted command/test
-  claim, missing edits, verifier failure/mutation, and human-required outcome remain
-  rejected and are never rendered as acceptance; reject overwrite, symlink target,
-  in-repository output, unknown schema version, receipt tampering, cross-stage or
-  malformed advisory input, selected-tier mismatch, or an advisory that claims it was
-  applied.
+  claim, missing edits, verifier failure/mutation, and human-required outcome retain
+  their gate classification and are never rendered as acceptance. Reject overwrite,
+  symlink target, in-repository output, unknown schema version, inconsistent receipt,
+  separately bound artifact/digest mismatch, malformed or duplicate handoff, envelope
+  snapshot/base/state/outcome/exit mismatch, post-gate or cross-stage advisory input,
+  selected-tier mismatch, or an advisory that claims it was applied. Wrapper/gate
+  preflight `64`, unknown exit, signal, missing evidence, internal `70`, and durable
+  publication `74` paths publish no receipt; injected validation, `fsync`, rename, and
+  parent-directory durability failures leave no final or partial receipt. An unsigned
+  receipt rewritten with recomputed hashes must not be falsely described as
+  tamper-evident without a separately trusted binding.
 - **Docs and AGENTS impact:** Update README, SKILL, privacy disclosure, REPO_MAP, and
   architectural lessons only after implementation. AGENTS then gains the actual new
   suite/count and a concise durable rule that receipts do not replace gate or human
   review. Run `agents-md-auditor` before and after.
 - **Size:** M.
 - **Done/exit criteria:** One isolated PR; no behavior change when `verify-job.sh` is
-  unused; all current suites plus receipt accept/reject matrix green; no raw private
-  data in the receipt; independent verifier confirms no weaker gate path.
+  unused and no behavior/output/exit change when `qa-gate.sh` is called without its
+  optional evidence handoff; all current suites plus the `0`, `10`–`15`, `64`, `70`,
+  and `74` receipt matrix green; no receipt on unknown/signal/missing-evidence or
+  publication failure; no raw private data in the receipt; no post-gate recommendation
+  binding in P0-A; and an independent verifier confirms no weaker gate path.
+
+The existing post-gate recommender remains external and unchanged. P0-A does not
+auto-run it or bind its output after a synchronous gate completes. A later, separate
+contract may bind a post-gate advisory without rewriting the canonical one-pass
+receipt or creating chronology ambiguity.
 
 #### P0-B — Human Report renderer
 
@@ -181,8 +229,10 @@ an earlier implementation because it shares a schema or helper.
 - **Minimum accept tests:** Receipts whose verdicts are `gate-passed`, `rejected`, and
   `routed` render stable, escaped text and Markdown with exact exit/outcome and
   verification labels.
-- **Minimum reject tests:** Malformed, tampered, unsupported-version, control-character,
-  Markdown-link-injection, or forbidden-private-field input produces no report.
+- **Minimum reject tests:** Malformed, internally inconsistent, unsupported-version,
+  control-character, Markdown-link-injection, forbidden-private-field, or separately
+  bound artifact/trusted-digest mismatch produces no report. Do not claim detection
+  of arbitrary unsigned receipt rewriting with recomputed hashes.
 - **Docs and AGENTS impact:** Add report examples to README/SKILL and ownership to
   REPO_MAP; update privacy language. Change AGENTS only for an actual suite/count.
 - **Size:** S.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,545 @@
+# Product roadmap
+
+This document describes **planned work, not current behavior**. The current command
+surface and verified limitations remain in [README.md](../README.md). A roadmap item
+becomes current only after its own implementation, adversarial tests, documentation
+review, and an accepted pull request.
+
+The first recommended implementation is **P0-A Evidence Receipt v1 only**. Starting
+that slice requires a fresh, explicit approval; this roadmap does not authorize code,
+commit, push, pull-request, merge, release, live model use, or another external action.
+
+## Product direction
+
+`codex-agy-worker` should remain a small Codex-to-agy pipeline whose differentiator is
+independent evidence, not feature-count parity. Codex owns planning, scope, acceptance
+criteria, verification, and human-facing judgment. agy performs bounded worker tasks.
+The worker envelope remains a claim.
+
+Nearby projects demonstrate useful demand for asynchronous jobs, lifecycle tools,
+diagnostics, multiple backends, MCP servers, and broad automation:
+
+- [codex-agy-delegator](https://github.com/swjturay/codex-agy-delegator)
+  exposes asynchronous multi-backend runs, report/apply/cleanup tools, and worktree
+  isolation through an MCP server.
+- [codex-antigravity-bridge](https://github.com/Common-ka/codex-antigravity-bridge)
+  provides asynchronous status/result tools, capability and smoke probes, compact
+  result modes, and retained local run artifacts.
+- [agy-mcp](https://github.com/Boulea7/agy-mcp) combines typed MCP tools, a doctor,
+  long-task supervision, skill bundles, worktrees, and safety policy.
+- [antigravity-for-claude-code](https://github.com/VKirill/antigravity-for-claude-code)
+  pursues detached jobs, multi-role orchestration, automatic commits, pushes, and
+  deployment.
+
+Those primary project sources motivate better diagnostics, lifecycle ergonomics, and
+portable evidence here. They do **not** justify adopting their MCP, daemon,
+multi-backend, or autonomous-shipping architecture. This project should make its
+narrow evidence boundary easier to see and use.
+
+## Evidence terminology
+
+Use these terms consistently in code, tests, documentation, and reports:
+
+- **Worker envelope:** schema-valid worker-authored claims. Shape is validated; truth
+  is not implied.
+- **Driver input:** immutable base, audited repository, path policy, verification
+  commands, and controlled routing evidence selected before or after dispatch by the
+  driver.
+- **Gate observation:** facts independently derived by `qa-gate.sh` from Git and
+  driver-owned verification.
+- **Accepted candidate:** gate exit `0` followed by human diff review. It is not a
+  commit, merge, release, or proof of general correctness or security.
+- **Evidence receipt:** a local, versioned record binding a gate invocation to hashes
+  of its inputs and observed outcome. It is not a signature or a new acceptance
+  authority.
+- **Receipt verdict:** exactly `gate-passed`, `rejected`, or `routed`. A receipt is
+  never “accepted.” `gate-passed` records gate exit `0`; only the required later human
+  diff review can turn that candidate into an accepted candidate.
+- **Human report:** a sanitized rendering of a validated receipt. It cannot improve
+  or reinterpret the underlying outcome.
+- **Provider-reported usage:** token, duration, or turn telemetry supplied by agy. It
+  is not independent billing or quota evidence.
+- **Persona evidence status:** the documented level of offline and bounded real-job
+  evidence for a prompt-injected persona. It is not a general quality guarantee.
+
+## Immutable cross-slice rules
+
+Every roadmap slice must preserve all of these rules:
+
+1. `agy`, its stream, and every envelope field remain untrusted.
+2. Acceptance continues to require an immutable base, complete Git-visible scope,
+   driver-owned verification, unchanged candidate state during verification, and
+   human diff review.
+3. No receipt, report, persona, profile, benchmark, usage number, or CI rendering may
+   become an alternative acceptance path.
+4. The caller selects the model tier. Recommendations remain visible and advisory,
+   with `recommendation_only: true` and `applied: false`.
+5. Never add automatic tier/model changes or a wrapper-level thinking/effort control.
+   Retries keep the caller-selected tier.
+6. Permission, authentication, scope-policy, invalid-contract, untrusted-claim, and
+   human-required outcomes are non-escalatable.
+7. No feature may automatically commit, push, open a pull request, merge, release,
+   submit an issue, enable a service, or publish an artifact.
+8. No feature may silently edit `~/.codex`, `~/.gemini`, or another user
+   configuration location.
+9. The runtime remains Bash 3.2-compatible shell, Python 3 standard library, and git.
+   Do not add Node, Bun, an MCP daemon, or a package-manager runtime dependency.
+10. Offline suites remain independent of agy, network, provider credentials, and
+    paid quota. Every new enforcement check needs both an accept and reject case.
+11. The canonical runtime remains under `skills/agy-worker/runtime/`; root runtime
+    commands are compatibility wrappers. Repository-only demonstrations and
+    conformance fixtures may remain outside the public skill when documented as such.
+12. External data transmission, live provider use, destructive cleanup, and GitHub
+    or release actions keep separate explicit approval gates.
+
+## Current agy inventory correction
+
+The local `./ground-truth.sh` inventory on agy `1.1.9` currently lists `--effort`,
+`models`, `agent`/`agents`, and `plugin`/`plugins` in addition to the already used
+print, model, mode, sandbox, schema, timeout, conversation, and directory options.
+However, the live `models` and `agents` probes failed in the current Codex sandbox
+because agy could not write under `~/.gemini` or bind its local language-server
+socket. Exact model and agent catalogs therefore remain unverified in this audit.
+
+This corrects the inventory without expanding the wrapper contract:
+
+- Do not add `--effort` or infer a thinking level. The roadmap deliberately preserves
+  explicit tier selection and recommendation-only routing.
+- Do not add dynamic model/persona discovery from help text alone.
+- Do not infer authentication from a single failure or invent `agy auth`; unknown
+  subcommands can print usage and exit `0`.
+- Any future exposure of newly advertised agy behavior is a separate compatibility
+  slice requiring official docs, official source, a sandbox-correct live inventory,
+  a bounded real job, paired offline tests, and explicit approval.
+
+## Release groups and slices
+
+Each slice below is independently reviewable. A later slice must not be smuggled into
+an earlier implementation because it shares a schema or helper.
+
+### P0 — make the evidence boundary visible and usable
+
+#### P0-A — Evidence Receipt v1
+
+- **User job:** Preserve what the driver checked, against which immutable base and
+  policy, and what the gate concluded without sharing source, prompts, raw logs, or
+  worker prose.
+- **Intended surface:** Add canonical
+  `skills/agy-worker/runtime/verify-job.sh`, root `verify-job.sh`,
+  `skills/agy-worker/runtime/schemas/evidence-receipt.schema.json`, and a
+  dependency-free receipt validator. The wrapper invokes the existing gate, writes
+  one atomic mode-`0600` receipt outside the audited repository, and returns the gate
+  exit unchanged. Optional `--pre-recommendation FILE` and
+  `--post-recommendation FILE` inputs may bind already-rendered advisory results; the
+  receipt command never generates or applies them.
+- **Receipt v1 minimum:** Version and kind; immutable base; envelope hash; candidate
+  state hash; ordered path-policy hash; verifier labels and command hashes; exact gate
+  exit/outcome; a verdict restricted to `gate-passed`, `rejected`, or `routed`;
+  optional caller-selected tier; optional validated pre/post advisory objects
+  retaining their rationale, controlled driver evidence, relative cost impact,
+  `recommendation_only: true`, and `applied: false`; `gate_authority: qa-gate`; and an
+  explicit statement that the receipt is unsigned and recommendations did not
+  participate in acceptance.
+- **Exclude:** Diff/source content, prompt, worker summary/confidence, raw verifier
+  commands or output, credentials, absolute repository paths, provider pricing, and
+  an applied recommendation.
+- **Dependencies:** Existing `qa-gate.sh`, envelope validator, Python SHA-256, git.
+- **Trust boundary:** A receipt records a gate execution. It must not reproduce gate
+  acceptance logic, treat its own existence as acceptance, use `accepted` as a
+  verdict, or map any nonzero gate result to `gate-passed`. A receipt path inside the
+  audited repository is rejected.
+- **Minimum accept tests:** An honest edit with passing driver verification yields a
+  schema-valid receipt with verdict `gate-passed`; hashes bind the exact base,
+  envelope, policy, verifier order, and candidate state; wrapper and gate exit codes
+  match. The test does not call the candidate accepted before human review.
+- **Minimum reject tests:** Scope failure, malformed envelope, untrusted command/test
+  claim, missing edits, verifier failure/mutation, and human-required outcome remain
+  rejected and are never rendered as acceptance; reject overwrite, symlink target,
+  in-repository output, unknown schema version, receipt tampering, cross-stage or
+  malformed advisory input, selected-tier mismatch, or an advisory that claims it was
+  applied.
+- **Docs and AGENTS impact:** Update README, SKILL, privacy disclosure, REPO_MAP, and
+  architectural lessons only after implementation. AGENTS then gains the actual new
+  suite/count and a concise durable rule that receipts do not replace gate or human
+  review. Run `agents-md-auditor` before and after.
+- **Size:** M.
+- **Done/exit criteria:** One isolated PR; no behavior change when `verify-job.sh` is
+  unused; all current suites plus receipt accept/reject matrix green; no raw private
+  data in the receipt; independent verifier confirms no weaker gate path.
+
+#### P0-B — Human Report renderer
+
+- **User job:** Read or share a compact bounded result without pasting private job
+  artifacts.
+- **Intended surface:** Add canonical `evidence-report.sh --receipt FILE
+  --format text|markdown` plus a root wrapper. Output defaults to stdout; writing a
+  file requires an explicit path and refuses overwrite.
+- **Dependencies:** Validated Receipt v1 schema and validator; no dispatch dependency.
+- **Trust boundary:** Rendering only. It cannot invoke agy, git, gate, routing, or a
+  network client. Rejected and routed receipts must be headed plainly as such. It may
+  state only the receipt's bounded observations.
+- **Minimum accept tests:** Receipts whose verdicts are `gate-passed`, `rejected`, and
+  `routed` render stable, escaped text and Markdown with exact exit/outcome and
+  verification labels.
+- **Minimum reject tests:** Malformed, tampered, unsupported-version, control-character,
+  Markdown-link-injection, or forbidden-private-field input produces no report.
+- **Docs and AGENTS impact:** Add report examples to README/SKILL and ownership to
+  REPO_MAP; update privacy language. Change AGENTS only for an actual suite/count.
+- **Size:** S.
+- **Done/exit criteria:** Deterministic output; no raw command, source, prompt, log, or
+  absolute-path disclosure; renderer has no execution or submission capability.
+
+#### P0-C — Read-only Doctor
+
+- **User job:** Diagnose readiness before spending provider quota or changing personal
+  configuration.
+- **Intended surface:** Add canonical `doctor.sh [--repo DIR]
+  [--format text|json]` plus root wrapper. Default execution is offline and read-only.
+- **Checks:** Runtime resolution; Bash compatibility; Python 3 and git availability;
+  Git worktree support; agy presence and version against checked-in compatibility
+  metadata; target repository validity; and due/invalid compatibility review
+  metadata.
+- **Dependencies:** Existing resolver, compatibility metadata, and `ground-truth.sh`
+  facts. It is independent of Receipt v1.
+- **Trust boundary:** A green result means only that offline prerequisites passed. It
+  does not certify authentication, provider availability, sandbox permission, task
+  quality, or future dispatch success. It never repairs configuration. Optional
+  config inspection requires an explicit path; it does not scan home files silently.
+- **Minimum accept tests:** A fake compatible toolchain yields structured green output
+  and a before/after filesystem snapshot is unchanged.
+- **Minimum reject tests:** Missing agy/Python/git, version drift, incomplete bundle,
+  invalid target repo, and invalid/due compatibility metadata fail or warn according
+  to a documented matrix; no `agy auth` or unknown-subcommand probing; no network or
+  configuration writes.
+- **Docs and AGENTS impact:** Add onboarding/troubleshooting to README and SKILL,
+  ownership to REPO_MAP, and a durable no-auto-fix lesson. AGENTS receives only the
+  implemented suite/count and current doctor boundary.
+- **Size:** M.
+- **Done/exit criteria:** Stable text/JSON contract, no live prompt, no personal-config
+  mutation, and offline fake-tool coverage for every reported state.
+
+#### P0-D — 60-second offline proof demo
+
+- **User job:** See the project's differentiator in under one minute without agy,
+  credentials, network, or API credits.
+- **Intended surface:** Add repository-only `proof-demo.sh` and a minimal
+  `demo/fixtures/` pair. It creates a temporary Git repository, demonstrates one
+  honest candidate that is `gate-passed` by driver verification and one plausible
+  worker claim rejected because Git reality disagrees, prints a short explanation,
+  and cleans only its own temporary directory. The demo performs no human review and
+  therefore labels no candidate accepted.
+- **Dependencies:** Current `qa-gate.sh`; use Receipt v1 when available without making
+  the demo block P0-A.
+- **Trust boundary:** This is a demonstration, not certification, a benchmark, or
+  evidence of real agy quality. It must not edit the checkout or use the current
+  repository as the fixture.
+- **Minimum accept tests:** Runs offline on macOS Bash 3.2 in less than 60 seconds and
+  shows the expected accept/reject exits.
+- **Minimum reject tests:** A deliberately trusting substitute gate cannot make the
+  demo pass; temporary-path collision and interrupted cleanup fail safely; no agy or
+  network executable is invoked.
+- **Docs and AGENTS impact:** README quick proof and Pages link; REPO_MAP ownership.
+  AGENTS changes only if this becomes a named completion check.
+- **Size:** S.
+- **Done/exit criteria:** Two bounded cases, deterministic summary, verified offline,
+  and explicit “starter proof, not conformance certification” wording.
+
+### P1 — integrate the evidence boundary without broadening autonomy
+
+#### P1-A — Safe local lifecycle
+
+- **User job:** Create, inspect, verify, and deliberately clean an isolated job without
+  manually reproducing the full worktree recipe.
+- **Intended surface:** `job.sh init|status|verify|preserve-instructions|cleanup` with
+  a private mode-`0600` state file binding exact target, worktree, branch, immutable
+  base, and job ID. `verify` delegates to Receipt v1. `preserve-instructions` prints
+  deliberate commands; it does not run them.
+- **Dependencies:** Receipt v1; Doctor is recommended but not required.
+- **Trust boundary:** No background process, polling, daemon, commit, push, PR, merge,
+  release, auto-dispatch, or auto-model choice. Destructive cleanup is allowed only
+  after explicit user approval for the exact job ID and exact hash-bound candidate
+  state recorded with receipt verdict `rejected`. Immediately before deletion it
+  re-derives that digest and refuses any mismatch. It refuses `gate-passed` or
+  accepted candidates, routed outcomes, tampered/stale state, foreign or unbound
+  artifacts, and every uncommitted state that does not exactly match the recorded
+  rejected digest.
+- **Minimum accept tests:** Init creates the exact branch-backed worktree; status
+  detects current state; verify produces the expected receipt; after explicit user
+  approval, cleanup removes only the exact uncommitted rejected candidate whose
+  current digest matches the hash-bound rejected receipt.
+- **Minimum reject tests:** Mutable base, path/branch collision, foreign or moved
+  worktree, tampered/stale state, changed-since-verification digest, outside-repo root,
+  symlink escape, missing explicit approval, `gate-passed`/accepted/routed outcome,
+  foreign or unbound artifact, uncommitted state not exactly matching the recorded
+  rejected digest, and any GitHub or commit command.
+- **Docs and AGENTS impact:** Replace the README's manual path with a primary lifecycle
+  example while retaining the manual reference; update SKILL, REPO_MAP, lessons, and
+  current completion checks after implementation.
+- **Size:** L.
+- **Done/exit criteria:** Crash-safe state transitions; cleanup only for an explicitly
+  approved, exact hash-bound rejected disposable state; no loss of gate-passed or
+  accepted work; no external action; and independent destructive-target review.
+
+#### P1-B — Full public conformance kit
+
+- **User job:** Let integrations and forks test the published contract rather than
+  claim compatibility from prose.
+- **Intended surface:** `conformance/run.sh --gate PATH`, versioned
+  `conformance/v1/manifest.json`, synthetic repositories/envelopes, and
+  `docs/CONFORMANCE.md`. P0-D fixtures become the small starter subset.
+- **Dependencies:** Stable gate behavior and Receipt v1 if receipts are part of the
+  conformance claim.
+- **Trust boundary:** Conformance means only that the implementation passes the
+  published fixtures. It is not a security certification or real-job quality proof.
+- **Minimum accept tests:** Current gate passes every required v1 fixture with exact
+  documented exits.
+- **Minimum reject tests:** Deliberately permissive gates that trust worker claims,
+  ignore ignored files, accept mutable bases, skip verification, accept verifier
+  mutation, or accept human-required outcomes must fail the kit.
+- **Docs and AGENTS impact:** Add conformance specification and bounded README badge
+  wording; update REPO_MAP and lessons. AGENTS receives actual suite/count only.
+- **Size:** L.
+- **Done/exit criteria:** Public versioned fixture contract, malicious reference
+  implementations rejected, and no “certified secure” language.
+
+#### P1-C — Reproducible benchmark harness
+
+- **User job:** Compare releases, caller-selected tiers, or personas on fixed bounded
+  tasks using gate observations rather than subjective worker summaries.
+- **Intended surface:** `benchmark.sh prepare|run|report`, frozen
+  `benchmarks/v1/manifest.json`, ignored local result directory, and
+  `docs/BENCHMARKING.md`. Paid work requires an explicit `--live` boundary.
+- **Dependencies:** Receipt v1; lifecycle is useful but optional.
+- **Trust boundary:** Every result binds exact fixture/base, tool versions, selected
+  tier, attempt count, policy, and verification. No hidden retries or model changes.
+  Competitor comparisons require identical public tasks and rules. No leaderboard by
+  default.
+- **Minimum accept tests:** Frozen offline fixture produces a deterministic report and
+  receipt; live-mode parser preserves selected tier and attempt count.
+- **Minimum reject tests:** Changed fixture hash, missing verifier, unpublished input,
+  partial task set described as complete, hidden retry/model change, or result without
+  exact version binding.
+- **Docs and AGENTS impact:** Add BENCHMARKING document and README evidence link;
+  update REPO_MAP. AGENTS updates only verified real/offline evidence boundaries, not
+  one-off results.
+- **Size:** L.
+- **Done/exit criteria:** Reproducible offline harness; live execution remains a
+  separately approved action with explicit Google/Gemini data scope and cost.
+
+#### P1-D — Persona evidence registry
+
+- **User job:** Distinguish offline persona contract coverage from honest escalation
+  and accepted real-candidate evidence.
+- **Intended surface:** Validated `compat/personas/<name>.json` records and a generated
+  documentation table. Runtime persona selection remains an explicit hardcoded
+  allowlist; target repositories cannot register executable personas dynamically.
+- **Dependencies:** Receipt v1 and public benchmark fixtures.
+- **Trust boundary:** Persona text remains prompt guidance, never enforcement. One
+  accepted real candidate does not make a persona generally reliable. Use evidence
+  states such as `offline-only`, `real-escalation-observed`, and
+  `accepted-real-candidate`; do not label a persona simply “trusted.”
+- **Minimum accept tests:** Registered persona exists, has valid frontmatter and mode
+  restriction, and references exact reproducible evidence for its stated level.
+- **Minimum reject tests:** Unknown/path-alias persona, edit mode for a read-only
+  persona, self-authored acceptance claim, missing base/verifier/tool version, private
+  evidence described as public, or target-repository dynamic registration.
+- **Docs and AGENTS impact:** Update README persona matrix, limitations, REPO_MAP, and
+  current evidence boundaries. Keep one-off run history out of AGENTS.
+- **Size:** M for registry; real exercises are separate approved operational work.
+- **Done/exit criteria:** Every shipped persona has precise evidence status; no
+  stronger claim than its reproducible records support.
+
+#### P1-E — CI-safe JSON, Markdown, and GitHub Step Summary reporter
+
+- **User job:** Render an already produced receipt in CI without custom parsing or a
+  networked bot.
+- **Intended surface:** Extend the report command with `--format json|markdown|github-step-summary`.
+  Output goes to stdout or an explicit file. Documentation shows explicit redirection
+  to `$GITHUB_STEP_SUMMARY`; the tool does not discover or write that environment file
+  implicitly.
+- **Dependencies:** Receipt v1 and Human Report renderer.
+- **Trust boundary:** Reporter never dispatches agy, runs the gate, comments on a PR,
+  calls GitHub APIs, or publishes artifacts. It escapes workflow-command and Markdown
+  injection. JSON is the validated bounded report representation, not the raw
+  envelope.
+- **Minimum accept tests:** Receipts whose verdicts are `gate-passed`, `rejected`, and
+  `routed` render exact status in all three formats and preserve stable
+  machine-readable fields.
+- **Minimum reject tests:** Workflow-command injection, Markdown links/HTML/control
+  characters, malformed receipt, forbidden private fields, implicit environment-file
+  writes, and external command/network invocation.
+- **Docs and AGENTS impact:** Add a GitHub Actions snippet and fork/secret warning;
+  update REPO_MAP. No GitHub integration claim beyond local rendering.
+- **Size:** M.
+- **Done/exit criteria:** Offline deterministic reporters, no network permissions, and
+  exact rejected-state visibility.
+
+Do not commit to SARIF: a gate run is not naturally a static-analysis result with
+locations/rules. Do not add JUnit unless a concrete consumer first demonstrates a
+semantically honest mapping; “job rejected” is not automatically a test-case failure.
+
+### P2 — optional local ergonomics and telemetry
+
+#### P2-A — Data-only workload profiles
+
+- **User job:** Start common bounded jobs from a maintained skeleton without hiding
+  policy choices.
+- **Intended surface:** Bundled `profiles/*.json` plus `profile.sh list|show NAME`.
+  Profiles may suggest mode, maintained persona, and path-policy shape. The driver
+  supplies the selected tier, exact repository, verification commands, and approval.
+- **Dependencies:** Stable lifecycle input contract.
+- **Trust boundary:** No target-repository auto-loading. Profiles contain no model,
+  tier, effort/thinking value, executable verifier, external add-dir, authorization,
+  auto-dispatch, or Git action.
+- **Minimum accept tests:** Maintained profile renders a non-executable plan that still
+  requires caller tier and verifier.
+- **Minimum reject tests:** Embedded model/tier/effort, shell command, authorization,
+  outside-workdir root, dynamic repository profile, path alias, or implicit dispatch.
+- **Docs and AGENTS impact:** README/SKILL/REPO_MAP and durable profile restrictions
+  only after implementation.
+- **Size:** M.
+- **Done/exit criteria:** Profiles reduce typing without deciding cost, executing
+  policy, or expanding read scope.
+
+#### P2-B — Provider-reported usage and latency
+
+- **User job:** Inspect one run's reported token, turn, and duration telemetry to make
+  a manual batching decision.
+- **Intended surface:** `usage-report.sh --stream FILE` for one explicitly selected
+  NDJSON stream, optionally folded into a receipt/report as
+  `provider_reported_usage`.
+- **Dependencies:** Stable receipt/report schema and confirmed agy terminal-event
+  shape.
+- **Trust boundary:** No automatic log-directory scan. Provider telemetry is not bill,
+  price, remaining quota, or independent evidence; it never changes acceptance,
+  routing, selected tier, or retry count.
+- **Minimum accept tests:** One valid terminal result yields labeled token/turn/duration
+  fields and preserves missing values honestly.
+- **Minimum reject tests:** Multiple ambiguous result events, malformed stream,
+  inferred currency, inferred quota, auth/permission failure treated as cost evidence,
+  implicit log scanning, and routing changes.
+- **Docs and AGENTS impact:** README limitations, privacy disclosure, REPO_MAP, and
+  model-routing lesson. AGENTS need not grow unless a new suite is added.
+- **Size:** S–M.
+- **Done/exit criteria:** No exact monetary/quota claims without a future official
+  stable source and a separately approved contract.
+
+#### P2-C — Optional local list/show/prune
+
+- **User job:** Find and deliberately remove old locally managed job records after the
+  lifecycle format is stable.
+- **Intended surface:** `job.sh list|show|prune`, limited to a single explicit managed
+  state root. `list`/`show` are read-only; `prune` requires exact job IDs and shows
+  targets before deletion.
+- **Dependencies:** Safe lifecycle plus a demonstrated accumulation problem. Do not
+  implement speculatively.
+- **Trust boundary:** Never scan arbitrary home/repository trees, infer ownership from
+  names alone, remove `gate-passed`/accepted/routed or changed-since-verification
+  worktrees, remove any uncommitted state not exactly matching its hash-bound rejected
+  receipt, or run on a timer. Every prune remains an explicitly approved destructive
+  action for exact job IDs.
+- **Minimum accept tests:** Bound stale rejected records are listed and an explicitly
+  approved prune removes only records whose current state still matches the recorded
+  rejected digest.
+- **Minimum reject tests:** Broad root, symlink escape, unknown/active/
+  `gate-passed`/accepted/routed job, changed or unbound state, ambiguous ID, missing
+  approval, implicit age-only deletion, and background scheduling.
+- **Docs and AGENTS impact:** Lifecycle docs and destructive-action lesson only when a
+  real need and implementation exist.
+- **Size:** M.
+- **Done/exit criteria:** Implement only after lifecycle usage supplies evidence that
+  manual cleanup is a recurring problem.
+
+### Deferred or rejected
+
+- **Cryptographic signing — deferred.** Receipt v1 may expose deterministic SHA-256
+  digests, which prove byte equality only. Signing needs a threat model, identity and
+  key-discovery policy, revocation, CI key custody, and explicit approval of an
+  external signer/tool. Never invent a home-grown signature or call a self-signed
+  digest trusted provenance.
+- **Async jobs, polling, background daemon, MCP server — rejected.** They add process
+  lifecycle, retention, authentication, and cleanup boundaries while duplicating the
+  main competitor niche.
+- **Dashboard or cloud service — rejected.** It would create storage, hosting,
+  authentication, privacy, and telemetry obligations unrelated to the local gate.
+- **Windows parity race — deferred.** Do not claim parity until maintainers can run
+  native adversarial suites and own the support burden. Portable code remains welcome,
+  but macOS correctness takes priority.
+- **Multiple worker backends — rejected for this product direction.** It would dilute
+  agy-specific ground truth and compatibility review.
+- **Automatic tier/model selection, thinking/effort controls, or quota routing —
+  rejected.** Recommendations remain advisory and caller selection remains explicit.
+- **Automatic commit, push, PR, merge, release, issue submission, or deployment —
+  rejected.** These remain deliberate user-owned workflows with separate approvals.
+- **Escalating permission, authentication, scope-policy, invalid-contract,
+  untrusted-claim, or human-required outcomes — rejected.** More model spend cannot
+  repair those boundaries.
+
+## Approval gates
+
+Roadmap priority is not authorization. Apply these gates independently:
+
+1. **Feature implementation:** fresh explicit approval for one named slice.
+2. **External data/live model:** name the repository and paths sent through agy and
+   obtain explicit approval before a live dispatch or benchmark.
+3. **Destructive local lifecycle:** allow cleanup only for the exact hash-bound state
+   recorded as rejected and disposable, then re-derive its digest and obtain explicit
+   user approval for those exact job/worktree/branch targets. Refuse every other
+   state; cleanup is never authorized merely because a job is old or uncommitted.
+4. **GitHub:** staging and local commits may occur only when requested; push, PR,
+   merge, and release each follow the user's explicit authorization boundary.
+5. **External distribution/search:** marketplace, directory, Search Console, or other
+   service enablement remains out of scope unless newly approved. The current product
+   direction is public GitHub distribution.
+6. **Signing:** requires an approved threat model and signer dependency before code.
+
+## Honest success measures
+
+Establish a dated baseline before the first P0 release, then review at 30, 60, and 90
+days. Do not add install beacons, hidden analytics, fake installs, fake stars, paid
+reviews, or automated promotional submissions.
+
+### 30 days — onboarding and proof
+
+- Measure median fresh-clone-to-offline-proof time in small opt-in sessions; target
+  under 10 minutes and keep P0-D itself under 60 seconds.
+- Record whether Doctor identifies the real blocker before any paid dispatch; report
+  misses as product defects, not user error.
+- Require 100% of published P0 examples to identify exact suite, fixture, base, and
+  bounded claim. No example may imply general correctness/security.
+- Track GitHub unique visitors and unique cloners around the release as interest only;
+  never call a clone an install or activation.
+
+### 60 days — qualified external use
+
+- Count distinct public external repositories or opt-in users that demonstrate a
+  valid receipt or starter proof. Verify each signal manually instead of inferring it
+  from stars.
+- Measure the share of inbound bug reports that include sanitized Doctor output or a
+  receipt identifier and sufficient reproduction data.
+- Review GitHub Traffic referral domains and, if separately approved and configured,
+  Search Console non-branded impressions/clicks for relevant delegation and evidence
+  queries. Report trends, not guaranteed ranking.
+- Keep zero regressions in the existing adversarial gate suite and zero external
+  actions performed by a reporter or lifecycle command.
+
+### 90 days — reusable evidence ecosystem
+
+- Count verified external workflows that link to or run the conformance kit or local
+  reporter. A public repository reference is stronger than a raw star.
+- Require the full conformance kit to reject every deliberately trusting reference
+  gate and accept the maintained implementation.
+- Publish benchmark claims only when every result binds exact public fixture, base,
+  selected tier, attempts, tool versions, policy, and driver verification.
+- Track accepted-real-candidate evidence per persona without converting one success
+  into a universal quality percentage.
+- Reassess P2 from observed friction. Do not build profiles, pruning, quota, or
+  signing merely because they appear on this roadmap.
+
+## First implementation recommendation
+
+Implement **P0-A Evidence Receipt v1 only** as the next isolated feature slice. Do
+not include the renderer, Doctor, proof demo, lifecycle, CI formats, profiles, usage,
+benchmarking, or signing in that change. Before any code begins, obtain a fresh user
+approval naming P0-A and preserve the normal independent implementation and
+verification-agent split.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,9 +5,12 @@ surface and verified limitations remain in [README.md](../README.md). A roadmap 
 becomes current only after its own implementation, adversarial tests, documentation
 review, and an accepted pull request.
 
-The first recommended implementation is **P0-A Evidence Receipt v1 only**. Starting
-that slice requires a fresh, explicit approval; this roadmap does not authorize code,
-commit, push, pull-request, merge, release, live model use, or another external action.
+The first recommended implementation is **G0 Compatibility Reconciliation & Watch
+only**. G1 Explicit Model & Effort Selection follows as a separate slice; P0-A
+Evidence Receipt v1 follows separately after the compatibility baseline is current.
+Starting any slice requires a fresh, explicit approval; this roadmap does not
+authorize code, commit, push, pull-request, merge, release, live model use, or another
+external action.
 
 ## Product direction
 
@@ -74,8 +77,10 @@ Every roadmap slice must preserve all of these rules:
    become an alternative acceptance path.
 4. The caller selects the model tier. Recommendations remain visible and advisory,
    with `recommendation_only: true` and `applied: false`.
-5. Never add automatic tier/model changes or a wrapper-level thinking/effort control.
-   Retries keep the caller-selected tier.
+5. Never add automatic tier/model/effort changes or invent a `--thinking-level`
+   control. After G0 reconciles the exact agy contract, G1 may expose agy's real
+   `--model MODEL` and `--effort low|medium|high` as explicit caller choices only.
+   Retries keep the caller's resolved selection byte-for-byte.
 6. Permission, authentication, scope-policy, invalid-contract, untrusted-claim, and
    human-required outcomes are non-escalatable.
 7. No feature may automatically commit, push, open a pull request, merge, release,
@@ -101,21 +106,213 @@ However, the live `models` and `agents` probes failed in the current Codex sandb
 because agy could not write under `~/.gemini` or bind its local language-server
 socket. Exact model and agent catalogs therefore remain unverified in this audit.
 
-This corrects the inventory without expanding the wrapper contract:
+This corrects the current inventory without claiming that locally advertised flags
+or historical failure behavior are the verified agy `1.1.10` contract:
 
-- Do not add `--effort` or infer a thinking level. The roadmap deliberately preserves
-  explicit tier selection and recommendation-only routing.
+- Do not expose `--effort` before G0 reconciles official releases/source/docs with a
+  sandbox-correct inventory and bounded behavior tests. G1 may then expose the real
+  agy flag; it must not infer effort or invent a thinking-level flag.
 - Do not add dynamic model/persona discovery from help text alone.
-- Do not infer authentication from a single failure or invent `agy auth`; unknown
-  subcommands can print usage and exit `0`.
-- Any future exposure of newly advertised agy behavior is a separate compatibility
-  slice requiring official docs, official source, a sandbox-correct live inventory,
-  a bounded real job, paired offline tests, and explicit approval.
+- Do not infer authentication from a single failure or invent `agy auth`. Probe only
+  documented commands and validate their expected semantic output; neither an unknown
+  subcommand's exit code nor generic usage text is compatibility evidence.
+- Do not assume a full model slug ending in an effort-like suffix composes safely with
+  `--effort`. Until official source plus a bounded test proves an exact combination,
+  the wrapper must reject it rather than send two possibly conflicting selectors.
+- Any exposure of newly advertised agy behavior remains a separate slice requiring
+  official docs, official source, a sandbox-correct live inventory, a bounded real
+  job, paired offline tests, and explicit approval.
 
 ## Release groups and slices
 
 Each slice below is independently reviewable. A later slice must not be smuggled into
 an earlier implementation because it shares a schema or helper.
+
+### G0 — Compatibility Reconciliation & Watch
+
+- **User job:** Learn that Codex or agy has drifted before a normal dispatch breaks,
+  while keeping every check read-only and requiring a human to reconcile behavior.
+- **Intended surface:** Extend the fixed-source compatibility contract in `update.sh`,
+  `compat/sources.md`, and dependency-free metadata from agy to both agy and Codex.
+  Use one explicit version, reviewed upstream revision, and last-reviewed date per
+  tool; migrate the current shared `compat/last-reviewed.txt` to unambiguous per-tool
+  records. Add a human-reviewed, dependency-free model/effort capability matrix bound
+  to the exact verified agy version and source revision. Add
+  `.github/workflows/compatibility-watch.yml` as a separate weekly and
+  `workflow_dispatch` macOS workflow. It is observational and is not a required pull
+  request check.
+- **Local check contract:** `./update.sh check` reports the installed version, the
+  repository's human-verified baseline, official stable release/source drift, and
+  official documentation-review age separately for agy and Codex. It exits `0` only
+  when all required evidence is available and unchanged, `3` when evidence establishes
+  drift or review is due, and `2` when network or source evidence is unavailable or
+  malformed. Exit `2` is **inconclusive**, never green. The command changes no file,
+  pulls nothing, applies nothing, and does not update its own baseline.
+- **Watch workflow contract:** The workflow runs only on `macos-latest`, declares
+  `permissions: contents: read`, uses no secrets, installs no package or CLI, invokes
+  no model, and performs no apply, pull, issue, PR, commit, or baseline write. A
+  bounded GitHub Step Summary identifies each fixed source as unchanged, review-due,
+  or evidence-unavailable without dumping fetched pages. Its command preserves the
+  same `0`/`3`/`2` meanings; the workflow may surface nonzero status for maintainers
+  but cannot open or modify anything. Scheduling it does not add it to the protected
+  branch's required `test` check.
+- **Fixed primary sources:** agy reconciliation binds the official
+  [Antigravity source](https://github.com/google-antigravity/antigravity-cli),
+  [releases](https://github.com/google-antigravity/antigravity-cli/releases),
+  [changelog](https://github.com/google-antigravity/antigravity-cli/blob/main/CHANGELOG.md),
+  and official CLI overview/usage pages already recorded in `compat/sources.md`.
+  Codex reconciliation binds the official
+  [Codex source and releases](https://github.com/openai/codex/releases),
+  [Codex changelog](https://developers.openai.com/codex/changelog), and
+  [Codex CLI reference](https://developers.openai.com/codex/cli/reference). Production
+  URLs, review intervals, release channels, and upstream repositories remain fixed in
+  the runtime and are not environment-overridable.
+- **Baseline advancement:** A maintainer may advance either verified baseline only
+  after reconciling official docs, release notes, and source; regenerating the local
+  `./ground-truth.sh` evidence for agy and equivalent documented Codex CLI inventory;
+  running every offline suite and syntax/compile/diff check; and recording the exact
+  reviewed revisions. If behavior affecting dispatch changed, a bounded job against
+  an explicit public fixture is a separate live-data approval, not part of the watch.
+  The watch never performs this reconciliation. If an official agy `1.1.10` release
+  and matching source cannot both be established, the verified baseline stays `1.1.9`
+  and the result remains AMBER/review-due rather than speculatively advancing.
+- **Capability-matrix rule:** G0 derives model-specific effort support from the exact
+  verified agy docs/source and bounded CLI behavior, not from a provider API table or
+  a model-name guess. The matrix records its agy version and source revision. Any agy
+  version/source drift makes the matrix stale and keeps effort dispatch disabled until
+  human reconciliation. The current candidate inventory to verify is Gemini 3.6 Flash
+  with low/medium/high and Gemini 3.1 Pro with low/high but **not medium**; it is not a
+  runtime promise until G0 establishes the exact agy model identifiers and pairs.
+- **Current-behavior correction:** Implementation updates README and AGENTS guidance
+  to say that probes must validate documented commands and expected semantic content,
+  never an unknown subcommand's exit or usage output. It also records that agy has a
+  real `--effort`, while this wrapper exposes no effort control until G1. No code may
+  combine `--effort` with a full slug that may already encode effort without exact
+  compatibility evidence.
+- **Model option decision gate:** `gemini-3.6-flash-high` is already selectable as a
+  raw custom `--tier` label. It remains unranked and non-escalating; no `bulk`/`hard`
+  mapping changes and no effort flag are part of G0. Google's official
+  [model catalog](https://ai.google.dev/gemini-api/docs/models) describes Gemini 3.6
+  Flash as a speed/intelligence balance and Gemini 3.1 Pro as the advanced model for
+  complex reasoning and coding. The official
+  [thinking guide](https://ai.google.dev/gemini-api/docs/generate-content/thinking)
+  shows real but model-specific effort levels, and
+  [pricing](https://ai.google.dev/gemini-api/docs/pricing) distinguishes model and
+  thinking usage. Those API facts must not be copied into the agy capability matrix;
+  they do not prove the agy CLI composition, relative quality, or effective
+  subscription cost for this wrapper. A discoverable `flash-high` alias is a later
+  isolated decision after G0/G1 compatibility tests; changing a default or
+  recommendation order additionally requires the pre-registered benchmark below.
+- **Dependencies:** Existing read-only `update.sh check`, fixed compatibility metadata,
+  `ground-truth.sh`, Bash 3.2, Python 3 standard library, git, and GitHub-hosted macOS.
+  No runtime dependency, provider credential, or paid quota is introduced.
+- **Trust boundary:** Release names, help text, provider prose, and worker output are
+  signals for review, not permission to update code or metadata. Missing network
+  evidence cannot be collapsed into unchanged. The watcher cannot authorize model
+  selection, acceptance, baseline advancement, dispatch, or an external action.
+- **Minimum accept tests:** Fixed fake official sources unchanged return `0`; installed
+  versus verified differences and stale review dates are reported separately and
+  return `3`; unavailable network returns `2` with an inconclusive label; absent
+  official `1.1.10` evidence retains `1.1.9` and AMBER; version-bound capability
+  fixtures reproduce every documented supported pair and mark drift stale; a raw
+  `gemini-3.6-flash-high` selection remains pass-through, unranked, recommendation-only,
+  and non-escalating; workflow fixtures prove weekly/manual triggers, macOS, read-only
+  permission, bounded summary, and no mutation.
+- **Minimum reject tests:** Green on missing evidence; automatic baseline edits;
+  environment-overridden source/review policy; malformed or future-dated metadata;
+  treating unknown-command exit/usage as support; secret access, installation, model
+  calls, `apply`, `pull`, GitHub writes, or required-PR-check coupling in the watcher;
+  automatic issue/PR creation; tier remapping; alias creation; or an effort flag.
+  Reject a matrix with an unbound/mismatched version or revision, an unsupported pair,
+  a provider-table-only claim, or an inferred capability for an unknown model.
+- **Docs and AGENTS impact:** README compatibility semantics and limitations,
+  `compat/sources.md`, REPO_MAP ownership/data flow, lessons learned on inconclusive
+  evidence, and concise durable AGENTS probing rules. Run `agents-md-auditor` before
+  and after those future guidance edits.
+- **Size:** M.
+- **Done/exit criteria:** Both tools have fixed, human-reviewed baselines; all three
+  outcomes are adversarially tested; the macOS watcher is read-only and separately
+  observable; all existing suites stay green; docs do not claim live compatibility
+  beyond evidence; and an independent verifier confirms zero write/escalation path.
+- **Success measures:** Zero false-green results when official evidence is unavailable;
+  compatibility drift is classified by the next weekly run; each baseline advance
+  links exact primary evidence and completed gates; and no watcher run changes a file,
+  opens an item, invokes a model, or changes required branch checks.
+
+### G1 — Explicit Model & Effort Selection
+
+- **User job:** Select an exact agy model and its verified supported effort directly,
+  without disguising the choice as a tier or allowing a recommendation to change it.
+- **Sequence gate:** Start only after G0 has reconciled the exact agy `1.1.10` (or
+  later explicitly verified) CLI/source behavior. G1 precedes any `flash-high` alias,
+  performance ranking, or default/recommendation remap and must be its own pull request.
+- **Intended surface:** Add wrapper CLI `--model MODEL` and agy's real
+  `--effort low|medium|high`; never add `--thinking-level`. Preserve `--tier` named
+  values, raw-label pass-through, and the no-option default exactly. Add
+  `AGY_WORKER_MODEL` and `AGY_WORKER_EFFORT` only with the strict conflict contract
+  below. Canonical runtime, root compatibility wrapper, public skill copy, validators,
+  recommendation schemas/renderers, and later receipt/report schemas carry the same
+  resolved selection contract.
+- **Selection and precedence contract:** There is no silent precedence. Each option
+  may be supplied by CLI or its matching environment variable, never both—even when
+  the values match. Any explicit tier source (`--tier` or `AGY_WORKER_TIER`) is mutually
+  exclusive with every explicit model/effort source. With no explicit selector, the
+  existing implicit `bulk` default remains. Direct mode uses one exact model source;
+  an effort source requires that model unless the G0 evidence explicitly proves and
+  pins safe effort-only behavior. Duplicate CLI occurrences, empty values, unknown
+  effort values, and cross-source conflicts fail before dispatch with usage exit `64`.
+- **Composition safety:** Pass `--model MODEL` and `--effort VALUE` as separate agy
+  arguments only for that exact pair in the G0 matrix whose agy version and source
+  revision still match the verified baseline. The globally accepted effort spelling
+  does not imply every model accepts all three values: the candidate matrix must, for
+  example, verify Flash low/medium/high separately and Pro low/high separately while
+  rejecting Pro medium. Unknown model/version, unsupported pair, or stale matrix fails
+  before dispatch. Until official source and a bounded test prove otherwise, also
+  reject effort combined with a slug ending in a known effort suffix such as `-low`,
+  `-medium`, `-high`, or another registered effort-bearing form, and reject every
+  other ambiguous combination. Do not strip, rewrite, normalize, or guess a base
+  model from the slug.
+- **Persistence and evidence:** Resolve selection once before attempt one and retain
+  the exact tier/model/effort provenance and values across every retry. Pre-dispatch
+  and post-gate recommendations, Evidence Receipt v1, and the Human Report represent
+  selected tier, model, and effort as distinct optional fields. A custom model or
+  effort remains unranked; recommendation output stays `recommendation_only: true`,
+  `applied: false`, and cannot alter or redispatch the selection.
+- **Non-escalatable outcomes:** Permission, authentication, scope-policy,
+  invalid-contract, untrusted-claim, and human-required failures remain
+  non-escalatable regardless of selected model or effort. Higher effort is never
+  proposed as a repair for those outcomes.
+- **Dependencies:** Completed G0 baseline and composition matrix, existing dispatcher
+  parsing/model assembly, advisory recommender, and the schema/report surfaces present
+  when G1 starts. No new dependency or provider lookup.
+- **Minimum accept tests:** Legacy named tiers, raw `--tier` labels, and implicit bulk
+  remain byte-compatible; one CLI or one environment model reaches agy exactly; every
+  matrix-admitted pair has its own test and reaches agy as two exact arguments; retries
+  preserve the resolved selection; recommendations and receipts/reports label custom
+  selection without ranking or applying it.
+- **Minimum reject tests:** CLI/env duplicates; tier plus model or effort across any
+  source; repeated selector; empty/invalid model or effort; effort without a model
+  unless explicitly verified; known effort-bearing slug plus `--effort`; unverified
+  composition; unsupported model/effort pair (including Pro medium when absent from
+  the verified matrix); unknown model or version; stale/unbound matrix; inferred
+  capability; invented thinking flag; retry mutation; recommendation-driven change;
+  or escalation of a non-escalatable failure. Assert that fake agy is never invoked
+  for every preflight rejection.
+- **Docs and AGENTS impact:** README option/precedence tables and examples, public
+  skill SKILL.md, REPO_MAP data flow, lessons learned on dual selectors, compatibility
+  metadata, and a concise AGENTS rule forbidding inferred effort and silent override.
+  Run `agents-md-auditor` before and after those future guidance edits.
+- **Size:** M.
+- **Done/exit criteria:** Exact G0-backed arguments and conflict behavior are documented
+  and adversarially tested on macOS Bash 3.2; all prior suites stay green; raw tier
+  compatibility remains; no recommendation changes selection; and independent
+  verification confirms no ambiguous or automatic model/effort path.
+- **Later alias/ranking gate:** A named `flash-high` alias can be proposed only after
+  G0/G1 prove its exact agy composition. Mapping `bulk`/`hard`, recommending Flash-high
+  over Pro-high, or changing a default additionally requires a pre-registered bounded
+  benchmark using fixed public fixtures, identical scope and verifier, pinned tool
+  versions, equal attempts, captured latency/provider telemetry, and explicit live-use
+  approval. Official model descriptions or a one-off result are not a ranking.
 
 ### P0 — make the evidence boundary visible and usable
 
@@ -146,8 +343,9 @@ an earlier implementation because it shares a schema or helper.
   exact envelope snapshot validated by the gate; ordered path-policy hash; verifier
   labels and command hashes; the gate-supplied initial and final candidate-state
   digests; actual gate exit/outcome; a verdict restricted to `gate-passed`, `rejected`,
-  or `routed`; optional
-  caller-selected tier; optional validated pre-dispatch advisory retaining its
+  or `routed`; optional caller-selection object with exactly one resolved mode and
+  distinct tier/model/effort values plus CLI/environment/default provenance under the
+  accepted G1 contract; optional validated pre-dispatch advisory retaining its
   rationale, controlled driver evidence, relative cost impact,
   `recommendation_only: true`, `applied: false`, and `stage: pre-dispatch`;
   `gate_authority: qa-gate`; and an explicit statement that the receipt is unsigned
@@ -165,7 +363,8 @@ an earlier implementation because it shares a schema or helper.
 - **Exclude:** Diff/source content, prompt, worker summary/confidence, raw verifier
   commands or output, credentials, absolute repository paths, provider pricing, and
   an applied recommendation.
-- **Dependencies:** Existing `qa-gate.sh`, envelope validator, Python SHA-256, git.
+- **Dependencies:** Existing `qa-gate.sh`, envelope validator, accepted G1 selection
+  contract, Python SHA-256, and git.
 - **Trust boundary:** A receipt records a gate execution. It must not reproduce gate
   acceptance logic, treat its own existence as acceptance, use `accepted` as a
   verdict, or map any nonzero gate result to `gate-passed`. A receipt path inside the
@@ -183,8 +382,9 @@ an earlier implementation because it shares a schema or helper.
   initial/final state digests; the wrapper returns `0`. Each normal gate result
   `10`–`14` durably publishes verdict `rejected`, result `15` publishes `routed`, and
   the wrapper returns that exact gate exit. A valid pre-dispatch advisory is bound
-  without changing the selected tier or gate result. The tests never call a candidate
-  accepted before human review. Direct `qa-gate.sh` calls without `--evidence-fd`
+  without changing the selected tier/model/effort or gate result. The tests never call
+  a candidate accepted before human review. Direct `qa-gate.sh` calls without
+  `--evidence-fd`
   retain their current stdout/stderr and exit contract.
 - **Minimum reject tests:** Scope failure, malformed envelope, untrusted command/test
   claim, missing edits, verifier failure/mutation, and human-required outcome retain
@@ -192,7 +392,8 @@ an earlier implementation because it shares a schema or helper.
   symlink target, in-repository output, unknown schema version, inconsistent receipt,
   separately bound artifact/digest mismatch, malformed or duplicate handoff, envelope
   snapshot/base/state/outcome/exit mismatch, post-gate or cross-stage advisory input,
-  selected-tier mismatch, or an advisory that claims it was applied. Wrapper/gate
+  selected tier/model/effort mismatch, ambiguous selector provenance, or an advisory
+  that claims it was applied. Wrapper/gate
   preflight `64`, unknown exit, signal, missing evidence, internal `70`, and durable
   publication `74` paths publish no receipt; injected validation, `fsync`, rename, and
   parent-directory durability failures leave no final or partial receipt. An unsigned
@@ -361,14 +562,14 @@ receipt or creating chronology ambiguity.
   `docs/BENCHMARKING.md`. Paid work requires an explicit `--live` boundary.
 - **Dependencies:** Receipt v1; lifecycle is useful but optional.
 - **Trust boundary:** Every result binds exact fixture/base, tool versions, selected
-  tier, attempt count, policy, and verification. No hidden retries or model changes.
-  Competitor comparisons require identical public tasks and rules. No leaderboard by
-  default.
+  tier/model/effort, attempt count, policy, and verification. No hidden retries or
+  selector changes. Competitor comparisons require identical public tasks and rules.
+  No leaderboard by default.
 - **Minimum accept tests:** Frozen offline fixture produces a deterministic report and
-  receipt; live-mode parser preserves selected tier and attempt count.
+  receipt; live-mode parser preserves selected tier/model/effort and attempt count.
 - **Minimum reject tests:** Changed fixture hash, missing verifier, unpublished input,
-  partial task set described as complete, hidden retry/model change, or result without
-  exact version binding.
+  partial task set described as complete, hidden retry/model/effort change, or result
+  without exact version binding.
 - **Docs and AGENTS impact:** Add BENCHMARKING document and README evidence link;
   update REPO_MAP. AGENTS updates only verified real/offline evidence boundaries, not
   one-off results.
@@ -517,8 +718,10 @@ semantically honest mapping; “job rejected” is not automatically a test-case
   but macOS correctness takes priority.
 - **Multiple worker backends — rejected for this product direction.** It would dilute
   agy-specific ground truth and compatibility review.
-- **Automatic tier/model selection, thinking/effort controls, or quota routing —
-  rejected.** Recommendations remain advisory and caller selection remains explicit.
+- **Automatic tier/model/effort selection, inferred thinking controls, or quota
+  routing — rejected.** Recommendations remain advisory and caller selection remains
+  explicit. G1 may expose agy's verified `--model` and `--effort` only as direct,
+  non-inferred caller controls; no `--thinking-level` is planned.
 - **Automatic commit, push, PR, merge, release, issue submission, or deployment —
   rejected.** These remain deliberate user-owned workflows with separate approvals.
 - **Escalating permission, authentication, scope-policy, invalid-contract,
@@ -530,18 +733,21 @@ semantically honest mapping; “job rejected” is not automatically a test-case
 Roadmap priority is not authorization. Apply these gates independently:
 
 1. **Feature implementation:** fresh explicit approval for one named slice.
-2. **External data/live model:** name the repository and paths sent through agy and
+2. **Compatibility watch enablement:** merging or scheduling the weekly external
+   watcher and changing a verified baseline each require explicit approval. A baseline
+   change also requires the G0 reconciliation record; the watcher cannot approve it.
+3. **External data/live model:** name the repository and paths sent through agy and
    obtain explicit approval before a live dispatch or benchmark.
-3. **Destructive local lifecycle:** allow cleanup only for the exact hash-bound state
+4. **Destructive local lifecycle:** allow cleanup only for the exact hash-bound state
    recorded as rejected and disposable, then re-derive its digest and obtain explicit
    user approval for those exact job/worktree/branch targets. Refuse every other
    state; cleanup is never authorized merely because a job is old or uncommitted.
-4. **GitHub:** staging and local commits may occur only when requested; push, PR,
+5. **GitHub:** staging and local commits may occur only when requested; push, PR,
    merge, and release each follow the user's explicit authorization boundary.
-5. **External distribution/search:** marketplace, directory, Search Console, or other
+6. **External distribution/search:** marketplace, directory, Search Console, or other
    service enablement remains out of scope unless newly approved. The current product
    direction is public GitHub distribution.
-6. **Signing:** requires an approved threat model and signer dependency before code.
+7. **Signing:** requires an approved threat model and signer dependency before code.
 
 ## Honest success measures
 
@@ -551,6 +757,8 @@ reviews, or automated promotional submissions.
 
 ### 30 days — onboarding and proof
 
+- Require every scheduled G0 result to distinguish unchanged, review-due, and
+  evidence-unavailable; target zero false green on missing official evidence.
 - Measure median fresh-clone-to-offline-proof time in small opt-in sessions; target
   under 10 minutes and keep P0-D itself under 60 seconds.
 - Record whether Doctor identifies the real blocker before any paid dispatch; report
@@ -562,6 +770,8 @@ reviews, or automated promotional submissions.
 
 ### 60 days — qualified external use
 
+- Measure compatibility-review lead time from first weekly drift signal to a recorded
+  human disposition; do not count an automatic metadata change as resolution.
 - Count distinct public external repositories or opt-in users that demonstrate a
   valid receipt or starter proof. Verify each signal manually instead of inferring it
   from stars.
@@ -575,6 +785,9 @@ reviews, or automated promotional submissions.
 
 ### 90 days — reusable evidence ecosystem
 
+- Audit every compatibility baseline advance for fixed primary sources, ground-truth
+  evidence, full offline gates, and any separately approved behavior-changing live
+  fixture; target zero unreviewed advances and zero watcher mutations.
 - Count verified external workflows that link to or run the conformance kit or local
   reporter. A public repository reference is stronger than a raw star.
 - Require the full conformance kit to reject every deliberately trusting reference
@@ -588,8 +801,10 @@ reviews, or automated promotional submissions.
 
 ## First implementation recommendation
 
-Implement **P0-A Evidence Receipt v1 only** as the next isolated feature slice. Do
-not include the renderer, Doctor, proof demo, lifecycle, CI formats, profiles, usage,
-benchmarking, or signing in that change. Before any code begins, obtain a fresh user
-approval naming P0-A and preserve the normal independent implementation and
-verification-agent split.
+Implement **G0 Compatibility Reconciliation & Watch only** as the next isolated
+feature slice. Do not include G1 selectors, a `flash-high` alias, routing/ranking
+changes, P0-A receipts, the renderer, Doctor, proof demo, lifecycle, CI report formats,
+profiles, usage, benchmarking, or signing in that change. After G0 is accepted, G1
+may proceed under its own fresh approval and pull request; P0-A follows separately.
+Never mix G0 and P0-A even if they touch shared documentation. Preserve the normal
+independent implementation and verification-agent split for every slice.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -75,12 +75,13 @@ Every roadmap slice must preserve all of these rules:
    human diff review.
 3. No receipt, report, persona, profile, benchmark, usage number, or CI rendering may
    become an alternative acceptance path.
-4. The caller selects the model tier. Recommendations remain visible and advisory,
-   with `recommendation_only: true` and `applied: false`.
+4. The caller selects the tier or explicit model/effort input. Recommendations remain
+   visible and advisory, with `recommendation_only: true` and `applied: false`.
 5. Never add automatic tier/model/effort changes or invent a `--thinking-level`
    control. After G0 reconciles the exact agy contract, G1 may expose agy's real
-   `--model MODEL` and `--effort low|medium|high` as explicit caller choices only.
-   Retries keep the caller's resolved selection byte-for-byte.
+   model and effort vocabulary as explicit wrapper choices only. The wrapper resolves
+   a verified pair to one exact agy model slug; it does not assume agy's two CLI
+   selectors compose. Retries keep the caller's resolved selection byte-for-byte.
 6. Permission, authentication, scope-policy, invalid-contract, untrusted-claim, and
    human-required outcomes are non-escalatable.
 7. No feature may automatically commit, push, open a pull request, merge, release,
@@ -110,15 +111,18 @@ This corrects the current inventory without claiming that locally advertised fla
 or historical failure behavior are the verified agy `1.1.10` contract:
 
 - Do not expose `--effort` before G0 reconciles official releases/source/docs with a
-  sandbox-correct inventory and bounded behavior tests. G1 may then expose the real
-  agy flag; it must not infer effort or invent a thinking-level flag.
+  sandbox-correct inventory and bounded behavior tests. G1 may then expose the same
+  vocabulary as a wrapper input; it must not infer effort, invent a thinking-level
+  flag, or imply that both agy selectors are forwarded.
 - Do not add dynamic model/persona discovery from help text alone.
 - Do not infer authentication from a single failure or invent `agy auth`. Probe only
   documented commands and validate their expected semantic output; neither an unknown
   subcommand's exit code nor generic usage text is compatibility evidence.
-- Do not assume a full model slug ending in an effort-like suffix composes safely with
-  `--effort`. Until official source plus a bounded test proves an exact combination,
-  the wrapper must reject it rather than send two possibly conflicting selectors.
+- Do not assume agy's separate `--model` and `--effort` flags compose safely.
+  Subsequent bounded `1.1.10` inventory evidence advertises compound slugs, while
+  public source does not establish dual-selector composition or precedence. G1
+  therefore resolves a verified base/effort pair to one exact advertised slug and
+  sends one `--model`.
 - Any exposure of newly advertised agy behavior remains a separate slice requiring
   official docs, official source, a sandbox-correct live inventory, a bounded real
   job, paired offline tests, and explicit approval.
@@ -136,8 +140,10 @@ an earlier implementation because it shares a schema or helper.
   `compat/sources.md`, and dependency-free metadata from agy to both agy and Codex.
   Use one explicit version, reviewed upstream revision, and last-reviewed date per
   tool; migrate the current shared `compat/last-reviewed.txt` to unambiguous per-tool
-  records. Add a human-reviewed, dependency-free model/effort capability matrix bound
-  to the exact verified agy version and source revision. Add
+  records. Add a human-reviewed, dependency-free model/effort resolution matrix bound
+  to the exact verified agy version and source revision. Each adjustable input pair
+  maps to one exact advertised compound slug; fixed/no-level entries are recorded as
+  non-adjustable. Add
   `.github/workflows/compatibility-watch.yml` as a separate weekly and
   `workflow_dispatch` macOS workflow. It is observational and is not a required pull
   request check.
@@ -176,19 +182,23 @@ an earlier implementation because it shares a schema or helper.
   The watch never performs this reconciliation. If an official agy `1.1.10` release
   and matching source cannot both be established, the verified baseline stays `1.1.9`
   and the result remains AMBER/review-due rather than speculatively advancing.
-- **Capability-matrix rule:** G0 derives model-specific effort support from the exact
-  verified agy docs/source and bounded CLI behavior, not from a provider API table or
-  a model-name guess. The matrix records its agy version and source revision. Any agy
-  version/source drift makes the matrix stale and keeps effort dispatch disabled until
-  human reconciliation. The current candidate inventory to verify is Gemini 3.6 Flash
-  with low/medium/high and Gemini 3.1 Pro with low/high but **not medium**; it is not a
-  runtime promise until G0 establishes the exact agy model identifiers and pairs.
+- **Resolution-matrix rule:** G0 derives model-specific effort support and its single
+  exact output slug from the verified `agy models` inventory, agy docs/source, and
+  bounded CLI behavior—not from a provider API table or a model-name guess. The
+  matrix records its agy version and source revision. Any agy version/source drift
+  makes it stale and keeps effort resolution disabled until human reconciliation.
+  The current `1.1.10` candidate inventory to verify exposes compound slugs: Gemini
+  3.6 Flash has low/medium/high and Gemini 3.1 Pro has low/high but **not medium**.
+  Sonnet is no-level; the advertised Opus thinking slug and GPT medium-labelled slug
+  are fixed model choices, not adjustable effort pairs. These are not runtime promises
+  until G0 binds every exact input and output slug to the verified inventory.
 - **Current-behavior correction:** Implementation updates README and AGENTS guidance
   to say that probes must validate documented commands and expected semantic content,
   never an unknown subcommand's exit or usage output. It also records that agy has a
-  real `--effort`, while this wrapper exposes no effort control until G1. No code may
-  combine `--effort` with a full slug that may already encode effort without exact
-  compatibility evidence.
+  real `--effort`, while this wrapper exposes no effort control until G1. G0 records
+  that the public source does not yet prove dual-selector composition: production code
+  sends one resolved model slug and cannot combine an effort-bearing slug with agy's
+  separate effort flag without a later, separately approved evidence gate.
 - **Model option decision gate:** `gemini-3.6-flash-high` is already selectable as a
   raw custom `--tier` label. It remains unranked and non-escalating; no `bulk`/`hard`
   mapping changes and no effort flag are part of G0. Google's official
@@ -198,7 +208,7 @@ an earlier implementation because it shares a schema or helper.
   [thinking guide](https://ai.google.dev/gemini-api/docs/generate-content/thinking)
   shows real but model-specific effort levels, and
   [pricing](https://ai.google.dev/gemini-api/docs/pricing) distinguishes model and
-  thinking usage. Those API facts must not be copied into the agy capability matrix;
+  thinking usage. Those API facts must not be copied into the agy resolution matrix;
   they do not prove the agy CLI composition, relative quality, or effective
   subscription cost for this wrapper. A discoverable `flash-high` alias is a later
   isolated decision after G0/G1 compatibility tests; changing a default or
@@ -213,8 +223,9 @@ an earlier implementation because it shares a schema or helper.
 - **Minimum accept tests:** Fixed fake official sources unchanged return `0`; installed
   versus verified differences and stale review dates are reported separately and
   return `3`; unavailable network returns `2` with an inconclusive label; absent
-  official `1.1.10` evidence retains `1.1.9` and AMBER; version-bound capability
-  fixtures reproduce every documented supported pair and mark drift stale; a raw
+  official `1.1.10` evidence retains `1.1.9` and AMBER; version-bound resolution
+  fixtures reproduce every documented pair-to-compound-slug mapping, preserve fixed
+  no-level/thinking/medium-labelled entries, and mark drift stale; a raw
   `gemini-3.6-flash-high` selection remains pass-through, unranked, recommendation-only,
   and non-escalating; workflow fixtures prove weekly/manual triggers, macOS, read-only
   permission, bounded summary, and no mutation.
@@ -224,7 +235,8 @@ an earlier implementation because it shares a schema or helper.
   calls, `apply`, `pull`, GitHub writes, or required-PR-check coupling in the watcher;
   automatic issue/PR creation; tier remapping; alias creation; or an effort flag.
   Reject a matrix with an unbound/mismatched version or revision, an unsupported pair,
-  a provider-table-only claim, or an inferred capability for an unknown model.
+  a provider-table-only claim, an inferred capability for an unknown model, a missing
+  exact output slug, or an adjustable effort entry for a fixed/no-level model.
 - **Docs and AGENTS impact:** README compatibility semantics and limitations,
   `compat/sources.md`, REPO_MAP ownership/data flow, lessons learned on inconclusive
   evidence, and concise durable AGENTS probing rules. Run `agents-md-auditor` before
@@ -241,14 +253,17 @@ an earlier implementation because it shares a schema or helper.
 
 ### G1 — Explicit Model & Effort Selection
 
-- **User job:** Select an exact agy model and its verified supported effort directly,
-  without disguising the choice as a tier or allowing a recommendation to change it.
+- **User job:** Select an exact advertised agy model or a verified base-model/effort
+  pair directly, without disguising the choice as a tier or allowing a recommendation
+  to change it.
 - **Sequence gate:** Start only after G0 has reconciled the exact agy `1.1.10` (or
   later explicitly verified) CLI/source behavior. G1 precedes any `flash-high` alias,
   performance ranking, or default/recommendation remap and must be its own pull request.
-- **Intended surface:** Add wrapper CLI `--model MODEL` and agy's real
-  `--effort low|medium|high`; never add `--thinking-level`. Preserve `--tier` named
-  values, raw-label pass-through, and the no-option default exactly. Add
+- **Intended surface:** Add wrapper CLI `--model MODEL` and
+  `--effort low|medium|high`, using agy's real vocabulary but never inventing
+  `--thinking-level`. These are wrapper inputs, not a promise to forward both agy
+  flags. Preserve `--tier` named values, raw-label pass-through, and the no-option
+  default exactly. Add
   `AGY_WORKER_MODEL` and `AGY_WORKER_EFFORT` only with the strict conflict contract
   below. Canonical runtime, root compatibility wrapper, public skill copy, validators,
   recommendation schemas/renderers, and later receipt/report schemas carry the same
@@ -258,55 +273,66 @@ an earlier implementation because it shares a schema or helper.
   the values match. Any explicit tier source (`--tier` or `AGY_WORKER_TIER`) is mutually
   exclusive with every explicit model/effort source. With no explicit selector, the
   existing implicit `bulk` default remains. Direct mode uses one exact model source;
-  an effort source requires that model unless the G0 evidence explicitly proves and
-  pins safe effort-only behavior. Duplicate CLI occurrences, empty values, unknown
-  effort values, and cross-source conflicts fail before dispatch with usage exit `64`.
-- **Composition safety:** Pass `--model MODEL` and `--effort VALUE` as separate agy
-  arguments only for that exact pair in the G0 matrix whose agy version and source
-  revision still match the verified baseline. The globally accepted effort spelling
-  does not imply every model accepts all three values: the candidate matrix must, for
-  example, verify Flash low/medium/high separately and Pro low/high separately while
-  rejecting Pro medium. Unknown model/version, unsupported pair, or stale matrix fails
-  before dispatch. Until official source and a bounded test prove otherwise, also
-  reject effort combined with a slug ending in a known effort suffix such as `-low`,
-  `-medium`, `-high`, or another registered effort-bearing form, and reject every
-  other ambiguous combination. Do not strip, rewrite, normalize, or guess a base
-  model from the slug.
+  effort always requires a base-model input. Duplicate CLI occurrences, empty values,
+  unknown effort values, and cross-source conflicts fail before dispatch with usage
+  exit `64`.
+- **Resolution and dispatch safety:** Exact advertised compound/no-level slugs supplied
+  through `--model` alone remain allowed and unranked; agy receives one
+  `--model EXACT_SLUG`. A base-model plus effort is allowed only when the G0 matrix for
+  the installed verified agy version maps that exact pair to one exact advertised
+  compound slug; agy again receives only `--model RESOLVED_SLUG`. The globally accepted
+  effort spelling does not imply every model accepts all three values: verify Flash
+  low/medium/high separately and Pro low/high separately while rejecting Pro medium.
+  Sonnet no-level, Opus thinking-labelled, and GPT medium-labelled slugs are fixed
+  exact-model choices and reject any effort input. Compound slug plus effort, unknown
+  model/version, unsupported pair, stale matrix, missing mapping, or ambiguous form
+  fails before dispatch with no fallback, slug surgery, normalization, or base-model
+  guess.
+- **Dual-selector evidence gate:** G1 never forwards agy's `--effort`. Passing both
+  `--model` and `--effort` to agy requires a later isolated slice with official source
+  or a separately approved bounded test proving exact composition, precedence, failure
+  semantics, and retry behavior for the pinned version. That future evidence cannot
+  silently replace the safe single-selector mapping.
 - **Persistence and evidence:** Resolve selection once before attempt one and retain
-  the exact tier/model/effort provenance and values across every retry. Pre-dispatch
-  and post-gate recommendations, Evidence Receipt v1, and the Human Report represent
-  selected tier, model, and effort as distinct optional fields. A custom model or
-  effort remains unranked; recommendation output stays `recommendation_only: true`,
-  `applied: false`, and cannot alter or redispatch the selection.
+  the exact tier or user model/effort provenance, matrix revision, and resolved agy
+  slug across every retry. Pre-dispatch and post-gate recommendations, Evidence Receipt
+  v1, and the Human Report represent selected tier, user model, user effort, and
+  resolved agy model as distinct optional fields. A custom model or effort remains
+  unranked; recommendation output stays `recommendation_only: true`, `applied: false`,
+  and cannot alter or redispatch the selection.
 - **Non-escalatable outcomes:** Permission, authentication, scope-policy,
   invalid-contract, untrusted-claim, and human-required failures remain
   non-escalatable regardless of selected model or effort. Higher effort is never
   proposed as a repair for those outcomes.
-- **Dependencies:** Completed G0 baseline and composition matrix, existing dispatcher
+- **Dependencies:** Completed G0 baseline and resolution matrix, existing dispatcher
   parsing/model assembly, advisory recommender, and the schema/report surfaces present
   when G1 starts. No new dependency or provider lookup.
 - **Minimum accept tests:** Legacy named tiers, raw `--tier` labels, and implicit bulk
-  remain byte-compatible; one CLI or one environment model reaches agy exactly; every
-  matrix-admitted pair has its own test and reaches agy as two exact arguments; retries
-  preserve the resolved selection; recommendations and receipts/reports label custom
-  selection without ranking or applying it.
+  remain byte-compatible; each exact advertised slug reaches agy as one exact
+  `--model`; every matrix-admitted base/effort pair has its own test and reaches agy as
+  one exact resolved compound `--model`; fixed Sonnet/Opus/GPT choices remain exact and
+  non-adjustable; retries preserve the same matrix revision and resolved slug;
+  recommendations and receipts/reports label user and resolved selection without
+  ranking or applying it.
 - **Minimum reject tests:** CLI/env duplicates; tier plus model or effort across any
-  source; repeated selector; empty/invalid model or effort; effort without a model
-  unless explicitly verified; known effort-bearing slug plus `--effort`; unverified
-  composition; unsupported model/effort pair (including Pro medium when absent from
-  the verified matrix); unknown model or version; stale/unbound matrix; inferred
-  capability; invented thinking flag; retry mutation; recommendation-driven change;
-  or escalation of a non-escalatable failure. Assert that fake agy is never invoked
-  for every preflight rejection.
+  source; repeated selector; empty/invalid model or effort; effort without a base
+  model; compound/fixed/no-level slug plus effort; unsupported pair (including Pro
+  medium); adjustable Sonnet, Opus, or GPT; unknown model or version; stale/unbound
+  matrix; missing exact output; inferred capability; dual-selector forwarding;
+  invented thinking flag; fallback to a nearby level/model; retry mutation;
+  recommendation-driven change; or escalation of a non-escalatable failure. Assert
+  that fake agy is never invoked for every preflight rejection.
 - **Docs and AGENTS impact:** README option/precedence tables and examples, public
-  skill SKILL.md, REPO_MAP data flow, lessons learned on dual selectors, compatibility
-  metadata, and a concise AGENTS rule forbidding inferred effort and silent override.
+  skill SKILL.md, REPO_MAP data flow, lessons learned on single-slug resolution and
+  unproven dual selectors, compatibility metadata, and a concise AGENTS rule forbidding
+  inferred effort, silent override, and unverified two-argument composition.
   Run `agents-md-auditor` before and after those future guidance edits.
 - **Size:** M.
-- **Done/exit criteria:** Exact G0-backed arguments and conflict behavior are documented
-  and adversarially tested on macOS Bash 3.2; all prior suites stay green; raw tier
-  compatibility remains; no recommendation changes selection; and independent
-  verification confirms no ambiguous or automatic model/effort path.
+- **Done/exit criteria:** Exact G0-backed single-slug mappings and conflict behavior are
+  documented and adversarially tested on macOS Bash 3.2; all prior suites stay green;
+  raw tier compatibility remains; agy receives no separate effort argument; no
+  recommendation changes selection; and independent verification confirms no
+  ambiguous, automatic, fallback, or dual-selector model/effort path.
 - **Later alias/ranking gate:** A named `flash-high` alias can be proposed only after
   G0/G1 prove its exact agy composition. Mapping `bulk`/`hard`, recommending Flash-high
   over Pro-high, or changing a default additionally requires a pre-registered bounded
@@ -343,9 +369,10 @@ an earlier implementation because it shares a schema or helper.
   exact envelope snapshot validated by the gate; ordered path-policy hash; verifier
   labels and command hashes; the gate-supplied initial and final candidate-state
   digests; actual gate exit/outcome; a verdict restricted to `gate-passed`, `rejected`,
-  or `routed`; optional caller-selection object with exactly one resolved mode and
-  distinct tier/model/effort values plus CLI/environment/default provenance under the
-  accepted G1 contract; optional validated pre-dispatch advisory retaining its
+  or `routed`; optional caller-selection object with exactly one resolved mode,
+  distinct tier/user-model/user-effort values, CLI/environment/default provenance,
+  matrix revision when used, and exact resolved agy model slug under the accepted G1
+  contract; optional validated pre-dispatch advisory retaining its
   rationale, controlled driver evidence, relative cost impact,
   `recommendation_only: true`, `applied: false`, and `stage: pre-dispatch`;
   `gate_authority: qa-gate`; and an explicit statement that the receipt is unsigned
@@ -382,18 +409,18 @@ an earlier implementation because it shares a schema or helper.
   initial/final state digests; the wrapper returns `0`. Each normal gate result
   `10`–`14` durably publishes verdict `rejected`, result `15` publishes `routed`, and
   the wrapper returns that exact gate exit. A valid pre-dispatch advisory is bound
-  without changing the selected tier/model/effort or gate result. The tests never call
-  a candidate accepted before human review. Direct `qa-gate.sh` calls without
-  `--evidence-fd`
-  retain their current stdout/stderr and exit contract.
+  without changing the selected input, matrix revision, resolved agy slug, or gate
+  result. The tests never call a candidate accepted before human review. Direct
+  `qa-gate.sh` calls without `--evidence-fd` retain their current stdout/stderr and
+  exit contract.
 - **Minimum reject tests:** Scope failure, malformed envelope, untrusted command/test
   claim, missing edits, verifier failure/mutation, and human-required outcome retain
   their gate classification and are never rendered as acceptance. Reject overwrite,
   symlink target, in-repository output, unknown schema version, inconsistent receipt,
   separately bound artifact/digest mismatch, malformed or duplicate handoff, envelope
   snapshot/base/state/outcome/exit mismatch, post-gate or cross-stage advisory input,
-  selected tier/model/effort mismatch, ambiguous selector provenance, or an advisory
-  that claims it was applied. Wrapper/gate
+  selected-input/matrix/resolved-slug mismatch, ambiguous selector provenance, or an
+  advisory that claims it was applied. Wrapper/gate
   preflight `64`, unknown exit, signal, missing evidence, internal `70`, and durable
   publication `74` paths publish no receipt; injected validation, `fsync`, rename, and
   parent-directory durability failures leave no final or partial receipt. An unsigned
@@ -555,21 +582,22 @@ receipt or creating chronology ambiguity.
 
 #### P1-C — Reproducible benchmark harness
 
-- **User job:** Compare releases, caller-selected tiers, or personas on fixed bounded
-  tasks using gate observations rather than subjective worker summaries.
+- **User job:** Compare releases, caller-selected model inputs, or personas on fixed
+  bounded tasks using gate observations rather than subjective worker summaries.
 - **Intended surface:** `benchmark.sh prepare|run|report`, frozen
   `benchmarks/v1/manifest.json`, ignored local result directory, and
   `docs/BENCHMARKING.md`. Paid work requires an explicit `--live` boundary.
 - **Dependencies:** Receipt v1; lifecycle is useful but optional.
 - **Trust boundary:** Every result binds exact fixture/base, tool versions, selected
-  tier/model/effort, attempt count, policy, and verification. No hidden retries or
-  selector changes. Competitor comparisons require identical public tasks and rules.
-  No leaderboard by default.
+  tier/user-model/user-effort, matrix revision, resolved agy slug, attempt count,
+  policy, and verification. No hidden retries or selector changes. Competitor
+  comparisons require identical public tasks and rules. No leaderboard by default.
 - **Minimum accept tests:** Frozen offline fixture produces a deterministic report and
-  receipt; live-mode parser preserves selected tier/model/effort and attempt count.
+  receipt; live-mode parser preserves selected input, matrix revision, resolved slug,
+  and attempt count.
 - **Minimum reject tests:** Changed fixture hash, missing verifier, unpublished input,
-  partial task set described as complete, hidden retry/model/effort change, or result
-  without exact version binding.
+  partial task set described as complete, hidden retry/input/resolution change, or
+  result without exact version binding.
 - **Docs and AGENTS impact:** Add BENCHMARKING document and README evidence link;
   update REPO_MAP. AGENTS updates only verified real/offline evidence boundaries, not
   one-off results.
@@ -793,7 +821,8 @@ reviews, or automated promotional submissions.
 - Require the full conformance kit to reject every deliberately trusting reference
   gate and accept the maintained implementation.
 - Publish benchmark claims only when every result binds exact public fixture, base,
-  selected tier, attempts, tool versions, policy, and driver verification.
+  selected input, matrix revision and resolved agy slug when applicable, attempts,
+  tool versions, policy, and driver verification.
 - Track accepted-real-candidate evidence per persona without converting one success
   into a universal quality percentage.
 - Reassess P2 from observed friction. Do not build profiles, pruning, quota, or

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,5 +59,7 @@ Checked-in repository files do not alter GitHub About fields, topics, homepage
 metadata, or social-preview settings. Those remain deliberate repository-owner
 actions.
 
-[Read the full documentation](https://github.com/cagdasyurekli/codex-agy-worker#readme)
-or [inspect the source and offline tests](https://github.com/cagdasyurekli/codex-agy-worker).
+[Read the full documentation](https://github.com/cagdasyurekli/codex-agy-worker#readme),
+[review the planned roadmap](https://github.com/cagdasyurekli/codex-agy-worker/blob/main/docs/ROADMAP.md), or
+[inspect the source and offline tests](https://github.com/cagdasyurekli/codex-agy-worker).
+Roadmap entries are proposals, not current product capabilities.


### PR DESCRIPTION
## Summary

- synthesize primary-source competitor research, the verified agy inventory, and the repository's existing evidence boundary into one dependency-ordered product roadmap
- separate planned work from current behavior and require a fresh approval for each implementation slice
- define P0 evidence receipt, human report, read-only doctor, and 60-second offline proof slices; P1 lifecycle, conformance, benchmark, persona-evidence, and CI-reporting slices; and optional P2 local ergonomics
- record the intentionally deferred or rejected directions, including signing without a threat model, async/daemon/MCP expansion, multi-backend work, automatic model or effort selection, quota routing, and automatic GitHub/release actions

## Contract corrections

- Receipt v1 uses `gate_authority: qa-gate` and only the verdicts `gate-passed`, `rejected`, or `routed`; a receipt is never called accepted.
- `accepted candidate` remains reserved for a gate-passed candidate after the required human diff review.
- Destructive lifecycle cleanup is planned only for an explicitly approved, exact hash-bound rejected disposable state. It must refuse gate-passed, accepted, routed, tampered, changed-since-verification, foreign, unbound, or non-matching uncommitted state.

## Boundaries

This PR contains documentation only. It does not implement any roadmap command, change the gate, alter model routing, dispatch agy, modify user configuration, or authorize P0-A. The first implementation recommendation remains P0-A Evidence Receipt v1 only, after a fresh explicit approval.

## Verification

- `./tests/test-qa-gate.sh` — 41 passed
- `./tests/test-agy-worker.sh` — 58 passed
- `./tests/test-update.sh` — 26 passed
- `./tests/test-reporting.sh` — 21 passed
- `./tests/test-packaging.sh` — 21 passed
- Bash syntax and Python byte-compilation passed
- all 6 YAML files parsed
- Markdown relative links passed
- `git diff --check` passed
- `agents-md-auditor` PRE/POST: root `AGENTS.md` 97/100 (A), active hierarchy 8,284 bytes, no AGENTS change required
