### PR TITLE
Watch the official agy distribution manifest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Keep these counts current when their suites change:
 - `qa-gate.sh`: 41 offline cases.
 - `agy-worker.sh` / `install.sh` / `model-recommendation.sh`: 60 offline
   fake-agy/routing cases.
-- `update.sh`: 92 offline local-remote/matrix/watch-policy cases.
+- `update.sh`: 164 offline local-remote/matrix/manifest/watch-policy cases.
 - `bug-report.sh`: 21 offline privacy/fake-`gh` cases.
 - Codex package/skill distribution: 21 offline manifest/runtime-copy/relocation/landing cases.
 
@@ -96,6 +96,10 @@ only a passing test has not been shown to catch anything.
   bounded real job when behavior changed. Production origins, release channels, and
   review cadence are not environment-overridable. The weekly watcher never advances
   metadata or takes an external action. `apply` is always an explicit action.
+- **The agy distribution manifest is only a canary.** Its endpoint is fixed; reject
+  proxies, redirects, oversized/malformed responses, and unexpected archive URLs.
+  Never request the archive. The checked-in tuple detects drift but cannot advance a
+  baseline, prove source/behavior, or activate model/effort resolution.
 - **Bug reports are local drafts first.** Never gather prompts, source, envelopes,
   paths, credentials, or raw logs automatically. Submission must show the exact body
   and require the matching SHA-256 confirmation token; send those validated bytes,

--- a/README.md
+++ b/README.md
@@ -376,15 +376,18 @@ There is no background updater. Checking is read-only:
 
 It reports the latest stable project tag without fetching it, then reports installed,
 verified, official stable-release/source drift, and 30-day documentation-review age
-separately for agy and Codex CLI. Exit `0` means all required evidence is available
-and unchanged. Exit `3` means established drift, a due review, or a missing installed
-tool. Exit `2` means evidence is unavailable or malformed, so the result is
-inconclusive—not green. Both tools are reported before those results are aggregated,
-with `2` taking precedence over `3`.
+separately for agy and Codex CLI. The agy section also checks one fixed official
+`darwin_arm64` distribution-manifest canary. It validates only that small JSON
+document and never requests, downloads, hashes, or executes the referenced archive.
+Exit `0` means all required evidence is available and unchanged. Exit `3` means
+established drift, a due review, or a missing installed tool. Exit `2` means evidence
+is unavailable or malformed, so the result is inconclusive—not green. Both tools are
+reported before those results are aggregated, with `2` taking precedence over `3`.
 
-The release origins, upstream sources, release channels, and 30-day cadence are fixed
-in the updater rather than overridable through environment variables. The check never
-fetches, pulls, applies, or writes a baseline. A future per-tool review date is
+The release origins, upstream sources, distribution-manifest endpoint, release
+channels, and 30-day cadence are fixed in the updater rather than overridable through
+arguments, environment variables, or configuration. The check never fetches into
+Git, pulls, applies, or writes a baseline. A future per-tool review date is
 inconclusive rather than silently postponing review.
 
 Apply is always explicit:
@@ -413,6 +416,13 @@ The fixed primary sources and exact reviewed revisions are recorded in
 watch runs the official-evidence-only mode without installing agy or Codex. It writes
 only a bounded Step Summary, preserves the same `0`/`3`/`2` meanings, is not a required
 pull-request check, and cannot advance metadata or open an issue or pull request.
+
+The official distribution manifest currently advertises agy `1.1.10`, while the
+public GitHub stable release and reviewed source remain `1.1.9`. That is established
+distribution drift, not authority to advance the verified baseline. The checked-in
+manifest tuple is an observational change detector rather than a trust root: a
+same-version archive build, URL, or SHA-512 change also requires review. Neither the
+live manifest nor its snapshot activates the disabled `1.1.10` model/effort matrix.
 
 agy's real CLI exposes `--effort`, but this wrapper exposes no effort control until a
 separately approved G1. The checked-in model/effort matrix is validated metadata, not
@@ -524,6 +534,7 @@ update.sh                     explicit release + agy/Codex compatibility check/a
 bug-report.sh                 sanitized local draft/preview/optional submission
 compat/                       per-tool baselines, sources, and disabled candidate matrix
 scripts/compatibility.py      stdlib metadata/matrix validation and exact resolution
+scripts/official_distribution.py  fixed, bounded agy distribution-manifest canary
 scripts/bug-report.py         privacy filter and SHA-bound gh submission
 skills/agy-worker/            canonical self-contained Agent Skill and runtime
 skills/agy-worker/runtime/    dispatcher, gate, advisory, personas, schema, Python helpers
@@ -537,7 +548,8 @@ CODE_OF_CONDUCT.md            enforceable participation standards
 .github/pull_request_template.md  review and verification checklist
 tests/test-qa-gate.sh         offline adversarial suite
 tests/test-agy-worker.sh       offline dispatcher/installer/routing suite
-tests/test-update.sh          offline local-remote updater suite
+tests/test-update.sh          164-case offline local-remote/matrix/manifest updater suite
+tests/test-official-distribution.py  test-only stdlib manifest adversary harness
 tests/test-reporting.sh       offline privacy/fake-gh reporting suite
 tests/test-packaging.sh       offline Codex package/relocation/landing suite
 .github/workflows/compatibility-watch.yml  observational weekly/manual fixed-source watch

--- a/compat/agy-distribution-manifest.json
+++ b/compat/agy-distribution-manifest.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.1.10",
+  "url": "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.1.10-6423386432339968/darwin-arm/cli_mac_arm64.tar.gz",
+  "sha512": "623f9fbbd9069a1ad0d71ab7e6235b5b286e19b1067e4164d1f9bb7a5ce866d21e4a955dba8ee397feaf8b076789cd9664da26169985efb5ac7d429018680bd1"
+}

--- a/compat/sources.md
+++ b/compat/sources.md
@@ -14,13 +14,25 @@ an external action.
 - Official changelog: https://github.com/google-antigravity/antigravity-cli/blob/main/CHANGELOG.md
 - Official CLI overview: https://antigravity.google/docs/cli-overview
 - Official usage guidance: https://antigravity.google/docs/cli-using
+- Official installer: https://antigravity.google/cli/install.sh
+- Fixed `darwin_arm64` distribution manifest: https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/darwin_arm64.json
 - Installed interface evidence: `./ground-truth.sh`
 
 The verified baseline is agy `1.1.9` at source revision
-`21f650e7bb852f58562425ddd0c7d203c80e3d0e`. Installed `1.1.10` is established
-drift, not permission to advance that baseline. Its model list is recorded only as a
-disabled candidate inventory in `agy-model-effort-matrix.json`, because today's
-official `1.1.9` release/source evidence does not substantiate those exact rows.
+`21f650e7bb852f58562425ddd0c7d203c80e3d0e`. The official distribution manifest and
+the installed executable advertise `1.1.10`; the public stable release and reviewed
+source still establish only `1.1.9`. This is drift, not permission to advance that
+baseline. The `1.1.10` model list remains a disabled candidate inventory in
+`agy-model-effort-matrix.json`, because distribution availability does not
+substantiate its source or behavior.
+
+`agy-distribution-manifest.json` records the observed `1.1.10` version, exact Google
+Storage archive URL, and lowercase SHA-512 tuple. It is an observational snapshot,
+not an authoritative baseline, signature, or permission to download the archive.
+The checker fetches only the fixed small manifest, rejects redirects and malformed
+transport/schema/URL evidence, and never makes an archive request. A version change
+or a same-version URL/build/hash change is `drift-review`; unavailable or invalid
+evidence is inconclusive.
 
 ## Codex CLI
 

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -31,8 +31,10 @@ accepting them.
 ## Opt-in maintenance flows
 
 - `update.sh check` queries fixed official agy and Codex stable-release/source
