### PR TITLE
feat: add 60-second offline proof demo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,3 +36,6 @@ jobs:
 
       - name: read-only doctor suite
         run: ./tests/test-doctor.sh
+
+      - name: starter proof suite
+        run: ./tests/test-proof-demo.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,8 +39,10 @@ Keep these counts current when their suites change:
   fake-agy/routing cases.
 - `update.sh`: 164 offline local-remote/matrix/manifest/watch-policy cases.
 - `bug-report.sh`: 21 offline privacy/fake-`gh` cases.
-- Codex package/skill distribution: 82 offline manifest/runtime-copy/relocation/landing cases.
+- Codex package/skill distribution: 86 offline
+  manifest/runtime-copy/relocation/landing cases.
 - `doctor.sh`: 143 offline fake-tool/read-only cases.
+- `proof-demo.sh`: 21 offline synthetic-boundary cases.
 
 Real runs prove one bounded edit, the complete `codex exec` pipeline, the combined
 Codex sandbox requirements, and an honest `repo-inventory` escalation. The
@@ -62,6 +64,7 @@ coverage is offline, partial, or absent as described in `README.md`.
 ./tests/test-reporting.sh       # offline fake-gh privacy/submission coverage
 ./tests/test-packaging.sh       # offline Codex manifest, relocation, policy, landing
 ./tests/test-doctor.sh          # offline fake-tool/read-only readiness coverage
