### PR TITLE
chore: prepare v0.2.0 release

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-agy-worker",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Delegate bounded coding work to Antigravity CLI, then independently verify repository evidence before acceptance.",
   "author": {
     "name": "cagdasyurekli",

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,6 +18,8 @@
 - [ ] `./tests/test-update.sh`
 - [ ] `./tests/test-reporting.sh`
 - [ ] `./tests/test-packaging.sh`
+- [ ] `./tests/test-doctor.sh`
+- [ ] `./tests/test-proof-demo.sh`
 - [ ] Bash and Python syntax checks
 - [ ] `git diff --check`
 - [ ] Human diff review completed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,8 @@ Run the offline suites and static checks before requesting review:
 ./tests/test-update.sh
 ./tests/test-reporting.sh
 ./tests/test-packaging.sh
+./tests/test-doctor.sh
+./tests/test-proof-demo.sh
 bash -n ./*.sh tests/*.sh skills/*/scripts/*.sh skills/*/runtime/*.sh
 python3 -m py_compile scripts/*.py skills/*/runtime/scripts/*.py
 git diff --check

--- a/README.md
+++ b/README.md
@@ -469,22 +469,25 @@ watch runs the official-evidence-only mode without installing agy or Codex. It w
 only a bounded Step Summary, preserves the same `0`/`3`/`2` meanings, is not a required
 pull-request check, and cannot advance metadata or open an issue or pull request.
 
-The official distribution manifest currently advertises agy `1.1.10`, while the
-public GitHub stable release and reviewed source remain `1.1.9`. That is established
-distribution drift, not authority to advance the verified baseline. The checked-in
-manifest tuple is an observational change detector rather than a trust root: a
-same-version archive build, URL, or SHA-512 change also requires review. Neither the
-live manifest nor its snapshot activates the disabled `1.1.10` model/effort matrix.
+The official stable release, current source, CLI documentation, and distribution
+manifest now expose agy `1.1.10` evidence, while this project's human-reviewed
+verified baseline remains `1.1.9`. That is established drift and enables a human
+reconciliation; it is not authority to advance the baseline or claim `1.1.10`
+support. The checked-in manifest tuple is an observational change detector rather
+than a trust root: a same-version archive build, URL, or SHA-512 change also requires
+review. Neither the live manifest nor its snapshot activates the disabled `1.1.10`
+model/effort matrix.
 
 agy's real CLI exposes `--effort`, but this wrapper exposes no effort control until a
 separately approved G1. The checked-in model/effort matrix is validated metadata, not
 routing or gate authority. Its agy `1.1.10` inventory is explicitly disabled candidate
-evidence because official `1.1.9` release/source evidence does not substantiate those
-exact rows; version/source drift keeps resolution disabled. The wrapper does not send
-both a compound model slug and agy's separate effort flag. `qa-gate.sh` remains the
-sole acceptance authority, and model recommendations remain visible, advisory-only,
-and unable to escalate permission, authentication, scope-policy, or human-required
-outcomes.
+evidence: the newly available official `1.1.10` evidence has not been reconciled with
+a sandbox-correct inventory and bounded behavior tests that substantiate those exact
+rows. Version/source drift therefore keeps resolution disabled. The wrapper does not
+send both a compound model slug and agy's separate effort flag. `qa-gate.sh` remains
+the sole acceptance authority, and model recommendations remain visible,
+advisory-only, and unable to escalate permission, authentication, scope-policy, or
+human-required outcomes.
 
 ## Sanitized bug reports and feature requests
 

--- a/compat/sources.md
+++ b/compat/sources.md
@@ -18,13 +18,15 @@ an external action.
 - Fixed `darwin_arm64` distribution manifest: https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/darwin_arm64.json
 - Installed interface evidence: `./ground-truth.sh`
 
-The verified baseline is agy `1.1.9` at source revision
-`21f650e7bb852f58562425ddd0c7d203c80e3d0e`. The official distribution manifest and
-the installed executable advertise `1.1.10`; the public stable release and reviewed
-source still establish only `1.1.9`. This is drift, not permission to advance that
-baseline. The `1.1.10` model list remains a disabled candidate inventory in
-`agy-model-effort-matrix.json`, because distribution availability does not
-substantiate its source or behavior.
+The verified baseline is agy `1.1.9` at reviewed source revision
+`21f650e7bb852f58562425ddd0c7d203c80e3d0e`. The current official stable release,
+source revision `bfab12dac5bd090015a89cf82e65093d13b567d9`, CLI documentation,
+and distribution manifest expose `1.1.10` evidence. These are drift evidence
+sufficient to begin human reconciliation, not permission to advance the verified
+baseline or claim `1.1.10` support. The `1.1.10` model list remains a disabled
+candidate inventory in `agy-model-effort-matrix.json` until its exact rows are
+human-reconciled against those primary sources, a sandbox-correct inventory, and
+bounded behavior tests.
 
 `agy-distribution-manifest.json` records the observed `1.1.10` version, exact Google
 Storage archive URL, and lowercase SHA-512 tuple. It is an observational snapshot,

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -118,10 +118,11 @@ or historical failure behavior are the verified agy `1.1.10` contract:
   documented commands and validate their expected semantic output; neither an unknown
   subcommand's exit code nor generic usage text is compatibility evidence.
 - Do not assume agy's separate `--model` and `--effort` flags compose safely.
-  Subsequent bounded `1.1.10` inventory evidence advertises compound slugs, while
-  public source does not establish dual-selector composition or precedence. G1
-  therefore resolves a verified base/effort pair to one exact advertised slug and
-  sends one `--model`.
+  Subsequent bounded `1.1.10` inventory evidence advertises compound slugs. Official
+  `1.1.10` source and documentation are now available for human reconciliation, but
+  this repository has not yet completed evidence that establishes dual-selector
+  composition or precedence. G1 therefore resolves a verified base/effort pair to
+  one exact advertised slug and sends one `--model`.
 - Any exposure of newly advertised agy behavior remains a separate slice requiring
   official docs, official source, a sandbox-correct live inventory, a bounded real
   job, paired offline tests, and explicit approval.
@@ -177,19 +178,21 @@ an earlier implementation because it shares a schema or helper.
   rejects redirects and oversized or malformed responses, validates the exact
   version/archive URL/SHA-512 tuple, and never requests the archive. Its checked-in
   tuple is an observational same-version change detector, not a verified release,
-  source revision, signature, or baseline. The manifest currently establishes
-  distribution `1.1.10` while public release/source remains verified at `1.1.9`;
-  this keeps G1 resolution disabled and produces drift-review rather than a
-  speculative advance.
+  source revision, signature, or baseline. Official release, source, documentation,
+  and distribution evidence now expose `1.1.10`, while the repository's
+  human-reviewed verified baseline remains `1.1.9`. That evidence enables human
+  reconciliation but does not complete it, activate G1 resolution, or permit a
+  speculative baseline advance; the current result remains drift-review.
 - **Baseline advancement:** A maintainer may advance either verified baseline only
   after reconciling official docs, release notes, and source; regenerating the local
   `./ground-truth.sh` evidence for agy and equivalent documented Codex CLI inventory;
   running every offline suite and syntax/compile/diff check; and recording the exact
   reviewed revisions. If behavior affecting dispatch changed, a bounded job against
   an explicit public fixture is a separate live-data approval, not part of the watch.
-  The watch never performs this reconciliation. If an official agy `1.1.10` release
-  and matching source cannot both be established, the verified baseline stays `1.1.9`
-  and the result remains AMBER/review-due rather than speculatively advancing.
+  The watch never performs this reconciliation. The official agy `1.1.10` release and
+  matching source now provide inputs to that review, but the verified baseline stays
+  `1.1.9` and the result remains AMBER/review-due until the complete human
+  reconciliation and its required evidence gates are accepted.
 - **Resolution-matrix rule:** G0 derives model-specific effort support and its single
   exact output slug from the verified `agy models` inventory, agy docs/source, and
   bounded CLI behavior—not from a provider API table or a model-name guess. The
@@ -203,10 +206,11 @@ an earlier implementation because it shares a schema or helper.
 - **Current-behavior correction:** Implementation updates README and AGENTS guidance
   to say that probes must validate documented commands and expected semantic content,
   never an unknown subcommand's exit or usage output. It also records that agy has a
-  real `--effort`, while this wrapper exposes no effort control until G1. G0 records
-  that the public source does not yet prove dual-selector composition: production code
-  sends one resolved model slug and cannot combine an effort-bearing slug with agy's
-  separate effort flag without a later, separately approved evidence gate.
+  real `--effort`, while this wrapper exposes no effort control until G1. Official
+  `1.1.10` source is now available, but the repository has not accepted a human
+  reconciliation proving dual-selector composition: production code sends one
+  resolved model slug and cannot combine an effort-bearing slug with agy's separate
+  effort flag without a later, separately approved evidence gate.
 - **Model option decision gate:** `gemini-3.6-flash-high` is already selectable as a
   raw custom `--tier` label. It remains unranked and non-escalating; no `bulk`/`hard`
   mapping changes and no effort flag are part of G0. Google's official

--- a/tests/test-packaging.sh
+++ b/tests/test-packaging.sh
@@ -22,6 +22,7 @@ import sys
 root = Path(sys.argv[1])
 manifest = json.loads((root / ".codex-plugin/plugin.json").read_text())
 assert manifest["name"] == "codex-agy-worker"
+assert manifest["version"] == "0.2.0"
 assert manifest["skills"] == "./skills/"
 assert manifest["license"] == "MIT"
 assert manifest["interface"]["privacyPolicyURL"].startswith("https://")
@@ -412,13 +413,31 @@ else
     bad "standalone resolver rejects a missing pipeline runtime"
 fi
 
-if grep -Fq 'Google/Gemini' "$ROOT/PRIVACY.md" \
+required_suite_paths=(
+    tests/test-qa-gate.sh
+    tests/test-agy-worker.sh
+    tests/test-update.sh
+    tests/test-reporting.sh
+    tests/test-packaging.sh
+    tests/test-doctor.sh
+    tests/test-proof-demo.sh
+)
+governance_lists_all_suites=1
+for suite in "${required_suite_paths[@]}"; do
+    if ! grep -Fq "./$suite" "$ROOT/CONTRIBUTING.md" \
+            || ! grep -Fq "./$suite" "$ROOT/.github/pull_request_template.md"; then
+        governance_lists_all_suites=0
+    fi
+done
+
+if [[ "$governance_lists_all_suites" == "1" ]] \
+        && grep -Fq 'Google/Gemini' "$ROOT/PRIVACY.md" \
         && grep -Fq 'logs/' "$ROOT/PRIVACY.md" \
         && grep -Fq 'GitHub Issues' "$ROOT/SUPPORT.md" \
         && grep -Fq 'not legal advice' "$ROOT/TERMS.md"; then
-    ok "public policy pages disclose external transfer, local artifacts, and support"
+    ok "governance docs require all seven suites and disclose public policy boundaries"
 else
-    bad "public policy pages disclose external transfer, local artifacts, and support"
+    bad "governance docs require all seven suites and disclose public policy boundaries"
 fi
 
 python3 "$ROOT/scripts/validate-brand-assets.py" "$ROOT/docs/assets/brand" \


### PR DESCRIPTION
## Summary

- bump the Codex package manifest to `0.2.0`
- correct public compatibility wording now that official agy release/source/docs/distribution expose `1.1.10`, while retaining the verified `1.1.9` baseline and disabled model/effort matrix
- require all seven offline suites in contributor and pull-request guidance
- strengthen packaging coverage for exact release version and governance-suite completeness

## Why

Current main contains release-ready user features added after `v0.1.0`, but it was not tag-ready: the manifest still said `0.1.0` and public compatibility text incorrectly said official stable/source remained `1.1.9`.

This prep does not activate G1, claim agy `1.1.10` support, or change runtime behavior.

## Release-ready user features

- self-contained Codex Agent Skill runtime
- GitHub-first, Codex-only distribution
- read-only agy/Codex compatibility watch and scheduled workflow
- bounded official agy distribution-manifest canary
- offline read-only Doctor
- 60-second repository-only proof demo

`v0.2.0` supersedes `v0.1.0` Claude/marketplace distribution claims; those catalogs are no longer maintained.

## Verification

Independent verifier: **ACCEPT** on `54ab63c840561782e756c25b6c1df0149b8b7e10`.

- all seven offline suites: 536 cases
- Bash 3.2 syntax, Python compilation, diff checks
- packaging negative copies reject wrong manifest version and missing doctor/proof checklist entries
- direct proof: exact three lines, exit 0
- fake-tool doctor: expected exit 3 / review-required
- compatibility check/watch: expected exit 3 / drift-review
- actual released `v0.1.0` updater passed a private file-only mirror upgrade to the candidate and installed only into a disposable Codex skill directory
- protected runtime, gate, updater, compatibility baselines, and disabled matrix unchanged

## Release limitations

- verified agy baseline remains `1.1.9`; official `1.1.10` awaits human reconciliation
- model/effort matrix remains disabled; no wrapper `--effort`
- macOS tested; Windows untested
- Doctor/proof are bounded offline evidence, not live acceptance or security certification
- no accepted real `bulk-test-writer` delivery; `diff-reviewer` remains untested live
- public tagged updater transition remains unexercised until an actual release exists
- roadmap Receipt/lifecycle/conformance/reporting/benchmark items are not implemented

## Approval boundary

Ready for review. Merging this PR does not authorize creating the `v0.2.0` tag or GitHub Release; both require separate explicit approval.