-  evidence, per-tool review age, and (locally) installed versions without changing
-  files. Its `--watch` mode needs no installed tools and preserves the same
+  evidence, one bounded agy `darwin_arm64` distribution-manifest canary, per-tool
+  review age, and (locally) installed versions without changing files. The manifest
+  helper requests no archive and its observational tuple cannot advance a baseline.
+  Its `--watch` mode needs no installed tools and preserves the same
   unchanged/drift-review/evidence-unavailable exit contract. `update.sh apply [TAG]`
   remains explicit: it verifies a
   stable tag and fast-forward, protects ignored-path collisions, runs the candidate
@@ -59,7 +61,7 @@ accepting them.
 | `skills/agy-worker/runtime/schemas/`, `skills/agy-worker/runtime/scripts/validate-envelope.py` | Dependency-free envelope contract validation | dispatcher and gate suites |
 | `qa-gate.sh`, `skills/agy-worker/runtime/qa-gate.sh` | Root compatibility entry plus canonical immutable-base Git audit, path policy, escalation, driver verification | `tests/test-qa-gate.sh` (41 cases) |
 | `skills/agy-worker/runtime/agents/*.md` | Prompt-injected bounded personas; prompt text is guidance, not enforcement | dispatcher suite plus bounded real exercises |
-| `update.sh`, `scripts/compatibility.py`, `compat/` | Explicit project releases; fixed-source agy/Codex review; strict per-tool metadata and disabled-on-drift model/effort matrix | `tests/test-update.sh` (92 cases) |
+| `update.sh`, `scripts/compatibility.py`, `scripts/official_distribution.py`, `compat/` | Explicit project releases; fixed-source agy/Codex review; bounded distribution-manifest canary; strict per-tool metadata and disabled-on-drift model/effort matrix | `tests/test-update.sh` (164 cases, including the test-only manifest adversary harness) |
 | `bug-report.sh`, `scripts/bug-report.py`, `.github/ISSUE_TEMPLATE/` | Local privacy filtering, exact review binding, optional issue submission | `tests/test-reporting.sh` (21 cases) |
 | `.codex-plugin/plugin.json` | Codex skills-only package identity retained for local validation; not a public listing | `tests/test-packaging.sh` (21 cases) plus platform validators |
 | `PRIVACY.md`, `TERMS.md`, `SUPPORT.md` | Public data disclosure, project policy, and support route | `tests/test-packaging.sh` (21 cases) plus review |
@@ -88,6 +90,10 @@ accepting them.
 - Scheduled compatibility evidence is observational. Missing or malformed official
   evidence is inconclusive, and neither the watcher nor a release/version name can
   advance a human-reviewed baseline.