+./tests/test-proof-demo.sh      # offline synthetic pass/reject proof coverage
 bash -n ./*.sh tests/*.sh skills/*/scripts/*.sh skills/*/runtime/*.sh  # syntax
 python3 -m py_compile scripts/*.py skills/*/runtime/scripts/*.py
 git diff --check

--- a/README.md
+++ b/README.md
@@ -55,7 +55,21 @@ text, and it hashes the Git diff plus every nontracked path—including ignored 
 before and after verification so a passing verifier cannot silently rewrite the
 candidate.
 
-The six offline suites need no agy process, network access, API key, or GitHub login.
+The seven offline suites need no agy process, network access, API key, or GitHub login.
+
+## See the evidence boundary in under a minute
+
+```bash
+./proof-demo.sh
+```
+
+This repository-only starter proof creates two independent private temporary Git
+repositories, exercises the maintained gate once on an exact synthetic edit and once
+on a plausible but incomplete synthetic envelope, then removes both repositories. It
+does not invoke agy, access the network, inspect credentials, or change the current
+checkout. The three-line result proves only that these two fixed cases produced the
+expected gate exits. `gate-passed` is not a human review, accepted candidate, general
+correctness claim, security certification, benchmark, or production validation.
 
 ## Roadmap
 
@@ -566,6 +580,7 @@ output, not its own recollection.
 ```
 agy-worker.sh                 dispatch a job, return a schema-valid envelope
 qa-gate.sh                    verify an envelope against the repo — the evidence
+proof-demo.sh                 offline starter proof of one gate pass and one rejection
 model-recommendation.sh       repository compatibility wrapper for the advisory
 doctor.sh                     repository wrapper for offline read-only diagnostics
 ground-truth.sh               dump live agy facts for skill authoring
@@ -591,8 +606,9 @@ tests/test-agy-worker.sh       offline dispatcher/installer/routing suite
 tests/test-update.sh          164-case offline local-remote/matrix/manifest updater suite
 tests/test-official-distribution.py  test-only stdlib manifest adversary harness
 tests/test-reporting.sh       offline privacy/fake-gh reporting suite
-tests/test-packaging.sh       82-case offline Codex package/relocation/landing suite
+tests/test-packaging.sh       86-case offline Codex package/relocation/landing suite
 tests/test-doctor.sh          143-case offline fake-tool/read-only doctor suite
+tests/test-proof-demo.sh      21-case offline starter-proof adversarial suite
 .github/workflows/compatibility-watch.yml  observational weekly/manual fixed-source watch
 ```
 

--- a/demo/fixtures/honest-envelope.json
+++ b/demo/fixtures/honest-envelope.json
@@ -1,0 +1,16 @@
+{
+  "status": "completed",
+  "summary": "synthetic worker claim",
+  "files_changed": [
+    {
+      "path": "proof.txt",
+      "change": "modified"
+    }
+  ],
+  "commands_run": [],
+  "tests_run": [],
+  "risks": [],
+  "open_questions": [],
+  "confidence": 0.9,
+  "requires_human": false
+}

--- a/demo/fixtures/scope-mismatch-envelope.json
+++ b/demo/fixtures/scope-mismatch-envelope.json
@@ -1,0 +1,16 @@
+{
+  "status": "completed",
+  "summary": "plausible but incomplete synthetic claim",
+  "files_changed": [
+    {
+      "path": "proof.txt",
+      "change": "modified"
+    }
+  ],
+  "commands_run": [],
+  "tests_run": [],
+  "risks": [],
+  "open_questions": [],
+  "confidence": 0.9,
+  "requires_human": false
+}

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -28,6 +28,20 @@ Git-visible state independently, rejects undeclared, phantom, wrong-kind, outsid
 policy, and verifier-created changes, and routes non-completed outcomes without
 accepting them.
 
+The repository-only starter proof has a deliberately smaller flow:
+
+```text
+canonical synthetic fixtures
+  -> proof-demo.sh
+  -> two independent private temporary Git repositories
+  -> fixed repository qa-gate.sh
+  -> exact honest exit 0 and mismatch exit 10
+  -> cleanup, then bounded three-line summary
+```
+
+It demonstrates only those maintained gate outcomes. It does not dispatch a worker,
+accept a candidate, replace human diff review, or certify correctness or security.
+
 ## Opt-in maintenance flows
 
 - `update.sh check` queries fixed official agy and Codex stable-release/source
@@ -68,15 +82,16 @@ accepting them.
 | `install.sh`, `skills/agy-worker/`, `skills/agy-worker/scripts/resolve-pipeline.sh` | Install and resolve complete-plugin, explicit-checkout, or folder-only skill layouts without fetching code | dispatcher and packaging suites |
 | `skills/agy-worker/runtime/schemas/`, `skills/agy-worker/runtime/scripts/validate-envelope.py` | Dependency-free envelope contract validation | dispatcher and gate suites |
 | `qa-gate.sh`, `skills/agy-worker/runtime/qa-gate.sh` | Root compatibility entry plus canonical immutable-base Git audit, path policy, escalation, driver verification | `tests/test-qa-gate.sh` (41 cases) |
+| `proof-demo.sh`, `demo/fixtures/` | Repository-only offline starter proof using two canonical synthetic envelopes and isolated temporary repositories | `tests/test-proof-demo.sh` (21 cases) |
 | `skills/agy-worker/runtime/agents/*.md` | Prompt-injected bounded personas; prompt text is guidance, not enforcement | dispatcher suite plus bounded real exercises |
 | `update.sh`, `scripts/compatibility.py`, `scripts/official_distribution.py`, `compat/` | Explicit project releases; fixed-source agy/Codex review; bounded distribution-manifest canary; strict per-tool metadata and disabled-on-drift model/effort matrix | `tests/test-update.sh` (164 cases, including the test-only manifest adversary harness) |
 | `bug-report.sh`, `scripts/bug-report.py`, `.github/ISSUE_TEMPLATE/` | Local privacy filtering, exact review binding, optional issue submission | `tests/test-reporting.sh` (21 cases) |
-| `.codex-plugin/plugin.json` | Codex skills-only package identity retained for local validation; not a public listing | `tests/test-packaging.sh` (82 cases) plus platform validators |
-| `PRIVACY.md`, `TERMS.md`, `SUPPORT.md` | Public data disclosure, project policy, and support route | `tests/test-packaging.sh` (82 cases) plus review |
-| `docs/index.md`, `docs/_layouts/`, `docs/_config.yml`, `docs/sitemap.xml` | Static GitHub Pages landing, canonical metadata, and sitemap; enabling Pages and submitting the sitemap through Search Console remain external | `tests/test-packaging.sh` (82 cases) plus rendered review |
-| `docs/assets/brand/`, `scripts/validate-brand-assets.py` | Approved light/dark master marks, pixel-hinted micro variants, favicon PNGs, social preview, and dependency-free asset validation | `tests/test-packaging.sh` (82 cases) plus rendered review |
+| `.codex-plugin/plugin.json` | Codex skills-only package identity retained for local validation; not a public listing | `tests/test-packaging.sh` (86 cases) plus platform validators |
+| `PRIVACY.md`, `TERMS.md`, `SUPPORT.md` | Public data disclosure, project policy, and support route | `tests/test-packaging.sh` (86 cases) plus review |
+| `docs/index.md`, `docs/_layouts/`, `docs/_config.yml`, `docs/sitemap.xml` | Static GitHub Pages landing, canonical metadata, and sitemap; enabling Pages and submitting the sitemap through Search Console remain external | `tests/test-packaging.sh` (86 cases) plus rendered review |
+| `docs/assets/brand/`, `scripts/validate-brand-assets.py` | Approved light/dark master marks, pixel-hinted micro variants, favicon PNGs, social preview, and dependency-free asset validation | `tests/test-packaging.sh` (86 cases) plus rendered review |
 | `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, `.github/pull_request_template.md` | Contribution workflow, private vulnerability route, conduct enforcement, and review checklist | human review plus relevant offline suites |
-| `.github/workflows/test.yml` | macOS CI for syntax and all six offline suites | exercised by GitHub Actions |
+| `.github/workflows/test.yml` | macOS CI for syntax and all seven offline suites | exercised by GitHub Actions |
 | `.github/workflows/compatibility-watch.yml` | Weekly/manual macOS observation of fixed official evidence; bounded Step Summary only, never a required PR or metadata/action path | static policy tests in `tests/test-update.sh` plus GitHub Actions observation |
 | `README.md` | User setup, examples, current capabilities and limitations | review plus relevant offline suites |
 | `docs/ROADMAP.md` | Planned dependency-ordered product slices, approval gates, and honest success measures; not current behavior | human review; implementation claims remain prohibited until their slices land |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,12 +5,11 @@ surface and verified limitations remain in [README.md](../README.md). A roadmap 
 becomes current only after its own implementation, adversarial tests, documentation
 review, and an accepted pull request.
 
-The first recommended implementation is **G0 Compatibility Reconciliation & Watch
-only**. G1 Explicit Model & Effort Selection follows as a separate slice; P0-A
-Evidence Receipt v1 follows separately after the compatibility baseline is current.
-Starting any slice requires a fresh, explicit approval; this roadmap does not
-authorize code, commit, push, pull-request, merge, release, live model use, or another
-external action.
+Compatibility reconciliation remains a prerequisite for model/effort selection and
+portable receipt work. The offline starter proof depends only on the maintained gate
+and can remain an independent slice. Starting any slice requires a fresh, explicit
+approval; this roadmap does not authorize code, commit, push, pull-request, merge,
+release, live model use, or another external action.
 
 ## Product direction
 
@@ -843,12 +842,10 @@ reviews, or automated promotional submissions.
 - Reassess P2 from observed friction. Do not build profiles, pruning, quota, or
   signing merely because they appear on this roadmap.
 
-## First implementation recommendation
+## Sequencing reminder
 
-Implement **G0 Compatibility Reconciliation & Watch only** as the next isolated
-feature slice. Do not include G1 selectors, a `flash-high` alias, routing/ranking
-changes, P0-A receipts, the renderer, Doctor, proof demo, lifecycle, CI report formats,
-profiles, usage, benchmarking, or signing in that change. After G0 is accepted, G1
-may proceed under its own fresh approval and pull request; P0-A follows separately.
-Never mix G0 and P0-A even if they touch shared documentation. Preserve the normal
-independent implementation and verification-agent split for every slice.
+Keep compatibility reconciliation separate from model/effort selection and receipt
+work. The offline starter proof may evolve independently because it relies only on
+the maintained gate. Do not mix otherwise independent slices merely because they
+touch shared documentation, and require fresh approval and independent verification
+for each implementation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,16 @@ Dispatches use the external Antigravity CLI and can send approved task text and
 repository content to Google/Gemini. Read the [privacy disclosure](https://github.com/cagdasyurekli/codex-agy-worker/blob/main/PRIVACY.md)
 before use.
 
+## See the evidence boundary in under a minute
+
+From a reviewed clone, run the repository-only
+[`./proof-demo.sh`](https://github.com/cagdasyurekli/codex-agy-worker/blob/main/proof-demo.sh).
+It builds two private synthetic repositories, confirms one exact edit passes the
+maintained gate and one plausible scope mismatch is rejected, then cleans up. It is
+offline and does not run agy or alter the checkout. Its three-line output is starter
+evidence for those fixed cases only: it is not human review, candidate acceptance,
+general correctness, a security certification, a benchmark, or production proof.
+
 ## Install and explore
 
 Use the GitHub repository as the source of truth. Review the cloned commit—or the

--- a/docs/lessons_learned.md
+++ b/docs/lessons_learned.md
@@ -120,6 +120,19 @@ scope or diff hygiene. Report such an outcome as successful enforcement by the g
 not as a successful worker delivery, and never weaken independent checks to obtain a
 green result.
 
+## A starter proof is not an acceptance claim
+
+A useful offline proof must exercise the maintained gate, not a reimplementation of
+its decision logic. Give the passing and rejecting cases independent repositories,
+require their exact exit contracts, and include a negative control showing that a
+copied permissive gate cannot make the overall proof pass. Keep canonical fixtures
+strict so silent edits cannot turn a teaching example into a different claim.
+
+Buffer success output until every case and cleanup step succeeds. Describe the
+result as evidence for the fixed synthetic cases only: a gate pass is still not a
+human diff review, accepted candidate, correctness result, security certification,
+benchmark, or production validation.
+
 ## Distribution must preserve the trust boundary
 
 A public skill cannot depend on a developer's absolute checkout path or assume that

--- a/proof-demo.sh
+++ b/proof-demo.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+# Synthetic, offline proof of qa-gate's independent Git-scope boundary.
+set -uo pipefail
+
+PROOF_WORK_DIR=''
+PROOF_ACTIVE_PID=''
+PROOF_ACTIVE_PGID=''
+PROOF_RUN_SEQUENCE=0
+
+proof_cleanup() {
+    local work_dir="${PROOF_WORK_DIR:-}"
+    [[ -n "$work_dir" ]] || return 0
+    case "$work_dir" in
+        /private/tmp/agy-worker-proof.*|/tmp/agy-worker-proof.*) ;;
+        *) return 1 ;;
+    esac
+    [[ -d "$work_dir" && ! -L "$work_dir" && -O "$work_dir" ]] || return 1
+    /bin/rm -rf -- "$work_dir" 2>/dev/null || return 1
+    [[ ! -e "$work_dir" ]] || return 1
+    PROOF_WORK_DIR=''
+}
+
+proof_stop_active() {
+    local signal_name="$1" active_pid="${PROOF_ACTIVE_PID:-}"
+    local active_pgid="${PROOF_ACTIVE_PGID:-}" poll
+    case "$active_pgid" in
+        ''|*[!0-9]*) ;;
+        *) kill -s "$signal_name" -- "-$active_pgid" 2>/dev/null || true ;;
+    esac
+    case "$active_pid" in
+        ''|*[!0-9]*) ;;
+        *) kill -s "$signal_name" -- "$active_pid" 2>/dev/null || true ;;
+    esac
+    for (( poll=0; poll<5; poll++ )); do
+        case "$active_pgid" in
+            ''|*[!0-9]*) break ;;
+            *) kill -0 -- "-$active_pgid" 2>/dev/null || break ;;
+        esac
+        /bin/sleep 0.01
+    done
+    case "$active_pgid" in
+        ''|*[!0-9]*) ;;
+        *) kill -KILL -- "-$active_pgid" 2>/dev/null || true ;;
+    esac
+    case "$active_pid" in
+        ''|*[!0-9]*) ;;
+        *)
+            kill -KILL -- "$active_pid" 2>/dev/null || true
+            wait "$active_pid" 2>/dev/null || true
+            ;;
+    esac
+    case "$active_pgid" in
+        ''|*[!0-9]*) ;;
+        *) kill -KILL -- "-$active_pgid" 2>/dev/null || true ;;
+    esac
+    PROOF_ACTIVE_PID=''
+    PROOF_ACTIVE_PGID=''
+}
+
+proof_on_signal() {
+    local signal_name="$1"
+    trap - HUP INT TERM
+    proof_stop_active "$signal_name"
+    proof_cleanup >/dev/null 2>&1 || true
+    echo "proof-demo: interrupted" >&2
+    exit 3
+}
+
+proof_run() {
+    local ready_marker poll ready=0 rc
+    PROOF_RUN_SEQUENCE=$((PROOF_RUN_SEQUENCE + 1))
+    ready_marker="$PROOF_WORK_DIR/.proof-run-ready.$PROOF_RUN_SEQUENCE"
+    [[ -n "$PROOF_WORK_DIR" && ! -e "$ready_marker" ]] || return 1
+    python3 -B - "$ready_marker" "$@" <<'PY' >/dev/null 2>&1 &
+import os
+import sys
+
+marker = sys.argv[1]
+command = sys.argv[2:]
+if not command:
+    raise SystemExit(1)
+os.setsid()
+descriptor = os.open(marker, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+os.close(descriptor)
+os.execvp(command[0], command)
+PY
+    PROOF_ACTIVE_PID=$!
+    PROOF_ACTIVE_PGID=$PROOF_ACTIVE_PID
+    for (( poll=0; poll<500; poll++ )); do
+        if [[ -f "$ready_marker" && ! -L "$ready_marker" ]]; then
+            ready=1
+            break
+        fi
+        kill -0 -- "$PROOF_ACTIVE_PID" 2>/dev/null || break
+        /bin/sleep 0.01
+    done
+    /bin/rm -f -- "$ready_marker" 2>/dev/null || {
+        proof_stop_active KILL
+        return 1
+    }
+    if (( ! ready )); then
+        proof_stop_active KILL
+        return 1
+    fi
+    wait "$PROOF_ACTIVE_PID"
+    rc=$?
+    kill -KILL -- "-$PROOF_ACTIVE_PGID" 2>/dev/null || true
+    PROOF_ACTIVE_PID=''
+    PROOF_ACTIVE_PGID=''
+    return "$rc"
+}
+
+proof_fail() {
+    echo "proof-demo: starter proof failed" >&2
+    exit 3
+}
+
+proof_prepare_workspace() {
+    local base base_dir work_dir old_umask rc seen='|'
+    for base in /private/tmp /tmp; do
+        base_dir="$(CDPATH= cd -- "$base" 2>/dev/null && pwd -P)" || continue
+        case "$seen" in *"|$base_dir|"*) continue ;; esac
+        seen="$seen$base_dir|"
+        [[ -d "$base_dir" && -w "$base_dir" && ! -L "$base" ]] || continue
+        old_umask="$(umask)"
+        umask 077
+        work_dir="$(/usr/bin/mktemp -d \
+            "$base_dir/agy-worker-proof.XXXXXX" 2>/dev/null)"
+        rc=$?
+        umask "$old_umask"
+        [[ "$rc" == 0 && -n "$work_dir" && -d "$work_dir" \
+            && ! -L "$work_dir" && -O "$work_dir" ]] || continue
+        /bin/chmod 700 "$work_dir" 2>/dev/null || {
+            /bin/rmdir "$work_dir" 2>/dev/null || true
+            continue
+        }
+        PROOF_WORK_DIR="$(CDPATH= cd -- "$work_dir" 2>/dev/null && pwd -P)" \
+            || return 1
+        return 0
+    done
+    return 1
+}
+
+proof_validate_fixtures() {
+    python3 -B - "$1" "$2" <<'PY' >/dev/null 2>&1
+import json
+import sys
+from pathlib import Path
+
+common = {
+    "status": "completed",
+    "summary": "synthetic worker claim",
+    "files_changed": [{"path": "proof.txt", "change": "modified"}],
+    "commands_run": [],
+    "tests_run": [],
+    "risks": [],
+    "open_questions": [],
+    "confidence": 0.9,
+    "requires_human": False,
+}
+expected = [common, dict(common, summary="plausible but incomplete synthetic claim")]
+
+def strict_object(raw: bytes):
+    def unique(pairs):
+        value = {}
+        for key, item in pairs:
+            if key in value:
+                raise ValueError("duplicate key")
+            value[key] = item
+        return value
+    return json.loads(raw.decode("ascii"), object_pairs_hook=unique)
+
+for name, wanted in zip(sys.argv[1:], expected):
+    raw = Path(name).read_bytes()
+    canonical = (json.dumps(wanted, indent=2, ensure_ascii=True) + "\n").encode("ascii")
+    if raw != canonical or strict_object(raw) != wanted:
+        raise SystemExit(1)
+PY
+}
+
+proof_init_repo() {
+    local repo="$1"
+    /bin/mkdir -p "$repo" || return 1
+    proof_run git -C "$repo" init -q || return 1
+    printf 'original synthetic value\n' > "$repo/proof.txt" || return 1
+    proof_run git -C "$repo" add proof.txt || return 1
+    proof_run git -C "$repo" commit -qm 'synthetic base' || return 1
+}
+
+proof_main() {
+    local script_dir gate fixture_root honest_fixture mismatch_fixture
+    local honest_repo mismatch_repo honest_base mismatch_base gate_rc verify_command
+
+    [[ $# == 0 ]] || exit 64
+    script_dir="$(CDPATH= cd -- "${BASH_SOURCE[0]%/*}" 2>/dev/null && pwd -P)" \
+        || proof_fail
+    gate="$script_dir/qa-gate.sh"
+    fixture_root="$script_dir/demo/fixtures"
+    honest_fixture="$fixture_root/honest-envelope.json"
+    mismatch_fixture="$fixture_root/scope-mismatch-envelope.json"
+
+    [[ -f "$gate" && -x "$gate" && ! -L "$gate" ]] || proof_fail
+    [[ -d "$script_dir/demo" && ! -L "$script_dir/demo" \
+        && -d "$fixture_root" && ! -L "$fixture_root" \
+        && -f "$honest_fixture" && ! -L "$honest_fixture" \
+        && -f "$mismatch_fixture" && ! -L "$mismatch_fixture" ]] || proof_fail
+    command -v git >/dev/null 2>&1 || proof_fail
+    command -v python3 >/dev/null 2>&1 || proof_fail
+
+    export GIT_CONFIG_GLOBAL=/dev/null
+    export GIT_CONFIG_NOSYSTEM=1
+    export GIT_AUTHOR_NAME='agy-worker proof demo'
+    export GIT_AUTHOR_EMAIL='proof@example.invalid'
+    export GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
+    export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
+
+    proof_validate_fixtures "$honest_fixture" "$mismatch_fixture" || proof_fail
+    proof_prepare_workspace || proof_fail
+    trap proof_cleanup EXIT
+    trap 'proof_on_signal HUP' HUP
+    trap 'proof_on_signal INT' INT
+    trap 'proof_on_signal TERM' TERM
+
+    honest_repo="$PROOF_WORK_DIR/honest"
+    mismatch_repo="$PROOF_WORK_DIR/mismatch"
+    proof_init_repo "$honest_repo" || proof_fail
+    proof_init_repo "$mismatch_repo" || proof_fail
+    honest_base="$(git -C "$honest_repo" rev-parse HEAD 2>/dev/null)" || proof_fail
+    mismatch_base="$(git -C "$mismatch_repo" rev-parse HEAD 2>/dev/null)" || proof_fail
+
+    printf 'verified synthetic change\n' > "$honest_repo/proof.txt" || proof_fail
+    verify_command="grep -Fxq 'verified synthetic change' '$honest_repo/proof.txt' && test \"\$(wc -l < '$honest_repo/proof.txt')\" -eq 1"
+    proof_run "$gate" --envelope "$honest_fixture" --repo "$honest_repo" \
+        --base "$honest_base" --only proof.txt --expect-edits \
+        --verify "$verify_command"
+    gate_rc=$?
+    [[ "$gate_rc" == 0 ]] || proof_fail
+
+    printf 'verified synthetic change\n' > "$mismatch_repo/proof.txt" || proof_fail
+    printf 'undeclared synthetic change\n' > "$mismatch_repo/hidden.txt" || proof_fail
+    verify_command="grep -Fxq 'verified synthetic change' '$mismatch_repo/proof.txt' && test \"\$(wc -l < '$mismatch_repo/proof.txt')\" -eq 1"
+    proof_run "$gate" --envelope "$mismatch_fixture" --repo "$mismatch_repo" \
+        --base "$mismatch_base" --expect-edits --verify "$verify_command"
+    gate_rc=$?
+    [[ "$gate_rc" == 10 ]] || proof_fail
+
+    trap - HUP INT TERM EXIT
+    proof_cleanup || proof_fail
+    printf '%s\n' \
+        'honest: gate-passed (exit 0)' \
+        'mismatch: rejected (exit 10)' \
+        'starter proof only; no candidate accepted because no human review occurred'
+}
+
+proof_main "$@"

--- a/tests/test-packaging.sh
+++ b/tests/test-packaging.sh
@@ -241,6 +241,44 @@ else
     bad "macOS CI runs the dedicated offline doctor suite"
 fi
 
+if [[ -x "$ROOT/proof-demo.sh" ]] \
+        && [[ -x "$ROOT/tests/test-proof-demo.sh" ]] \
+        && [[ -f "$ROOT/demo/fixtures/honest-envelope.json" ]] \
+        && [[ ! -L "$ROOT/demo/fixtures/honest-envelope.json" ]] \
+        && [[ -f "$ROOT/demo/fixtures/scope-mismatch-envelope.json" ]] \
+        && [[ ! -L "$ROOT/demo/fixtures/scope-mismatch-envelope.json" ]] \
+        && [[ ! -e "$ROOT/skills/agy-worker/runtime/proof-demo.sh" ]]; then
+    ok "repository package includes the repo-only starter proof and canonical fixtures"
+else
+    bad "repository package includes the repo-only starter proof and canonical fixtures"
+fi
+
+if grep -Fq 'run: ./tests/test-proof-demo.sh' "$ROOT/.github/workflows/test.yml"; then
+    ok "macOS CI runs the dedicated offline starter-proof suite"
+else
+    bad "macOS CI runs the dedicated offline starter-proof suite"
+fi
+
+if grep -Fq './proof-demo.sh' "$ROOT/README.md" \
+        && grep -Fq 'starter proof' "$ROOT/README.md" \
+        && grep -Fq 'proof-demo.sh' "$ROOT/docs/index.md" \
+        && grep -Fq 'not human review' "$ROOT/docs/index.md"; then
+    ok "public documentation links the bounded starter proof without claiming acceptance"
+else
+    bad "public documentation links the bounded starter proof without claiming acceptance"
+fi
+
+if grep -Fq 'gate="$script_dir/qa-gate.sh"' "$ROOT/proof-demo.sh" \
+        && ! grep -Eq 'PROOF_GATE|--gate([=[:space:]]|$)' "$ROOT/proof-demo.sh" \
+        && grep -Fq 'honest: gate-passed (exit 0)' "$ROOT/proof-demo.sh" \
+        && grep -Fq 'mismatch: rejected (exit 10)' "$ROOT/proof-demo.sh" \
+        && grep -Fq 'starter proof only; no candidate accepted because no human review occurred' \
+            "$ROOT/proof-demo.sh"; then
+    ok "starter proof fixes the maintained gate and its bounded success contract"
+else
+    bad "starter proof fixes the maintained gate and its bounded success contract"
+fi
+
 if cmp -s "$ROOT/compat/agy-verified-version.txt" \
         "$ROOT/skills/agy-worker/runtime/compat/agy-verified-version.txt" \
         && cmp -s "$ROOT/compat/agy-last-reviewed.txt" \

--- a/tests/test-proof-demo.sh
+++ b/tests/test-proof-demo.sh
@@ -1,0 +1,382 @@
+#!/usr/bin/env bash
+# Offline adversarial tests for the synthetic starter proof.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$HERE/.."
+HOST_PYTHON="$(command -v python3)"
+REAL_GIT="$(command -v git)"
+TMP="$(mktemp -d -t agyworker-proof-tests.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+pass=0; fail=0
+
+ok() { printf '  ok   %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL %s\n' "$1"; fail=$((fail+1)); }
+
+EXPECTED_OUTPUT="$(printf '%s\n' \
+    'honest: gate-passed (exit 0)' \
+    'mismatch: rejected (exit 10)' \
+    'starter proof only; no candidate accepted because no human review occurred')"
+
+snapshot_tree() {
+    "$HOST_PYTHON" -B - "$1" <<'PY'
+import hashlib
+import os
+import stat
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+digest = hashlib.sha256()
+root_info = root.lstat()
+digest.update(b".\0" + oct(stat.S_IMODE(root_info.st_mode)).encode() + b"\0directory\0")
+for current, dirs, files in os.walk(root):
+    dirs[:] = sorted(dirs)
+    for name in sorted(dirs + files):
+        path = Path(current) / name
+        relative = path.relative_to(root).as_posix().encode("utf-8", "surrogateescape")
+        info = path.lstat()
+        digest.update(relative + b"\0" + oct(stat.S_IMODE(info.st_mode)).encode() + b"\0")
+        if path.is_symlink():
+            digest.update(b"symlink\0")
+            digest.update(os.readlink(path).encode("utf-8", "surrogateescape"))
+        elif path.is_dir():
+            digest.update(b"directory\0")
+        elif path.is_file():
+            digest.update(b"file\0")
+            digest.update(path.read_bytes())
+        else:
+            digest.update(b"special\0" + str(stat.S_IFMT(info.st_mode)).encode())
+        digest.update(b"\0")
+print(digest.hexdigest())
+PY
+}
+
+list_proof_roots() {
+    "$HOST_PYTHON" -B - <<'PY'
+from pathlib import Path
+
+seen = set()
+matches = []
+for raw_base in ("/private/tmp", "/tmp"):
+    try:
+        base = Path(raw_base).resolve(strict=True)
+    except OSError:
+        continue
+    if base in seen:
+        continue
+    seen.add(base)
+    try:
+        matches.extend(str(path) for path in base.glob("agy-worker-proof.*"))
+    except OSError:
+        pass
+print("\n".join(sorted(matches)))
+PY
+}
+
+process_alive() {
+    case "${1:-}" in
+        ''|*[!0-9]*) return 1 ;;
+        *) kill -0 "$1" 2>/dev/null ;;
+    esac
+}
+
+make_demo_tree() {
+    local destination="$1"
+    mkdir -p "$destination/demo/fixtures" \
+        "$destination/skills/agy-worker/runtime/scripts" \
+        "$destination/skills/agy-worker/runtime/schemas"
+    cp "$ROOT/proof-demo.sh" "$ROOT/qa-gate.sh" "$destination/"
+    cp "$ROOT/demo/fixtures/"*.json "$destination/demo/fixtures/"
+    cp "$ROOT/skills/agy-worker/runtime/qa-gate.sh" \
+        "$destination/skills/agy-worker/runtime/qa-gate.sh"
+    cp "$ROOT/skills/agy-worker/runtime/scripts/validate-envelope.py" \
+        "$destination/skills/agy-worker/runtime/scripts/validate-envelope.py"
+    cp "$ROOT/skills/agy-worker/runtime/schemas/worker-result.schema.json" \
+        "$destination/skills/agy-worker/runtime/schemas/worker-result.schema.json"
+    chmod +x "$destination/proof-demo.sh" "$destination/qa-gate.sh" \
+        "$destination/skills/agy-worker/runtime/qa-gate.sh" \
+        "$destination/skills/agy-worker/runtime/scripts/validate-envelope.py"
+}
+
+mkdir -p "$TMP/bin" "$TMP/caller-temp/agy-worker-proof.COLLISION"
+printf 'preserve me\n' > "$TMP/caller-temp/agy-worker-proof.COLLISION/sentinel"
+for forbidden in agy gemini curl wget gh npm npx credential update.sh; do
+    printf '#!/usr/bin/env bash\n: > "$DEMO_FORBIDDEN_MARKER"\nexit 97\n' \
+        > "$TMP/bin/$forbidden"
+    chmod +x "$TMP/bin/$forbidden"
+done
+printf '%s\n' '#!/usr/bin/env bash' \
+    'if [[ "$1" == "-C" && "${3:-}" == "init" ]]; then' \
+    '  "$DEMO_HOST_PYTHON" -B - "$2" "$DEMO_GIT_LOG" <<'"'"'PY'"'"'' \
+    'import os, stat, sys' \
+    'repo, output = sys.argv[1:]' \
+    'root = os.path.dirname(repo)' \
+    'mode = stat.S_IMODE(os.stat(root).st_mode)' \
+    'with open(output, "a", encoding="utf-8") as handle:' \
+    '    handle.write(f"{root}|{os.path.basename(repo)}|{mode:03o}|{os.stat(root).st_uid}\n")' \
+    'PY' \
+    'fi' \
+    'exec "$DEMO_REAL_GIT" "$@"' > "$TMP/bin/git"
+chmod +x "$TMP/bin/git"
+
+run_demo() {
+    local demo_root="$1" label="$2"
+    TMPDIR="$TMP/caller-temp" \
+    DEMO_REAL_GIT="$REAL_GIT" DEMO_HOST_PYTHON="$HOST_PYTHON" \
+    DEMO_GIT_LOG="$TMP/$label.git-log" \
+    DEMO_FORBIDDEN_MARKER="$TMP/$label.forbidden" \
+    PATH="$TMP/bin:$PATH" \
+        "$demo_root/proof-demo.sh" \
+        > "$TMP/$label.out" 2> "$TMP/$label.err"
+}
+
+echo "proof-demo.sh offline test suite"
+echo
+
+initial_proof_roots="$(list_proof_roots)"
+before_tree="$(snapshot_tree "$ROOT")"
+start_seconds="$(date +%s)"
+run_demo "$ROOT" normal
+normal_rc=$?
+elapsed=$(( $(date +%s) - start_seconds ))
+after_tree="$(snapshot_tree "$ROOT")"
+if [[ "$normal_rc" == 0 && "$(cat "$TMP/normal.out")" == "$EXPECTED_OUTPUT" \
+        && ! -s "$TMP/normal.err" ]]; then
+    ok "maintained gate proves honest exit 0 and mismatch exit 10"
+else
+    bad "maintained gate proves honest exit 0 and mismatch exit 10"
+fi
+if (( elapsed < 60 )); then
+    ok "starter proof completes in under 60 seconds"
+else
+    bad "starter proof completes in under 60 seconds"
+fi
+if [[ "$before_tree" == "$after_tree" ]]; then
+    ok "starter proof leaves the current checkout byte-identical"
+else
+    bad "starter proof leaves the current checkout byte-identical"
+fi
+
+snapshot_repo="$TMP/snapshot-negative"
+mkdir -p "$snapshot_repo"
+GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 \
+    "$REAL_GIT" -C "$snapshot_repo" init -q
+snapshot_before="$(snapshot_tree "$snapshot_repo")"
+printf '\n[proof-negative]\n\tchanged = true\n' >> "$snapshot_repo/.git/config"
+snapshot_after="$(snapshot_tree "$snapshot_repo")"
+if [[ "$snapshot_before" != "$snapshot_after" ]]; then
+    ok "checkout snapshot detects a synthetic Git metadata mutation"
+else
+    bad "checkout snapshot detects a synthetic Git metadata mutation"
+fi
+if [[ ! -e "$TMP/normal.forbidden" ]]; then
+    ok "starter proof invokes no forbidden offline executable"
+else
+    bad "starter proof invokes no forbidden offline executable"
+fi
+if [[ -f "$TMP/caller-temp/agy-worker-proof.COLLISION/sentinel" ]] \
+        && grep -Fxq 'preserve me' \
+            "$TMP/caller-temp/agy-worker-proof.COLLISION/sentinel"; then
+    ok "caller temp collision and sentinel are preserved"
+else
+    bad "caller temp collision and sentinel are preserved"
+fi
+if "$HOST_PYTHON" -B - "$TMP/normal.git-log" <<'PY'
+import os
+import sys
+lines = open(sys.argv[1], encoding="utf-8").read().splitlines()
+initial = [line.split("|") for line in lines if line.split("|")[1] in {"honest", "mismatch"}]
+assert len(initial) == 2
+assert {item[1] for item in initial} == {"honest", "mismatch"}
+assert len({item[0] for item in initial}) == 1
+assert all(item[2] == "700" and int(item[3]) == os.getuid() for item in initial)
+assert not os.path.exists(initial[0][0])
+PY
+then
+    ok "two independent repos use one private owned root and clean normally"
+else
+    bad "two independent repos use one private owned root and clean normally"
+fi
+
+run_demo "$ROOT" deterministic
+if [[ "$?" == 0 ]] && cmp -s "$TMP/normal.out" "$TMP/deterministic.out" \
+        && ! grep -Fq "$TMP" "$TMP/deterministic.out" "$TMP/deterministic.err" \
+        && [[ "$(wc -l < "$TMP/deterministic.out" | tr -d ' ')" == 3 ]]; then
+    ok "success output is deterministic, three-line, bounded, and nonleaking"
+else
+    bad "success output is deterministic, three-line, bounded, and nonleaking"
+fi
+
+"$ROOT/proof-demo.sh" unexpected > "$TMP/args.out" 2> "$TMP/args.err"
+if [[ "$?" == 64 && ! -s "$TMP/args.out" && ! -s "$TMP/args.err" ]]; then
+    ok "arguments are rejected without starting a proof"
+else
+    bad "arguments are rejected without starting a proof"
+fi
+
+VALID_TREE="$TMP/valid-tree"
+make_demo_tree "$VALID_TREE"
+run_demo "$VALID_TREE" valid-copy
+if [[ "$?" == 0 && "$(cat "$TMP/valid-copy.out")" == "$EXPECTED_OUTPUT" ]]; then
+    ok "canonical copied fixture pair remains valid"
+else
+    bad "canonical copied fixture pair remains valid"
+fi
+
+for fixture_mode in malformed extra altered missing; do
+    fixture_tree="$TMP/fixture-$fixture_mode"
+    make_demo_tree "$fixture_tree"
+    case "$fixture_mode" in
+        malformed)
+            printf '{not json\n' > "$fixture_tree/demo/fixtures/honest-envelope.json"
+            ;;
+        extra)
+            "$HOST_PYTHON" -B - "$fixture_tree/demo/fixtures/honest-envelope.json" <<'PY'
+import json, sys
+path = sys.argv[1]
+value = json.load(open(path, encoding="utf-8"))
+value["extra"] = True
+open(path, "w", encoding="utf-8").write(json.dumps(value, indent=2) + "\n")
+PY
+            ;;
+        altered)
+            "$HOST_PYTHON" -B - "$fixture_tree/demo/fixtures/scope-mismatch-envelope.json" <<'PY'
+from pathlib import Path
+import sys
+path = Path(sys.argv[1])
+path.write_text(path.read_text().replace('"proof.txt"', '"hidden.txt"'), encoding="utf-8")
+PY
+            ;;
+        missing)
+            rm -f "$fixture_tree/demo/fixtures/honest-envelope.json"
+            ;;
+    esac
+    run_demo "$fixture_tree" "fixture-$fixture_mode"
+    rc=$?
+    if [[ "$rc" == 3 && ! -s "$TMP/fixture-$fixture_mode.out" ]] \
+            && grep -Fxq 'proof-demo: starter proof failed' \
+                "$TMP/fixture-$fixture_mode.err"; then
+        ok "$fixture_mode fixture fails closed"
+    else
+        bad "$fixture_mode fixture fails closed"
+    fi
+done
+
+for gate_mode in missing nonexec trusting; do
+    gate_tree="$TMP/gate-$gate_mode"
+    make_demo_tree "$gate_tree"
+    case "$gate_mode" in
+        missing) rm -f "$gate_tree/qa-gate.sh" ;;
+        nonexec) chmod -x "$gate_tree/qa-gate.sh" ;;
+        trusting)
+            printf '#!/usr/bin/env bash\nexit 0\n' > "$gate_tree/qa-gate.sh"
+            chmod +x "$gate_tree/qa-gate.sh"
+            ;;
+    esac
+    run_demo "$gate_tree" "gate-$gate_mode"
+    rc=$?
+    if [[ "$rc" == 3 && ! -s "$TMP/gate-$gate_mode.out" ]] \
+            && grep -Fxq 'proof-demo: starter proof failed' \
+                "$TMP/gate-$gate_mode.err"; then
+        ok "$gate_mode repository-relative gate cannot pass the proof"
+    else
+        bad "$gate_mode repository-relative gate cannot pass the proof"
+    fi
+done
+
+mkdir -p "$TMP/signal-bin"
+printf '%s\n' '#!/usr/bin/env bash' \
+    'if [[ "$1" == "-C" && "${3:-}" == "init" ]]; then' \
+    '  printf "%s\n" "$$" > "$DEMO_SIGNAL_CHILD"' \
+    '  "$DEMO_HOST_PYTHON" -B -c '\''import os; print(os.getpgrp())'\'' > "$DEMO_SIGNAL_PGID"' \
+    '  printf "%s\n" "${2%/*}" > "$DEMO_SIGNAL_ROOT"' \
+    '  /bin/bash -c '\''trap "" HUP INT TERM; while :; do /bin/sleep 1; done'\'' &' \
+    '  signal_grandchild=$!' \
+    '  printf "%s\n" "$signal_grandchild" > "$DEMO_SIGNAL_GRANDCHILD"' \
+    '  : > "$DEMO_SIGNAL_READY"' \
+    '  trap "" HUP INT TERM' \
+    '  while :; do /bin/sleep 1; done' \
+    'fi' \
+    'exec "$DEMO_REAL_GIT" "$@"' > "$TMP/signal-bin/git"
+chmod +x "$TMP/signal-bin/git"
+
+for signal_name in HUP INT TERM; do
+    label="signal-$signal_name"
+    DEMO_REAL_GIT="$REAL_GIT" \
+    DEMO_HOST_PYTHON="$HOST_PYTHON" \
+    DEMO_SIGNAL_CHILD="$TMP/$label.child" \
+    DEMO_SIGNAL_PGID="$TMP/$label.pgid" \
+    DEMO_SIGNAL_GRANDCHILD="$TMP/$label.grandchild" \
+    DEMO_SIGNAL_ROOT="$TMP/$label.root" \
+    DEMO_SIGNAL_READY="$TMP/$label.ready" \
+    PATH="$TMP/signal-bin:$PATH" \
+        "$HOST_PYTHON" -B -c '
+import os, signal, sys
+for signum in (signal.SIGHUP, signal.SIGINT, signal.SIGTERM):
+    signal.signal(signum, signal.SIG_DFL)
+os.execv("/bin/bash", ["/bin/bash", sys.argv[1]])
+' "$ROOT/proof-demo.sh" > "$TMP/$label.out" 2> "$TMP/$label.err" &
+    demo_pid=$!
+    ready=0
+    for (( poll=0; poll<100; poll++ )); do
+        if [[ -e "$TMP/$label.ready" && -s "$TMP/$label.child" \
+                && -s "$TMP/$label.pgid" \
+                && -s "$TMP/$label.grandchild" \
+                && -s "$TMP/$label.root" ]]; then
+            ready=1
+            break
+        fi
+        /bin/sleep 0.05
+    done
+    if (( ready )); then kill -s "$signal_name" "$demo_pid" 2>/dev/null || true; fi
+    completed=0
+    for (( poll=0; poll<100; poll++ )); do
+        if ! kill -0 "$demo_pid" 2>/dev/null; then completed=1; break; fi
+        /bin/sleep 0.05
+    done
+    if (( completed )); then wait "$demo_pid"; rc=$?; else rc=99; fi
+    child_pid="$(cat "$TMP/$label.child" 2>/dev/null || true)"
+    child_pgid="$(cat "$TMP/$label.pgid" 2>/dev/null || true)"
+    grandchild_pid="$(cat "$TMP/$label.grandchild" 2>/dev/null || true)"
+    work_root="$(cat "$TMP/$label.root" 2>/dev/null || true)"
+    descendants_gone=0
+    for (( poll=0; poll<100; poll++ )); do
+        if ! process_alive "$child_pid" && ! process_alive "$grandchild_pid"; then
+            descendants_gone=1
+            break
+        fi
+        /bin/sleep 0.05
+    done
+    if (( ready && completed )) && [[ "$rc" == 3 && ! -s "$TMP/$label.out" ]] \
+            && grep -Fxq 'proof-demo: interrupted' "$TMP/$label.err" \
+            && [[ "$child_pgid" == "$child_pid" && "$child_pgid" != "$demo_pid" ]] \
+            && (( descendants_gone )) \
+            && [[ -n "$work_root" && ! -e "$work_root" ]]; then
+        ok "$signal_name cleans the private root, direct child, and grandchild"
+    else
+        bad "$signal_name cleans the private root, direct child, and grandchild"
+        printf '       ready=%s completed=%s rc=%s child=%s pgid=%s demo=%s child_alive=%s grandchild_alive=%s root_exists=%s\n' \
+            "$ready" "$completed" "$rc" \
+            "$child_pid" "$child_pgid" "$demo_pid" \
+            "$(process_alive "$child_pid" && echo yes || echo no)" \
+            "$(process_alive "$grandchild_pid" && echo yes || echo no)" \
+            "$([[ -e "$work_root" ]] && echo yes || echo no)"
+        kill -KILL "$demo_pid" "$child_pid" "$grandchild_pid" 2>/dev/null || true
+        wait "$demo_pid" 2>/dev/null || true
+    fi
+done
+
+final_proof_roots="$(list_proof_roots)"
+if [[ "$initial_proof_roots" == "$final_proof_roots" ]]; then
+    ok "complete suite leaves no new proof workspace root"
+else
+    bad "complete suite leaves no new proof workspace root"
+fi
+
+echo
+if (( fail )); then
+    echo "FAILED: $fail failed, $pass passed"
+    exit 1
+fi
+echo "PASSED: $pass tests"


### PR DESCRIPTION
## Summary

- add a repository-only offline proof that exercises the maintained QA gate in two isolated synthetic Git repositories
- show one exact declared edit with driver-owned verification (exit 0) and one plausible incomplete worker claim rejected by Git reality (exit 10)
- add paired adversarial coverage for trusting/missing gates, fixture tampering, full checkout invariance, prohibited provider/network tools, private temp ownership, and HUP/INT/TERM process-tree cleanup
- document the starter-proof boundary in README, Pages, repository map, roadmap, lessons, CI, and contributor guidance

## Trust boundary

This is a synthetic starter proof only. It does not invoke agy or a provider, access the network or credentials, alter the checkout, accept a candidate, replace human review, or claim conformance, benchmark, security, correctness, or real-agy quality. `qa-gate.sh` remains the sole gate authority.

## Verification

Independent verifier: **ACCEPT** on `1397bba5fadbf6776ac21dc3edd8ce52e627af21`.

- QA gate: 41
- Worker/routing: 60
- Update/watch: 164
- Reporting: 21
- Packaging: 86
- Doctor: 143
- Proof demo: 21
- Total: 536 offline cases
- macOS Bash 3.2 syntax, Python compilation, and diff checks passed
- direct proof exit 0 with exact three-line output in under one second
- protected core/runtime/compatibility/receipt paths unchanged

## Approval boundary

Ready for review. Do not merge, release, or publish further without separate explicit approval.