+- The fixed agy distribution manifest is a drift canary, not executable or source
+  evidence. Its validated archive tuple is never requested, opened, hashed, or run;
+  the observational snapshot detects same-version build/hash changes but cannot
+  activate the model/effort matrix.
 - `--workdir` is the single audited repository. User-supplied `--add-dir` roots must
   resolve inside it; multi-repository mutation is unsupported.
 - Release tags are trusted only through the fixed official origin and exact ref/commit

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -173,6 +173,15 @@ an earlier implementation because it shares a schema or helper.
   [Codex CLI reference](https://developers.openai.com/codex/cli/reference). Production
   URLs, review intervals, release channels, and upstream repositories remain fixed in
   the runtime and are not environment-overridable.
+- **Official distribution canary:** The agy evidence set also observes the fixed
+  official `darwin_arm64` updater manifest. The stdlib-only checker disables proxies,
+  rejects redirects and oversized or malformed responses, validates the exact
+  version/archive URL/SHA-512 tuple, and never requests the archive. Its checked-in
+  tuple is an observational same-version change detector, not a verified release,
+  source revision, signature, or baseline. The manifest currently establishes
+  distribution `1.1.10` while public release/source remains verified at `1.1.9`;
+  this keeps G1 resolution disabled and produces drift-review rather than a
+  speculative advance.
 - **Baseline advancement:** A maintainer may advance either verified baseline only
   after reconciling official docs, release notes, and source; regenerating the local
   `./ground-truth.sh` evidence for agy and equivalent documented Codex CLI inventory;
@@ -228,12 +237,18 @@ an earlier implementation because it shares a schema or helper.
   no-level/thinking/medium-labelled entries, and mark drift stale; a raw
   `gemini-3.6-flash-high` selection remains pass-through, unranked, recommendation-only,
   and non-escalating; workflow fixtures prove weekly/manual triggers, macOS, read-only
-  permission, bounded summary, and no mutation.
+  permission, bounded summary, and no mutation; fixed-manifest fixtures pair exact
+  transport/schema/URL/hash acceptance with redirect, timeout, oversize,
+  duplicate/extra/malformed field, archive-policy, and same-version build/hash
+  rejection while proving that no archive request occurs.
 - **Minimum reject tests:** Green on missing evidence; automatic baseline edits;
   environment-overridden source/review policy; malformed or future-dated metadata;
   treating unknown-command exit/usage as support; secret access, installation, model
   calls, `apply`, `pull`, GitHub writes, or required-PR-check coupling in the watcher;
   automatic issue/PR creation; tier remapping; alias creation; or an effort flag.
+  Reject manifest redirects, missing or conflicting length/type metadata, invalid
+  UTF-8/JSON/schema/SemVer/SHA-512, unexpected archive origins or paths, test/runtime
+  source overrides, and any archive request.
   Reject a matrix with an unbound/mismatched version or revision, an unsupported pair,
   a provider-table-only claim, an inferred capability for an unknown model, a missing
   exact output slug, or an adjustable effort entry for a fixed/no-level model.

--- a/docs/lessons_learned.md
+++ b/docs/lessons_learned.md
@@ -44,6 +44,14 @@ usage is not semantic evidence. The weekly watcher observes the same fixed sourc
 it never updates a baseline, installs a tool, dispatches a model, or takes a GitHub
 write action. A bounded real job remains separately approved when behavior changed.
 
+An official installer channel can move before a public release/source repository.
+Observe that difference through one fixed, bounded manifest canary, but do not turn a
+distribution version or checksum into source or behavior evidence. Disable proxies,
+reject redirects, cap and validate the JSON response, structurally bind its archive
+URL to the expected host/path/version, and make no archive request. Keep the recorded
+tuple explicitly observational: version or same-version build/hash drift asks for
+human review and cannot advance a baseline or activate model routing.
+
 A disposable candidate worktree isolates files, not execution. Candidate validation
 runs release-owned scripts with the invoking user's privileges. Exact tag/ref and
 fast-forward checks prove transport consistency, not that candidate code is harmless.

--- a/scripts/official_distribution.py
+++ b/scripts/official_distribution.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Validate one fixed, observational agy distribution-manifest canary."""
+
+from __future__ import annotations
+
+import json
+import re
+import ssl
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+
+MANIFEST_URL = (
+    "https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/"
+    "manifests/darwin_arm64.json"
+)
+ARCHIVE_HOST = "storage.googleapis.com"
+MAX_RESPONSE_BYTES = 4096
+FETCH_TIMEOUT_SECONDS = 10.0
+SEMVER_RE = re.compile(
+    r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)"
+)
+SHA512_RE = re.compile(r"[0-9a-f]{128}")
+ARCHIVE_PATH_RE = re.compile(
+    r"/antigravity-public/antigravity-cli/"
+    r"((?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))"
+    r"-([0-9]+)/darwin-arm/cli_mac_arm64\.tar\.gz"
+)
+
+
+class DistributionEvidenceError(ValueError):
+    """A sanitized fixed-source evidence failure."""
+
+    def __init__(self, category: str):
+        super().__init__(category)
+        self.category = category
+
+
+class DuplicateKeyError(DistributionEvidenceError):
+    """A duplicate JSON key makes the document ambiguous."""
+
+
+class RejectRedirects(urllib.request.HTTPRedirectHandler):
+    """Reject redirects before urllib can make a second request."""
+
+    def redirect_request(
+        self,
+        req: urllib.request.Request,
+        fp: Any,
+        code: int,
+        msg: str,
+        headers: Any,
+        newurl: str,
+    ) -> None:
+        del req, fp, code, msg, headers, newurl
+        raise DistributionEvidenceError("redirect rejected")
+
+
+def no_duplicate_object(pairs: Iterable[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise DuplicateKeyError("invalid manifest document")
+        result[key] = value
+    return result
+
+
+def build_fixed_opener() -> urllib.request.OpenerDirector:
+    """Build the production opener: default TLS, no proxies, no redirects."""
+    context = ssl.create_default_context()
+    return urllib.request.build_opener(
+        urllib.request.ProxyHandler({}),
+        RejectRedirects(),
+        urllib.request.HTTPSHandler(context=context),
+    )
+
+
+def _single_header(headers: Any, name: str) -> str:
+    values = headers.get_all(name) if hasattr(headers, "get_all") else None
+    if values is None:
+        value = headers.get(name) if hasattr(headers, "get") else None
+        values = [] if value is None else [value]
+    if len(values) != 1 or not isinstance(values[0], str):
+        raise DistributionEvidenceError("invalid response metadata")
+    return values[0]
+
+
+def _validate_content_type(raw: str) -> None:
+    parts = [part.strip() for part in raw.split(";")]
+    if not parts or parts[0].lower() != "application/json":
+        raise DistributionEvidenceError("invalid response metadata")
+    for parameter in parts[1:]:
+        if parameter.lower() != "charset=utf-8":
+            raise DistributionEvidenceError("invalid response metadata")
+
+
+def fetch_manifest_bytes(
+    opener: Any,
+    *,
+    url: str = MANIFEST_URL,
+    timeout: float = FETCH_TIMEOUT_SECONDS,
+    limit: int = MAX_RESPONSE_BYTES,
+) -> bytes:
+    """Fetch one bounded manifest response through an injected opener."""
+    request = urllib.request.Request(
+        url,
+        headers={"Accept": "application/json", "User-Agent": "codex-agy-worker/compat"},
+        method="GET",
+    )
+    try:
+        response = opener.open(request, timeout=timeout)
+    except DistributionEvidenceError:
+        raise
+    except urllib.error.HTTPError as exc:
+        if 300 <= exc.code < 400:
+            raise DistributionEvidenceError("redirect rejected") from None
+        raise DistributionEvidenceError("HTTP evidence unavailable") from None
+    except (urllib.error.URLError, TimeoutError, OSError):
+        raise DistributionEvidenceError("network evidence unavailable") from None
+    except Exception:
+        raise DistributionEvidenceError("network evidence unavailable") from None
+
+    try:
+        with response:
+            status = getattr(response, "status", None)
+            if status is None and hasattr(response, "getcode"):
+                status = response.getcode()
+            if status != 200:
+                raise DistributionEvidenceError("HTTP evidence unavailable")
+
+            _validate_content_type(_single_header(response.headers, "Content-Type"))
+            length_text = _single_header(response.headers, "Content-Length")
+            if re.fullmatch(r"[1-9][0-9]*", length_text) is None:
+                raise DistributionEvidenceError("invalid response metadata")
+            expected_length = int(length_text)
+            if expected_length > limit:
+                raise DistributionEvidenceError("response too large")
+            body = response.read(limit + 1)
+    except DistributionEvidenceError:
+        raise
+    except (TimeoutError, OSError):
+        raise DistributionEvidenceError("network evidence unavailable") from None
+    except Exception:
+        raise DistributionEvidenceError("network evidence unavailable") from None
+
+    if len(body) > limit:
+        raise DistributionEvidenceError("response too large")
+    if len(body) != expected_length:
+        raise DistributionEvidenceError("invalid response metadata")
+    return body
+
+
+def _validate_string(value: Any) -> str:
+    if not isinstance(value, str) or not value or value.strip() != value:
+        raise DistributionEvidenceError("invalid manifest policy")
+    if any(ord(character) < 0x20 or ord(character) == 0x7F for character in value):
+        raise DistributionEvidenceError("invalid manifest policy")
+    return value
+
+
+def validate_archive_url(value: str, version: str) -> None:
+    if not value.isascii() or "%" in value or "\\" in value:
+        raise DistributionEvidenceError("invalid archive policy")
+    try:
+        parsed = urllib.parse.urlsplit(value)
+        port = parsed.port
+    except ValueError:
+        raise DistributionEvidenceError("invalid archive policy") from None
+    if (
+        parsed.scheme != "https"
+        or parsed.netloc != ARCHIVE_HOST
+        or parsed.hostname != ARCHIVE_HOST
+        or parsed.username is not None
+        or parsed.password is not None
+        or port is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise DistributionEvidenceError("invalid archive policy")
+    match = ARCHIVE_PATH_RE.fullmatch(parsed.path)
+    if match is None or match.group(1) != version:
+        raise DistributionEvidenceError("invalid archive policy")
+
+
+def parse_manifest_bytes(raw: bytes) -> dict[str, str]:
+    try:
+        text = raw.decode("utf-8", "strict")
+        value = json.loads(text, object_pairs_hook=no_duplicate_object)
+    except (UnicodeDecodeError, json.JSONDecodeError, DuplicateKeyError):
+        raise DistributionEvidenceError("invalid manifest document") from None
+    if not isinstance(value, dict) or set(value) != {"version", "url", "sha512"}:
+        raise DistributionEvidenceError("invalid manifest schema")
+
+    version = _validate_string(value["version"])
+    archive_url = _validate_string(value["url"])
+    sha512 = _validate_string(value["sha512"])
+    if SEMVER_RE.fullmatch(version) is None:
+        raise DistributionEvidenceError("invalid manifest policy")
+    if SHA512_RE.fullmatch(sha512) is None:
+        raise DistributionEvidenceError("invalid manifest policy")
+    validate_archive_url(archive_url, version)
+    return {"version": version, "url": archive_url, "sha512": sha512}
+
+
+def read_verified_version(path: Path) -> str:
+    try:
+        raw = path.read_bytes()
+    except OSError:
+        raise DistributionEvidenceError("invalid verified baseline") from None
+    if not raw.endswith(b"\n") or raw.count(b"\n") != 1:
+        raise DistributionEvidenceError("invalid verified baseline")
+    try:
+        value = raw[:-1].decode("ascii", "strict")
+    except UnicodeDecodeError:
+        raise DistributionEvidenceError("invalid verified baseline") from None
+    if SEMVER_RE.fullmatch(value) is None:
+        raise DistributionEvidenceError("invalid verified baseline")
+    return value
+
+
+def read_snapshot(path: Path) -> dict[str, str]:
+    try:
+        raw = path.read_bytes()
+    except OSError:
+        raise DistributionEvidenceError("invalid observational snapshot") from None
+    try:
+        return parse_manifest_bytes(raw)
+    except DistributionEvidenceError:
+        raise DistributionEvidenceError("invalid observational snapshot") from None
+
+
+def evaluate_manifest(
+    observed: dict[str, str], verified_version: str, snapshot: dict[str, str]
+) -> tuple[int, str]:
+    if observed != snapshot:
+        return 3, "validated tuple differs from observational snapshot"
+    if observed["version"] != verified_version:
+        return 3, (
+            f"official distribution {observed['version']}; verified {verified_version}"
+        )
+    return 0, f"{verified_version}"
+
+
+def check_production_manifest(
+    *,
+    root: Optional[Path] = None,
+    opener: Optional[Any] = None,
+) -> tuple[int, str]:
+    repository = root if root is not None else Path(__file__).resolve().parent.parent
+    verified_version = read_verified_version(
+        repository / "compat" / "agy-verified-version.txt"
+    )
+    snapshot = read_snapshot(repository / "compat" / "agy-distribution-manifest.json")
+    fixed_opener = opener if opener is not None else build_fixed_opener()
+    observed = parse_manifest_bytes(fetch_manifest_bytes(fixed_opener))
+    return evaluate_manifest(observed, verified_version, snapshot)
+
+
+def main() -> None:
+    if len(sys.argv) != 1:
+        print("  distribution manifest: evidence-unavailable (invalid invocation)")
+        raise SystemExit(64)
+    try:
+        status, detail = check_production_manifest()
+    except DistributionEvidenceError as exc:
+        print(f"  distribution manifest: evidence-unavailable ({exc.category})")
+        raise SystemExit(2) from None
+    except Exception:
+        print("  distribution manifest: evidence-unavailable (internal evidence failure)")
+        raise SystemExit(2) from None
+    if status == 0:
+        print(f"  distribution manifest: unchanged ({detail})")
+    else:
+        print(f"  distribution manifest: drift-review ({detail})")
+    raise SystemExit(status)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test-official-distribution.py
+++ b/tests/test-official-distribution.py
@@ -1,0 +1,708 @@
+#!/usr/bin/env python3
+"""Offline adversarial tests for the fixed agy distribution canary."""
+
+from __future__ import annotations
+
+import contextlib
+import email.message
+import importlib.util
+import io
+import json
+import os
+import ssl
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Callable, List, Optional, Tuple
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parent.parent
+MODULE_PATH = ROOT / "scripts" / "official_distribution.py"
+SPEC = importlib.util.spec_from_file_location("official_distribution", MODULE_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise SystemExit("cannot load official distribution module")
+distribution = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(distribution)
+
+VERSION = "1.1.10"
+SHA512 = "a" * 128
+ARCHIVE_URL = (
+    "https://storage.googleapis.com/antigravity-public/antigravity-cli/"
+    "1.1.10-6423386432339968/darwin-arm/cli_mac_arm64.tar.gz"
+)
+
+
+def manifest_bytes(**changes: Any) -> bytes:
+    value = {"version": VERSION, "url": ARCHIVE_URL, "sha512": SHA512}
+    value.update(changes)
+    return json.dumps(value, separators=(",", ":")).encode("utf-8")
+
+
+class FakeResponse:
+    def __init__(
+        self,
+        body: bytes,
+        *,
+        status: int = 200,
+        content_type: str = "application/json",
+        content_length: Optional[str] = None,
+        extra_headers: Optional[List[Tuple[str, str]]] = None,
+    ):
+        self.body = body
+        self.status = status
+        self.headers = email.message.Message()
+        if content_type:
+            self.headers["Content-Type"] = content_type
+        self.headers["Content-Length"] = (
+            str(len(body)) if content_length is None else content_length
+        )
+        for name, value in extra_headers or []:
+            self.headers[name] = value
+        self.read_sizes: list[int] = []
+
+    def __enter__(self) -> "FakeResponse":
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        del args
+
+    def getcode(self) -> int:
+        return self.status
+
+    def read(self, size: int) -> bytes:
+        self.read_sizes.append(size)
+        return self.body[:size]
+
+
+class FakeOpener:
+    def __init__(self, response: Any):
+        self.response = response
+        self.calls: list[tuple[urllib.request.Request, float]] = []
+
+    def open(self, request: urllib.request.Request, *, timeout: float) -> Any:
+        self.calls.append((request, timeout))
+        if isinstance(self.response, BaseException):
+            raise self.response
+        return self.response
+
+
+def expect_error(category: str, callback: Callable[[], Any]) -> None:
+    try:
+        callback()
+    except distribution.DistributionEvidenceError as exc:
+        if exc.category != category:
+            raise AssertionError(f"category {exc.category!r}, expected {category!r}")
+        return
+    raise AssertionError(f"expected controlled {category!r} error")
+
+
+def parse(**changes: Any) -> dict[str, str]:
+    return distribution.parse_manifest_bytes(manifest_bytes(**changes))
+
+
+def replace_url(old: str, new: str) -> str:
+    if old not in ARCHIVE_URL:
+        raise AssertionError("test fixture replacement does not match")
+    return ARCHIVE_URL.replace(old, new)
+
+
+TESTS: list[tuple[str, Callable[[], None]]] = []
+
+
+def test(name: str) -> Callable[[Callable[[], None]], Callable[[], None]]:
+    def register(callback: Callable[[], None]) -> Callable[[], None]:
+        TESTS.append((name, callback))
+        return callback
+
+    return register
+
+
+@test("fixed production manifest URL is exact")
+def _() -> None:
+    assert distribution.MANIFEST_URL == (
+        "https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/"
+        "manifests/darwin_arm64.json"
+    )
+
+
+@test("production opener disables environment proxies")
+def _() -> None:
+    real_proxy_handler = urllib.request.ProxyHandler
+    constructor_inputs: list[Any] = []
+
+    class RecordingProxyHandler(real_proxy_handler):
+        def __init__(self, proxies: Any = None):
+            constructor_inputs.append(proxies)
+            super().__init__(proxies)
+
+    with mock.patch.object(urllib.request, "ProxyHandler", RecordingProxyHandler):
+        distribution.build_fixed_opener()
+    assert constructor_inputs == [{}]
+
+
+@test("production opener installs a redirect rejector")
+def _() -> None:
+    opener = distribution.build_fixed_opener()
+    assert any(
+        isinstance(handler, distribution.RejectRedirects)
+        for handler in opener.handlers
+    )
+
+
+@test("bounded fetch accepts exact response and makes one request")
+def _() -> None:
+    body = manifest_bytes()
+    response = FakeResponse(body)
+    opener = FakeOpener(response)
+    assert distribution.fetch_manifest_bytes(opener) == body
+    assert len(opener.calls) == 1
+    request, timeout = opener.calls[0]
+    assert request.full_url == distribution.MANIFEST_URL
+    assert request.get_method() == "GET"
+    assert request.headers["Accept"] == "application/json"
+    assert timeout == distribution.FETCH_TIMEOUT_SECONDS
+    assert response.read_sizes == [distribution.MAX_RESPONSE_BYTES + 1]
+
+
+@test("response exactly at byte limit is accepted")
+def _() -> None:
+    body = b"x" * 32
+    opener = FakeOpener(FakeResponse(body))
+    assert distribution.fetch_manifest_bytes(opener, limit=32) == body
+
+
+@test("streamed body over byte limit is rejected")
+def _() -> None:
+    body = b"x" * 33
+    opener = FakeOpener(FakeResponse(body, content_length="32"))
+    expect_error(
+        "response too large",
+        lambda: distribution.fetch_manifest_bytes(opener, limit=32),
+    )
+
+
+@test("declared body over byte limit is rejected before reading")
+def _() -> None:
+    response = FakeResponse(b"x", content_length="33")
+    expect_error(
+        "response too large",
+        lambda: distribution.fetch_manifest_bytes(FakeOpener(response), limit=32),
+    )
+    assert response.read_sizes == []
+
+
+@test("missing Content-Length is rejected")
+def _() -> None:
+    response = FakeResponse(b"x")
+    del response.headers["Content-Length"]
+    expect_error(
+        "invalid response metadata",
+        lambda: distribution.fetch_manifest_bytes(FakeOpener(response)),
+    )
+
+
+@test("duplicate Content-Length is rejected")
+def _() -> None:
+    response = FakeResponse(b"x", extra_headers=[("Content-Length", "1")])
+    expect_error(
+        "invalid response metadata",
+        lambda: distribution.fetch_manifest_bytes(FakeOpener(response)),
+    )
+
+
+@test("noncanonical Content-Length is rejected")
+def _() -> None:
+    response = FakeResponse(b"x", content_length="01")
+    expect_error(
+        "invalid response metadata",
+        lambda: distribution.fetch_manifest_bytes(FakeOpener(response)),
+    )
+
+
+@test("truncated body is rejected")
+def _() -> None:
+    response = FakeResponse(b"x", content_length="2")
+    expect_error(
+        "invalid response metadata",
+        lambda: distribution.fetch_manifest_bytes(FakeOpener(response)),
+    )
+
+
+@test("wrong content type is rejected")
+def _() -> None:
+    response = FakeResponse(b"x", content_type="text/plain")
+    expect_error(
+        "invalid response metadata",
+        lambda: distribution.fetch_manifest_bytes(FakeOpener(response)),
+    )
+
+
+@test("UTF-8 JSON content type is accepted")
+def _() -> None:
+    response = FakeResponse(b"x", content_type="application/json; charset=utf-8")
+    assert distribution.fetch_manifest_bytes(FakeOpener(response)) == b"x"
+
+
+@test("non-UTF-8 JSON charset is rejected")
+def _() -> None:
+    response = FakeResponse(b"x", content_type="application/json; charset=latin1")
+    expect_error(
+        "invalid response metadata",
+        lambda: distribution.fetch_manifest_bytes(FakeOpener(response)),
+    )
+
+
+@test("unknown content-type parameter is rejected")
+def _() -> None:
+    response = FakeResponse(b"x", content_type="application/json; profile=test")
+    expect_error(
+        "invalid response metadata",
+        lambda: distribution.fetch_manifest_bytes(FakeOpener(response)),
+    )
+
+
+@test("non-200 response is rejected")
+def _() -> None:
+    response = FakeResponse(b"x", status=503)
+    expect_error(
+        "HTTP evidence unavailable",
+        lambda: distribution.fetch_manifest_bytes(FakeOpener(response)),
+    )
+
+
+@test("HTTP error is sanitized")
+def _() -> None:
+    error = urllib.error.HTTPError(
+        distribution.MANIFEST_URL, 503, "secret upstream body", {}, None
+    )
+    expect_error(
+        "HTTP evidence unavailable",
+        lambda: distribution.fetch_manifest_bytes(FakeOpener(error)),
+    )
+
+
+def redirect_is_rejected(location: str) -> None:
+    handler = distribution.RejectRedirects()
+    request = urllib.request.Request(distribution.MANIFEST_URL)
+    expect_error(
+        "redirect rejected",
+        lambda: handler.redirect_request(
+            request, None, 302, "redirect", {"Location": location}, location
+        ),
+    )
+
+
+@test("same-host redirect is rejected before following")
+def _() -> None:
+    redirect_is_rejected(distribution.MANIFEST_URL + "?next=1")
+
+
+@test("cross-host redirect is rejected before following")
+def _() -> None:
+    redirect_is_rejected("https://example.invalid/credential")
+
+
+@test("redirect HTTP error is classified without Location disclosure")
+def _() -> None:
+    error = urllib.error.HTTPError(
+        distribution.MANIFEST_URL,
+        302,
+        "redirect",
+        {"Location": "https://example.invalid/secret"},
+        None,
+    )
+    expect_error(
+        "redirect rejected",
+        lambda: distribution.fetch_manifest_bytes(FakeOpener(error)),
+    )
+
+
+@test("TLS failure is inconclusive and sanitized")
+def _() -> None:
+    expect_error(
+        "network evidence unavailable",
+        lambda: distribution.fetch_manifest_bytes(
+            FakeOpener(ssl.SSLError("certificate secret"))
+        ),
+    )
+
+
+@test("DNS failure is inconclusive and sanitized")
+def _() -> None:
+    expect_error(
+        "network evidence unavailable",
+        lambda: distribution.fetch_manifest_bytes(
+            FakeOpener(urllib.error.URLError("dns secret"))
+        ),
+    )
+
+
+@test("timeout is inconclusive and sanitized")
+def _() -> None:
+    expect_error(
+        "network evidence unavailable",
+        lambda: distribution.fetch_manifest_bytes(FakeOpener(TimeoutError("secret"))),
+    )
+
+
+@test("unexpected opener failure is inconclusive and sanitized")
+def _() -> None:
+    expect_error(
+        "network evidence unavailable",
+        lambda: distribution.fetch_manifest_bytes(
+            FakeOpener(RuntimeError("raw exception credential-secret"))
+        ),
+    )
+
+
+@test("exact manifest schema and tuple are accepted")
+def _() -> None:
+    assert parse() == {"version": VERSION, "url": ARCHIVE_URL, "sha512": SHA512}
+
+
+@test("duplicate manifest key is rejected")
+def _() -> None:
+    raw = manifest_bytes()[:-1] + b',"version":"1.1.10"}'
+    expect_error("invalid manifest document", lambda: distribution.parse_manifest_bytes(raw))
+
+
+@test("missing manifest key is rejected")
+def _() -> None:
+    value = {"version": VERSION, "url": ARCHIVE_URL}
+    expect_error(
+        "invalid manifest schema",
+        lambda: distribution.parse_manifest_bytes(json.dumps(value).encode()),
+    )
+
+
+@test("extra manifest key is rejected")
+def _() -> None:
+    expect_error("invalid manifest schema", lambda: parse(extra="no"))
+
+
+@test("non-string version is rejected")
+def _() -> None:
+    expect_error("invalid manifest policy", lambda: parse(version=110))
+
+
+@test("non-string URL is rejected")
+def _() -> None:
+    expect_error("invalid manifest policy", lambda: parse(url=[]))
+
+
+@test("non-string SHA-512 is rejected")
+def _() -> None:
+    expect_error("invalid manifest policy", lambda: parse(sha512=None))
+
+
+@test("padded value is rejected")
+def _() -> None:
+    expect_error("invalid manifest policy", lambda: parse(version=" 1.1.10"))
+
+
+@test("escaped control character is rejected")
+def _() -> None:
+    expect_error("invalid manifest policy", lambda: parse(sha512=SHA512 + "\u0000"))
+
+
+@test("invalid UTF-8 is rejected")
+def _() -> None:
+    expect_error(
+        "invalid manifest document",
+        lambda: distribution.parse_manifest_bytes(b"{\xff}"),
+    )
+
+
+@test("trailing second JSON document is rejected")
+def _() -> None:
+    expect_error(
+        "invalid manifest document",
+        lambda: distribution.parse_manifest_bytes(manifest_bytes() + b"{}"),
+    )
+
+
+@test("non-object JSON is rejected")
+def _() -> None:
+    expect_error("invalid manifest schema", lambda: distribution.parse_manifest_bytes(b"[]"))
+
+
+@test("semantic version prerelease is rejected")
+def _() -> None:
+    expect_error("invalid manifest policy", lambda: parse(version="1.1.10-rc.1"))
+
+
+@test("semantic version leading zero is rejected")
+def _() -> None:
+    expect_error("invalid manifest policy", lambda: parse(version="01.1.10"))
+
+
+@test("uppercase SHA-512 is rejected")
+def _() -> None:
+    expect_error("invalid manifest policy", lambda: parse(sha512="A" * 128))
+
+
+@test("short SHA-512 is rejected")
+def _() -> None:
+    expect_error("invalid manifest policy", lambda: parse(sha512="a" * 127))
+
+
+@test("HTTP archive scheme is rejected")
+def _() -> None:
+    expect_error("invalid archive policy", lambda: parse(url=replace_url("https://", "http://")))
+
+
+@test("wrong archive host is rejected")
+def _() -> None:
+    expect_error(
+        "invalid archive policy",
+        lambda: parse(url=replace_url("storage.googleapis.com", "example.invalid")),
+    )
+
+
+@test("archive URL userinfo is rejected")
+def _() -> None:
+    expect_error(
+        "invalid archive policy",
+        lambda: parse(url=replace_url("https://", "https://user:secret@")),
+    )
+
+
+@test("archive URL nondefault port is rejected")
+def _() -> None:
+    expect_error(
+        "invalid archive policy",
+        lambda: parse(url=replace_url("storage.googleapis.com", "storage.googleapis.com:444")),
+    )
+
+
+@test("archive URL query is rejected")
+def _() -> None:
+    expect_error("invalid archive policy", lambda: parse(url=ARCHIVE_URL + "?token=secret"))
+
+
+@test("archive URL fragment is rejected")
+def _() -> None:
+    expect_error("invalid archive policy", lambda: parse(url=ARCHIVE_URL + "#secret"))
+
+
+@test("encoded archive separator is rejected")
+def _() -> None:
+    expect_error(
+        "invalid archive policy",
+        lambda: parse(url=replace_url("/darwin-arm/", "%2fdarwin-arm/")),
+    )
+
+
+@test("encoded archive backslash is rejected")
+def _() -> None:
+    expect_error(
+        "invalid archive policy",
+        lambda: parse(url=replace_url("/darwin-arm/", "%5cdarwin-arm/")),
+    )
+
+
+@test("archive path traversal is rejected")
+def _() -> None:
+    expect_error(
+        "invalid archive policy",
+        lambda: parse(url=replace_url("/darwin-arm/", "/../darwin-arm/")),
+    )
+
+
+@test("encoded archive traversal is rejected")
+def _() -> None:
+    expect_error(
+        "invalid archive policy",
+        lambda: parse(url=replace_url("/darwin-arm/", "/%2e%2e/darwin-arm/")),
+    )
+
+
+@test("archive version mismatch is rejected")
+def _() -> None:
+    expect_error(
+        "invalid archive policy",
+        lambda: parse(url=replace_url("1.1.10-", "1.1.9-")),
+    )
+
+
+@test("nonnumeric archive build is rejected")
+def _() -> None:
+    expect_error(
+        "invalid archive policy",
+        lambda: parse(url=replace_url("6423386432339968", "build-secret")),
+    )
+
+
+@test("wrong archive platform directory is rejected")
+def _() -> None:
+    expect_error(
+        "invalid archive policy",
+        lambda: parse(url=replace_url("darwin-arm", "linux-x64")),
+    )
+
+
+@test("wrong archive filename is rejected")
+def _() -> None:
+    expect_error(
+        "invalid archive policy",
+        lambda: parse(url=replace_url("cli_mac_arm64.tar.gz", "cli_linux.tar.gz")),
+    )
+
+
+@test("exact trusted tuple matching baseline is unchanged")
+def _() -> None:
+    value = parse()
+    assert distribution.evaluate_manifest(value, VERSION, value) == (0, VERSION)
+
+
+@test("distribution version beyond baseline is drift-review")
+def _() -> None:
+    value = parse()
+    status, detail = distribution.evaluate_manifest(value, "1.1.9", value)
+    assert status == 3 and "1.1.10" in detail and "1.1.9" in detail
+
+
+@test("same-version archive build drift is drift-review")
+def _() -> None:
+    observed = parse()
+    snapshot = parse(url=replace_url("6423386432339968", "6423386432339967"))
+    assert distribution.evaluate_manifest(observed, VERSION, snapshot)[0] == 3
+
+
+@test("same-version archive hash drift is drift-review")
+def _() -> None:
+    observed = parse()
+    snapshot = parse(sha512="b" * 128)
+    assert distribution.evaluate_manifest(observed, VERSION, snapshot)[0] == 3
+
+
+@test("production check makes no archive request")
+def _() -> None:
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        (root / "compat").mkdir()
+        (root / "compat" / "agy-verified-version.txt").write_text(
+            VERSION + "\n", encoding="ascii"
+        )
+        (root / "compat" / "agy-distribution-manifest.json").write_bytes(
+            manifest_bytes()
+        )
+        opener = FakeOpener(FakeResponse(manifest_bytes()))
+        assert distribution.check_production_manifest(root=root, opener=opener) == (
+            0,
+            VERSION,
+        )
+        assert [call[0].full_url for call in opener.calls] == [distribution.MANIFEST_URL]
+
+
+@test("malformed local snapshot fails closed without bytes")
+def _() -> None:
+    with tempfile.TemporaryDirectory() as temporary:
+        path = Path(temporary) / "snapshot.json"
+        path.write_bytes(b'{"url":"credential-secret"}')
+        try:
+            distribution.read_snapshot(path)
+        except distribution.DistributionEvidenceError as exc:
+            assert exc.category == "invalid observational snapshot"
+            assert "credential-secret" not in str(exc)
+            return
+    raise AssertionError("malformed snapshot was accepted")
+
+
+@test("malformed verified baseline fails closed without bytes")
+def _() -> None:
+    with tempfile.TemporaryDirectory() as temporary:
+        path = Path(temporary) / "baseline.txt"
+        path.write_bytes(b"credential-secret\n")
+        try:
+            distribution.read_verified_version(path)
+        except distribution.DistributionEvidenceError as exc:
+            assert exc.category == "invalid verified baseline"
+            assert "credential-secret" not in str(exc)
+            return
+    raise AssertionError("malformed baseline was accepted")
+
+
+@test("top-level failure output leaks no body exception URL or credential")
+def _() -> None:
+    error = distribution.DistributionEvidenceError("network evidence unavailable")
+    output = io.StringIO()
+    with mock.patch.object(distribution, "check_production_manifest", side_effect=error):
+        with mock.patch.object(sys, "argv", [str(MODULE_PATH)]):
+            with contextlib.redirect_stdout(output), contextlib.redirect_stderr(output):
+                try:
+                    distribution.main()
+                except SystemExit as exc:
+                    assert exc.code == 2
+                else:
+                    raise AssertionError("main did not fail")
+    rendered = output.getvalue()
+    assert "evidence-unavailable" in rendered
+    for forbidden in (
+        distribution.MANIFEST_URL,
+        ARCHIVE_URL,
+        "credential",
+        "Traceback",
+        "secret",
+    ):
+        assert forbidden not in rendered
+
+
+@test("unexpected top-level exception is sanitized without traceback")
+def _() -> None:
+    output = io.StringIO()
+    error = RuntimeError("raw exception credential-secret https://example.invalid")
+    with mock.patch.object(distribution, "check_production_manifest", side_effect=error):
+        with mock.patch.object(sys, "argv", [str(MODULE_PATH)]):
+            with contextlib.redirect_stdout(output), contextlib.redirect_stderr(output):
+                try:
+                    distribution.main()
+                except SystemExit as exc:
+                    assert exc.code == 2
+                else:
+                    raise AssertionError("main did not fail")
+    rendered = output.getvalue()
+    assert rendered == (
+        "  distribution manifest: evidence-unavailable "
+        "(internal evidence failure)\n"
+    )
+
+
+@test("direct CLI URL override is rejected without echo")
+def _() -> None:
+    output = io.StringIO()
+    with mock.patch.object(
+        sys, "argv", [str(MODULE_PATH), "--url", "https://example.invalid/secret"]
+    ):
+        with contextlib.redirect_stdout(output), contextlib.redirect_stderr(output):
+            try:
+                distribution.main()
+            except SystemExit as exc:
+                assert exc.code == 64
+            else:
+                raise AssertionError("invalid invocation was accepted")
+    assert "example.invalid" not in output.getvalue()
+    assert "secret" not in output.getvalue()
+
+
+def main() -> None:
+    passed = 0
+    failed = 0
+    for name, callback in TESTS:
+        try:
+            callback()
+        except Exception as exc:  # test-only diagnostic boundary
+            failed += 1
+            print(f"  FAIL manifest: {name}: {type(exc).__name__}: {exc}")
+        else:
+            passed += 1
+            print(f"  ok   manifest: {name}")
+    print(f"MANIFEST_TEST_RESULT passed={passed} failed={failed}")
+    raise SystemExit(1 if failed else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test-update.sh
+++ b/tests/test-update.sh
@@ -7,6 +7,8 @@ ROOT="$HERE/.."
 TMP="$(mktemp -d -t agyworker-update-tests.XXXXXX)"
 trap 'rm -rf "$TMP"' EXIT
 pass=0; fail=0
+REAL_PYTHON_REAL="$(command -v python3)"
+export REAL_PYTHON_REAL
 
 ok() { printf '  ok   %s\n' "$1"; pass=$((pass+1)); }
 bad() { printf '  FAIL %s\n' "$1"; fail=$((fail+1)); }
@@ -98,6 +100,7 @@ cp "$ROOT/update.sh" "$ROOT/install.sh" "$SOURCE/"
 cp -R "$ROOT/skills/agy-worker" "$SOURCE/skills/agy-worker"
 cp "$ROOT/compat/"* "$SOURCE/compat/"
 cp "$ROOT/scripts/compatibility.py" "$SOURCE/scripts/"
+cp "$ROOT/scripts/official_distribution.py" "$SOURCE/scripts/"
 
 mkdir -p "$UPSTREAM_SOURCE"
 git -C "$UPSTREAM_SOURCE" init -q -b main
@@ -156,7 +159,50 @@ case "${FAKE_CODEX_MODE:-version}" in
 esac
 printf '%s\n' "${FAKE_CODEX_OUTPUT:-codex-cli ${FAKE_CODEX_VERSION:-0.146.0}}"
 STUB
-chmod +x "$SOURCE/"*.sh "$SOURCE/tests/"*.sh "$TMP/bin/agy" "$TMP/bin/codex" "$SOURCE/scripts/compatibility.py"
+cat > "$TMP/bin/python3" <<'STUB'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  */scripts/official_distribution.py)
+    if [[ $# -ne 1 ]] || ! "$REAL_PYTHON_REAL" -B -c '
+import importlib.util
+import sys
+expected = (
+    "https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/"
+    "manifests/darwin_arm64.json"
+)
+spec = importlib.util.spec_from_file_location("manifest_fixture", sys.argv[1])
+if spec is None or spec.loader is None:
+    raise SystemExit(1)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+raise SystemExit(0 if module.MANIFEST_URL == expected else 1)
+' "$1"; then
+      printf '%s\n' 'fake manifest launcher rejected production argv or fixed URL' >&2
+      exit 70
+    fi
+    case "${FAKE_MANIFEST_RESULT:-unchanged}" in
+      unchanged)
+        printf '%s\n' '  distribution manifest: unchanged (1.1.9)'
+        exit 0 ;;
+      drift)
+        printf '%s\n' '  distribution manifest: drift-review (official distribution 1.1.10; verified 1.1.9)'
+        exit 3 ;;
+      unavailable)
+        printf '%s\n' '  distribution manifest: evidence-unavailable (network evidence unavailable)'
+        exit 2 ;;
+      invalid)
+        printf '%s\n' 'https://example.invalid/credential-secret'
+        printf '%s\n' 'raw exception credential-secret' >&2
+        exit 0 ;;
+      *) exit 70 ;;
+    esac
+    ;;
+esac
+exec "$REAL_PYTHON_REAL" "$@"
+STUB
+chmod +x "$SOURCE/"*.sh "$SOURCE/tests/"*.sh "$TMP/bin/agy" "$TMP/bin/codex" \
+    "$TMP/bin/python3" "$SOURCE/scripts/compatibility.py" "$SOURCE/scripts/official_distribution.py"
 
 git -C "$SOURCE" init -q -b main
 git -C "$SOURCE" config user.email test@example.com
@@ -220,6 +266,7 @@ expect_same_snapshot "exit 0 preserves HEAD, refs, index, and all worktree bytes
     "$TMP/check-zero.before" "$TMP/check-zero.after"
 if grep -Fq 'agy compatibility:' "$TMP/check.out" \
         && grep -Fq 'codex compatibility:' "$TMP/check.out" \
+        && grep -Fq 'distribution manifest: unchanged' "$TMP/check.out" \
         && grep -Fq 'stable release: unchanged' "$TMP/check.out" \
         && grep -Fq 'source revision: unchanged' "$TMP/check.out"; then
     ok "local check always reports both tools and official evidence"
@@ -242,6 +289,7 @@ fi
 
 PATH="$TMP/bin:$PATH" OFFICIAL_AGY_UPSTREAM=https://example.invalid/secret \
     OFFICIAL_CODEX_UPSTREAM=https://example.invalid/secret \
+    OFFICIAL_AGY_DISTRIBUTION_MANIFEST=https://example.invalid/credential \
     COMPATIBILITY_REVIEW_DAYS=9999 \
     "$CLIENT/update.sh" check > "$TMP/fixed-policy.out" 2> "$TMP/fixed-policy.err"
 rc=$?
@@ -250,6 +298,50 @@ if ! grep -Fq 'example.invalid' "$TMP/fixed-policy.out" "$TMP/fixed-policy.err";
     ok "ignored source overrides are never disclosed"
 else
     bad "ignored source overrides are never disclosed"
+fi
+
+PATH="$TMP/bin:$PATH" "$CLIENT/update.sh" check \
+    --manifest-url https://example.invalid/credential-secret \
+    > "$TMP/manifest-cli-override.out" 2> "$TMP/manifest-cli-override.err"
+rc=$?
+expect_exit "CLI cannot override the fixed distribution manifest" 64 "$rc"
+if ! grep -Fq 'example.invalid' "$TMP/manifest-cli-override.out" \
+        "$TMP/manifest-cli-override.err"; then
+    ok "rejected manifest override is not disclosed"
+else
+    bad "rejected manifest override is not disclosed"
+fi
+
+snapshot_repo "$CLIENT" "$TMP/manifest-three.before"
+PATH="$TMP/bin:$PATH" FAKE_MANIFEST_RESULT=drift \
+    "$CLIENT/update.sh" check > "$TMP/manifest-drift.out" 2> "$TMP/manifest-drift.err"
+rc=$?
+snapshot_repo "$CLIENT" "$TMP/manifest-three.after"
+expect_exit "official distribution drift requires review without advancing baseline" 3 "$rc"
+expect_same_snapshot "distribution drift preserves HEAD, refs, index, and all worktree bytes/status" \
+    "$TMP/manifest-three.before" "$TMP/manifest-three.after"
+
+snapshot_repo "$CLIENT" "$TMP/manifest-two.before"
+PATH="$TMP/bin:$PATH" FAKE_MANIFEST_RESULT=unavailable FAKE_CODEX_VERSION=9.9.9 \
+    "$CLIENT/update.sh" check > "$TMP/manifest-unavailable.out" \
+    2> "$TMP/manifest-unavailable.err"
+rc=$?
+snapshot_repo "$CLIENT" "$TMP/manifest-two.after"
+expect_exit "distribution evidence-unavailable outranks established tool drift" 2 "$rc"
+expect_same_snapshot "distribution failure preserves HEAD, refs, index, and all worktree bytes/status" \
+    "$TMP/manifest-two.before" "$TMP/manifest-two.after"
+
+PATH="$TMP/bin:$PATH" FAKE_MANIFEST_RESULT=invalid \
+    "$CLIENT/update.sh" check > "$TMP/manifest-invalid-helper.out" \
+    2> "$TMP/manifest-invalid-helper.err"
+rc=$?
+expect_exit "unexpected manifest-helper result fails closed" 2 "$rc"
+if grep -Fq 'invalid helper result' "$TMP/manifest-invalid-helper.out" \
+        && ! grep -Eq 'example\.invalid|credential-secret|raw exception' \
+            "$TMP/manifest-invalid-helper.out" "$TMP/manifest-invalid-helper.err"; then
+    ok "manifest helper output and errors are sanitized"
+else
+    bad "manifest helper output and errors are sanitized"
 fi
 
 snapshot_repo "$CLIENT" "$TMP/check-three.before"
@@ -282,9 +374,10 @@ expect_exit "failed documented version command is inconclusive" 2 "$rc"
 
 NO_AGY_BIN="$TMP/no-agy-bin"
 mkdir -p "$NO_AGY_BIN"
-for required_tool in bash git python3 dirname; do
+for required_tool in bash git dirname; do
     ln -s "$(command -v "$required_tool")" "$NO_AGY_BIN/$required_tool"
 done
+ln -s "$TMP/bin/python3" "$NO_AGY_BIN/python3"
 cp "$TMP/bin/codex" "$NO_AGY_BIN/codex"
 PATH="$NO_AGY_BIN" "$CLIENT/update.sh" check > "$TMP/missing-agy.out" 2> "$TMP/missing-agy.err"
 rc=$?
@@ -744,6 +837,16 @@ awk 'NR == 2 { print "  \"$schema\": \"duplicate\"," } { print }' \
 expect_matrix_validation "duplicate schema key fails closed" 2 \
     "$ACTIVE_MATRIX" "$TMP/schema-duplicate-key.json" schema-duplicate-key
 
+MANIFEST_TEST_OUTPUT="$($REAL_PYTHON_REAL "$ROOT/tests/test-official-distribution.py" 2>&1)"
+rc=$?
+printf '%s\n' "$MANIFEST_TEST_OUTPUT"
+MANIFEST_RESULT="$(printf '%s\n' "$MANIFEST_TEST_OUTPUT" | tail -1)"
+if [[ "$rc" == 0 && "$MANIFEST_RESULT" == "MANIFEST_TEST_RESULT passed=64 failed=0" ]]; then
+    pass=$((pass+64))
+else
+    bad "official distribution policy tests (expected 64 controlled passes)"
+fi
+
 WORKFLOW="$ROOT/.github/workflows/compatibility-watch.yml"
 if grep -Fq 'schedule:' "$WORKFLOW" && grep -Fq 'workflow_dispatch:' "$WORKFLOW" \
         && grep -Fq 'runs-on: macos-latest' "$WORKFLOW" \
@@ -753,7 +856,7 @@ if grep -Fq 'schedule:' "$WORKFLOW" && grep -Fq 'workflow_dispatch:' "$WORKFLOW"
 else
     bad "watch workflow has only the weekly/manual read-only platform contract"
 fi
-if ! grep -Eq 'pull_request:|secrets\.|contents: write|issues: write|git (pull|commit|push)|gh |curl |wget |brew |npm |pip |update\.sh apply' "$WORKFLOW"; then
+if ! grep -Eq 'pull_request:|secrets\.|contents: write|issues: write|git (pull|commit|push)|gh |curl |wget |brew |npm |pip |update\.sh apply|agy-worker|model-recommendation|ground-truth|agy --|codex ' "$WORKFLOW"; then
     ok "watch workflow has no install, secret, mutation, or GitHub-write path"
 else
     bad "watch workflow has no install, secret, mutation, or GitHub-write path"

--- a/update.sh
+++ b/update.sh
@@ -112,6 +112,33 @@ compat_metadata() {
     python3 "$SCRIPT_DIR/scripts/compatibility.py" metadata --kind "$1" --file "$2"
 }
 
+agy_distribution_manifest_check() {
+    local output="" status=0
+    output="$(python3 "$SCRIPT_DIR/scripts/official_distribution.py" 2>/dev/null)" || status=$?
+    case "$status" in
+        0)
+            if [[ "$output" == "  distribution manifest: unchanged ("*')' ]]; then
+                printf '%s\n' "$output"
+                return 0
+            fi
+            ;;
+        3)
+            if [[ "$output" == "  distribution manifest: drift-review ("*')' ]]; then
+                printf '%s\n' "$output"
+                return 3
+            fi
+            ;;
+        2)
+            if [[ "$output" == "  distribution manifest: evidence-unavailable ("*')' ]]; then
+                printf '%s\n' "$output"
+                return 2
+            fi
+            ;;
+    esac
+    echo "  distribution manifest: evidence-unavailable (invalid helper result)"
+    return 2
+}
+
 tool_compatibility_check() {
     local tool="$1" mode="$2" upstream verified_file reviewed_file revision_file
     local verified_version="" review_date="" reviewed_head="" installed_output="" installed_version=""
@@ -179,6 +206,12 @@ tool_compatibility_check() {
         fi
     else
         echo "  installed: not required in watch mode"
+    fi
+
+    if [[ "$tool" == "agy" ]]; then
+        step_rc=0
+        agy_distribution_manifest_check || step_rc=$?
+        rc="$(merge_status "$rc" "$step_rc")"
     fi
 
     step_rc=0


### PR DESCRIPTION
## Summary
- observe one fixed official darwin-arm64 distribution manifest canary
- validate the response and archive tuple under a strict no-download trust boundary
- report unchanged, drift, or evidence-unavailable without updating compatibility baselines
- document the G0-F1 evidence boundary and updated offline coverage

## Safety boundary
- advisory and observational only; no model, effort, routing, or gate changes
- no archive download, hashing, execution, or provider dispatch
- no runtime URL override; redirects and proxies are rejected/disabled
- agy 1.1.9 remains the verified baseline and the 1.1.10 matrix remains disabled

## Verification
- qa gate: 41/41
- dispatcher/routing: 60/60
- updater and manifest: 164/164
- reporting: 21/21
- packaging: 21/21
- standalone manifest adversary harness: 64/64
- Bash 3.2 syntax, Python compile, diff check, apply byte identity, and AGENTS audit passed
- independent verifier: ACCEPT, no findings

## Live observation
The fixed manifest matched the checked-in snapshot and reported distribution 1.1.10 versus verified 1.1.9. This is distribution drift only and does not activate G1.

Closes the G0-F1 follow-up slice only.