### PR TITLE
Keep agy provider artifacts owner-private

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ an unknown subcommand's exit code or generic usage text as compatibility evidenc
 Keep these counts current when their suites change:
 
 - `qa-gate.sh`: 41 offline cases.
-- `agy-worker.sh` / `install.sh` / `model-recommendation.sh`: 60 offline
+- `agy-worker.sh` / `install.sh` / `model-recommendation.sh`: 77 offline
   fake-agy/routing cases.
 - `update.sh`: 164 offline local-remote/matrix/manifest/watch-policy cases.
 - `bug-report.sh`: 21 offline privacy/fake-`gh` cases.

--- a/README.md
+++ b/README.md
@@ -337,6 +337,20 @@ Personas are injected as prompt text, **not** via agy's `--agent` flag, because
 Worker exits: `0` ok · `2` no prompt · `3` empty output · `4` schema invalid ·
 `5` agy failed · `6` permission gate.
 
+The dispatcher creates each job directory and its task, full prompt, stream, stderr,
+staged prompt, and envelope under an owner-only mask, even when the caller's mask is
+permissive. A missing `AGY_WORKER_LOG_DIR` is created owner-only. An existing final
+log root must be a real directory owned by the current user with no group/other write
+bits; a final symlink is rejected, and the accepted root is resolved physically. The
+dispatcher does not rewrite that caller-owned root or change the caller's umask inside
+agy, so this boundary does not silently change candidate-file permissions. A job ID
+is exclusive: an existing directory, file, or symlink at that job path is rejected
+before the prompt is read or agy is invoked. Oversized staged prompts return to
+owner-only modes after the child, on an early exit, and before HUP, INT, or TERM is
+re-raised with its normal status. This bounded final-root check does not validate the
+full ancestor chain or claim to eliminate every filesystem time-of-check/time-of-use
+race.
+
 ### Model selection is explicit; recommendations are advisory
 
 The dispatcher does not infer difficulty or score the gap between worker output and

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -9,7 +9,7 @@ from Graphify or another indexer.
 ```text
 driver task
   -> model-recommendation.sh --stage pre-dispatch (visible advisory only)
-  -> agy-worker.sh (bounded prompt, sandbox/mode/model, job artifacts)
+  -> agy-worker.sh (bounded prompt, sandbox/mode/model, owner-private job artifacts)
   -> agy (untrusted worker)
   -> structured envelope
   -> skills/agy-worker/runtime/scripts/validate-envelope.py (shape and contract only)
@@ -76,8 +76,8 @@ accept a candidate, replace human diff review, or certify correctness or securit
 
 | Path | Responsibility | Owning offline suite |
 |---|---|---|
-| `agy-worker.sh`, `skills/agy-worker/runtime/agy-worker.sh` | Root compatibility entry plus canonical dispatch, model/mode selection, bounded retries, prompt staging, envelope extraction | `tests/test-agy-worker.sh` (60 cases) |
-| `model-recommendation.sh`, `skills/agy-worker/runtime/model-recommendation.sh`, `skills/agy-worker/runtime/scripts/model-recommendation.py` | Root compatibility entry plus side-effect-free pre-dispatch and post-gate recommendations | `tests/test-agy-worker.sh` (60 cases) |
+| `agy-worker.sh`, `skills/agy-worker/runtime/agy-worker.sh` | Root compatibility entry plus canonical dispatch, model/mode selection, bounded retries, bounded final-log-root validation, exclusive private prompt/log staging with signal cleanup, envelope extraction | `tests/test-agy-worker.sh` (77 cases) |
+| `model-recommendation.sh`, `skills/agy-worker/runtime/model-recommendation.sh`, `skills/agy-worker/runtime/scripts/model-recommendation.py` | Root compatibility entry plus side-effect-free pre-dispatch and post-gate recommendations | `tests/test-agy-worker.sh` (77 cases) |
 | `doctor.sh`, `skills/agy-worker/runtime/doctor.sh`, `skills/agy-worker/runtime/scripts/doctor-metadata.py`, `skills/agy-worker/runtime/compat/` | Root compatibility entry plus deterministic offline prerequisite checks and byte-synchronized portable agy metadata | `tests/test-doctor.sh` (143 cases) plus packaging synchronization checks |
 | `install.sh`, `skills/agy-worker/`, `skills/agy-worker/scripts/resolve-pipeline.sh` | Install and resolve complete-plugin, explicit-checkout, or folder-only skill layouts without fetching code | dispatcher and packaging suites |
 | `skills/agy-worker/runtime/schemas/`, `skills/agy-worker/runtime/scripts/validate-envelope.py` | Dependency-free envelope contract validation | dispatcher and gate suites |
@@ -138,8 +138,14 @@ accept a candidate, replace human diff review, or certify correctness or securit
 ## Generated and private artifacts
 
 - `logs/<job>/` contains the task, full prompt, stream, stderr, staged oversized
-  prompt, and extracted envelope. Treat it as private evidence; do not commit or paste
-  it into reports.
+  prompt, and extracted envelope. The dispatcher creates this job tree owner-only
+  even under a permissive caller umask. A missing log root is created privately; an
+  existing final root must be current-user-owned, non-symlink, and not group/other
+  writable before its physical path is used. The caller-owned root is not rewritten.
+  This final-component check is not full ancestor-chain or TOCTOU protection. Job
+  paths are created exclusively rather than reused, and staged prompt modes are
+  restored on completion, early exit, and handled termination signals. Treat the
+  tree as private evidence; do not commit or paste it into reports.
 - Temporary worktrees, envelopes, updater candidates, and bug drafts normally live
   outside the repository. Preserve accepted work before cleanup; force removal is only
   for deliberately rejected disposable changes.

--- a/docs/lessons_learned.md
+++ b/docs/lessons_learned.md
@@ -91,6 +91,28 @@ over stdin, or use an equally immutable private snapshot. Bind the destination t
 intended public GitHub host, require the exact reviewed SHA-256, and never collect
 prompts, source, envelopes, credentials, private paths, or raw logs automatically.
 
+## Private evidence must be private when created
+
+Prompts, model streams, stderr, and extracted envelopes can contain repository data.
+Set an owner-only process mask before creating dispatcher-owned log directories or
+files; fixing permissions after a write leaves an avoidable disclosure window. A
+custom log root belongs to the caller, so contain each new job under its own private
+directory instead of rewriting that root. Before the first job write, require the
+final existing root itself to be a current-user-owned real directory without
+group/other write bits, then use its physical path. Create a missing root under the
+private mask. This is a bounded final-component invariant, not proof that every
+ancestor is safe or that all filesystem TOCTOU races are eliminated. Create the job
+directory atomically and fail closed when its path already names a directory, file,
+or symlink; reusing an attacker-prepared path defeats creation-time permissions.
+
+Do not let log hardening alter candidate-file behavior. Restore the caller's mask
+only inside the untrusted worker child while keeping the shell-owned redirections
+private. An oversized staged prompt may need its proven read-only access modes during
+agy execution, but it must stay below a non-traversable job parent and return to
+owner-only modes immediately afterward. Restore those modes from the normal child
+return path and an EXIT trap; HUP, INT, and TERM handlers must restore first and then
+re-raise the same signal so cleanup does not turn termination into success.
+
 ## Model routing is explicit
 
 The caller selects the tier. Built-in retries reuse the same model; gate failures do

--- a/skills/agy-worker/runtime/agy-worker.sh
+++ b/skills/agy-worker/runtime/agy-worker.sh
@@ -19,6 +19,12 @@
 #   * Therefore: exit code 0 proves nothing. Empty stdout is a FAILURE. See classify().
 set -euo pipefail
 
+# Prompts, streams, stderr, and envelopes can contain private repository content.
+# Create dispatcher-owned artifacts under a private mask regardless of the caller's
+# umask. The agy child gets the caller's mask back so target-file behavior is stable.
+CALLER_UMASK="$(umask)"
+umask 077
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCHEMA="${AGY_WORKER_SCHEMA:-$SCRIPT_DIR/schemas/worker-result.schema.json}"
 LOG_DIR="${AGY_WORKER_LOG_DIR:-$SCRIPT_DIR/logs}"
@@ -30,6 +36,27 @@ mode="${AGY_WORKER_MODE:-plan}"               # plan | accept-edits  (rec: plan 
 print_timeout="${AGY_WORKER_TIMEOUT:-5m0s}"
 max_attempts="${AGY_WORKER_MAX_ATTEMPTS:-2}"  # bounded retries, then fail closed (rec #11)
 job_id="${AGY_WORKER_JOB_ID:-job-$$}"
+
+validate_log_root() {
+    python3 - "$1" <<'PY'
+import os
+import stat
+import sys
+
+try:
+    metadata = os.lstat(sys.argv[1])
+except OSError:
+    raise SystemExit(1)
+mode = stat.S_IMODE(metadata.st_mode)
+valid = (
+    not stat.S_ISLNK(metadata.st_mode)
+    and stat.S_ISDIR(metadata.st_mode)
+    and metadata.st_uid == os.geteuid()
+    and (mode & 0o022) == 0
+)
+raise SystemExit(0 if valid else 1)
+PY
+}
 
 usage() {
     cat >&2 <<'EOF'
@@ -101,12 +128,22 @@ if [[ "$mode" != "plan" && ( "$persona" == "repo-inventory" || "$persona" == "di
     exit 64
 fi
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" 2>/dev/null || {
+    echo "agy-worker.sh: log root cannot be created safely" >&2
+    exit 64
+}
+if ! validate_log_root "$LOG_DIR"; then
+    echo "agy-worker.sh: log root must be an owner-owned, non-writable real directory" >&2
+    exit 64
+fi
 # agy operates on its CWD as the workspace, so the dispatcher must actually move
 # there. LOG_DIR is resolved to an absolute path first: it defaults to a path under
 # SCRIPT_DIR, but a caller-supplied relative AGY_WORKER_LOG_DIR would otherwise
 # silently follow us into the worktree and scatter artifacts.
-LOG_DIR="$(cd "$LOG_DIR" && pwd)"
+if ! LOG_DIR="$(CDPATH= cd -- "$LOG_DIR" 2>/dev/null && pwd -P)"; then
+    echo "agy-worker.sh: log root cannot be resolved safely" >&2
+    exit 64
+fi
 [[ -f "$SCHEMA" ]] || { echo "agy-worker.sh: schema not found: $SCHEMA" >&2; exit 64; }
 SCHEMA="$(cd "$(dirname "$SCHEMA")" && pwd)/$(basename "$SCHEMA")"
 [[ -d "$workdir" ]] || { echo "agy-worker.sh: --workdir not a directory: $workdir" >&2; exit 64; }
@@ -129,7 +166,10 @@ fi
 cd "$workdir"
 
 job_dir="$LOG_DIR/$job_id"
-mkdir -p "$job_dir"
+if ! mkdir "$job_dir" 2>/dev/null; then
+    echo "agy-worker.sh: job artifact path already exists or cannot be created: $job_id" >&2
+    exit 64
+fi
 stdout_file="$job_dir/stream.ndjson"
 stderr_file="$job_dir/stderr.txt"
 prompt_file="$job_dir/task.txt"
@@ -137,6 +177,26 @@ full_prompt_file="$job_dir/full-prompt.txt"
 envelope_file="$job_dir/envelope.json"
 staged_dir="$job_dir/staged"
 staged_prompt_file="$staged_dir/full-prompt.txt"
+
+restore_staged_permissions() {
+    if [[ -d "$staged_dir" ]]; then
+        chmod 0700 "$staged_dir" 2>/dev/null || true
+        [[ ! -f "$staged_prompt_file" ]] || chmod 0600 "$staged_prompt_file" 2>/dev/null || true
+    fi
+}
+
+handle_signal() {
+    local signal="$1" status="$2"
+    restore_staged_permissions
+    trap - "$signal"
+    kill -s "$signal" "$$"
+    exit "$status"
+}
+
+trap 'restore_staged_permissions' EXIT
+trap 'handle_signal HUP 129' HUP
+trap 'handle_signal INT 130' INT
+trap 'handle_signal TERM 143' TERM
 
 # --- read the task -----------------------------------------------------------
 # stdin is consumed once; cache it so a retry can replay it verbatim.
@@ -206,8 +266,7 @@ build_cmd() {
     if (( ${#full_prompt} > 100000 )); then
         # The automatic out-of-repo root contains only one read-only staged prompt.
         # Logs and envelopes remain outside agy's granted roots.
-        [[ -d "$staged_dir" ]] && chmod 0755 "$staged_dir"
-        [[ -f "$staged_prompt_file" ]] && chmod 0644 "$staged_prompt_file"
+        restore_staged_permissions
         mkdir -p "$staged_dir"
         printf '%s' "$full_prompt" > "$staged_prompt_file"
         chmod 0444 "$staged_prompt_file"
@@ -298,12 +357,12 @@ while (( attempt <= max_attempts )); do
     build_cmd
     : > "$stdout_file"; : > "$stderr_file"
     set +e
-    "${cmd[@]}" > "$stdout_file" 2> "$stderr_file" < /dev/null
+    (
+        umask "$CALLER_UMASK"
+        exec "${cmd[@]}"
+    ) > "$stdout_file" 2> "$stderr_file" < /dev/null
     agy_rc=$?
-    if [[ -d "$staged_dir" ]]; then
-        chmod 0755 "$staged_dir"
-        [[ -f "$staged_prompt_file" ]] && chmod 0644 "$staged_prompt_file"
-    fi
+    restore_staged_permissions
     classify "$agy_rc"
     verdict=$?
     set -e

--- a/tests/test-agy-worker.sh
+++ b/tests/test-agy-worker.sh
@@ -73,8 +73,55 @@ expect_recommendation_reject() {
         bad "$name (exit $rc, wanted 64 with empty stdout)"
     fi
 }
+private_tree_is_private() {
+    python3 - "$1" <<'PY'
+import os
+import stat
+import sys
+
+root = sys.argv[1]
+paths = [root]
+for current, directories, files in os.walk(root, followlinks=False):
+    paths.extend(os.path.join(current, name) for name in directories + files)
+for path in paths:
+    mode = stat.S_IMODE(os.lstat(path).st_mode)
+    if mode & 0o077:
+        print(f"non-private artifact: {path} mode={mode:04o}", file=sys.stderr)
+        raise SystemExit(1)
+PY
+}
+mode_is() {
+    python3 - "$1" "$2" <<'PY'
+import os
+import stat
+import sys
+
+actual = stat.S_IMODE(os.lstat(sys.argv[1]).st_mode)
+expected = int(sys.argv[2], 8)
+raise SystemExit(0 if actual == expected else 1)
+PY
+}
+log_root_is_acceptable() {
+    python3 - "$1" <<'PY'
+import os
+import stat
+import sys
+
+metadata = os.lstat(sys.argv[1])
+mode = stat.S_IMODE(metadata.st_mode)
+valid = (
+    not stat.S_ISLNK(metadata.st_mode)
+    and stat.S_ISDIR(metadata.st_mode)
+    and metadata.st_uid == os.geteuid()
+    and (mode & 0o022) == 0
+)
+raise SystemExit(0 if valid else 1)
+PY
+}
 
 mkdir -p "$TMP/bin" "$TMP/repo" "$TMP/logs"
+chmod 0755 "$TMP/logs"
+LOGS_REAL="$(cd "$TMP/logs" && pwd -P)"
 cat > "$TMP/bin/agy" <<'FAKE'
 #!/usr/bin/env bash
 set -u
@@ -107,6 +154,16 @@ if [[ "${FAKE_TRY_STAGE_WRITE:-0}" == "1" && -n "$stage_dir" ]]; then
         printf 'blocked' > "$FAKE_STAGE_RESULT_FILE"
     fi
 fi
+if [[ -n "${FAKE_CALLED_FILE:-}" ]]; then
+    : > "$FAKE_CALLED_FILE"
+fi
+if [[ -n "${FAKE_SIGNAL_PARENT:-}" ]]; then
+    kill -s "$FAKE_SIGNAL_PARENT" "$PPID"
+    exit "${FAKE_EXIT_CODE:-23}"
+fi
+if [[ "${FAKE_EXIT_CODE:-0}" != "0" ]]; then
+    exit "$FAKE_EXIT_CODE"
+fi
 status="${FAKE_AGY_STATUS:-SUCCESS}"
 if [[ "${FAKE_BAD_ENVELOPE:-0}" == "1" ]]; then
     envelope='{"status":"completed","summary":"done","files_changed":[],"commands_run":[],"tests_run":[],"risks":[],"open_questions":[],"confidence":9,"requires_human":false}'
@@ -120,7 +177,7 @@ chmod +x "$TMP/bin/agy"
 run_worker() {
     local job="$1"; shift
     PATH="$TMP/bin:$PATH" \
-    AGY_WORKER_LOG_DIR="$TMP/logs" \
+    AGY_WORKER_LOG_DIR="${AGY_TEST_LOG_DIR:-$TMP/logs}" \
     AGY_WORKER_JOB_ID="$job" \
     FAKE_MODEL_FILE="$TMP/$job.model" \
     FAKE_PROMPT_FILE="$TMP/$job.prompt" \
@@ -128,7 +185,10 @@ run_worker() {
     FAKE_ARGV_FILE="$TMP/$job.argv" \
     FAKE_STAGE_RESULT_FILE="$TMP/$job.stage-result" \
     FAKE_TRY_STAGE_WRITE="${FAKE_TRY_STAGE_WRITE:-0}" \
-    "$WORKER" --workdir "$TMP/repo" "$@"
+    FAKE_CALLED_FILE="$TMP/$job.called" \
+    FAKE_SIGNAL_PARENT="${FAKE_SIGNAL_PARENT:-}" \
+    FAKE_EXIT_CODE="${FAKE_EXIT_CODE:-0}" \
+    "${AGY_TEST_WORKER:-$WORKER}" --workdir "$TMP/repo" "$@"
 }
 
 echo "agy-worker.sh offline test suite"
@@ -182,6 +242,210 @@ else
     bad "root wrapper treats an empty log override as the historical root logs default"
 fi
 
+PRIVATE_LOG_022="$TMP/existing-log-022"
+mkdir -p "$PRIVATE_LOG_022"
+chmod 0755 "$PRIVATE_LOG_022"
+(
+    umask 022
+    printf 'private artifacts under umask 022\n' | \
+        AGY_TEST_LOG_DIR="$PRIVATE_LOG_022" run_worker private-022
+) > "$TMP/private-022.out" 2>/dev/null
+rc=$?
+if [[ "$rc" == "0" ]] \
+        && mode_is "$PRIVATE_LOG_022" 0755 \
+        && log_root_is_acceptable "$PRIVATE_LOG_022" \
+        && private_tree_is_private "$PRIVATE_LOG_022/private-022"; then
+    ok "dispatcher keeps a new job private under umask 022 and a traversable custom log root"
+else
+    bad "dispatcher keeps a new job private under umask 022 and a traversable custom log root"
+fi
+
+PRIVATE_LOG_000="$TMP/existing-log-000"
+mkdir -p "$PRIVATE_LOG_000"
+chmod 0755 "$PRIVATE_LOG_000"
+(
+    umask 000
+    printf 'private artifacts under umask 000\n' | \
+        AGY_TEST_LOG_DIR="$PRIVATE_LOG_000" run_worker private-000
+) > "$TMP/private-000.out" 2>/dev/null
+rc=$?
+if [[ "$rc" == "0" ]] \
+        && mode_is "$PRIVATE_LOG_000" 0755 \
+        && log_root_is_acceptable "$PRIVATE_LOG_000" \
+        && mode_is "$TMP/private-000.model" 0666 \
+        && private_tree_is_private "$PRIVATE_LOG_000/private-000"; then
+    ok "dispatcher keeps artifacts private under umask 000 without changing the agy child umask"
+else
+    bad "dispatcher keeps artifacts private under umask 000 without changing the agy child umask"
+fi
+
+MISSING_LOG_ROOT="$TMP/missing-log-root"
+(
+    umask 000
+    printf 'create a private log root\n' | \
+        AGY_TEST_LOG_DIR="$MISSING_LOG_ROOT" run_worker missing-log-root
+) > "$TMP/missing-log-root.out" 2>/dev/null
+rc=$?
+if [[ "$rc" == "0" ]] \
+        && mode_is "$MISSING_LOG_ROOT" 0700 \
+        && log_root_is_acceptable "$MISSING_LOG_ROOT" \
+        && private_tree_is_private "$MISSING_LOG_ROOT/missing-log-root"; then
+    ok "a missing custom log root is created owner-only under caller umask 000"
+else
+    bad "a missing custom log root is created owner-only under caller umask 000"
+fi
+
+invalid_root_index=0
+for invalid_root_mode in 0777 0775; do
+    invalid_root_index=$((invalid_root_index+1))
+    invalid_root="$TMP/invalid-root-$invalid_root_index"
+    invalid_job="invalid-root-$invalid_root_index"
+    mkdir -p "$invalid_root"
+    chmod "$invalid_root_mode" "$invalid_root"
+    printf 'root sentinel %s\n' "$invalid_root_mode" > "$invalid_root/sentinel"
+    printf 'must reject writable log root\n' | \
+        AGY_TEST_LOG_DIR="$invalid_root" run_worker "$invalid_job" \
+        > "$TMP/$invalid_job.out" 2>/dev/null
+    rc=$?
+    if [[ "$rc" == "64" ]] \
+            && [[ "$(<"$invalid_root/sentinel")" == "root sentinel $invalid_root_mode" ]] \
+            && [[ ! -e "$invalid_root/$invalid_job" ]] \
+            && [[ ! -e "$TMP/$invalid_job.called" ]]; then
+        ok "mode $invalid_root_mode log root is rejected before prompt staging or agy"
+    else
+        bad "mode $invalid_root_mode log root is rejected before prompt staging or agy"
+    fi
+done
+
+SYMLINK_LOG_TARGET="$TMP/symlink-log-target"
+SYMLINK_LOG_ROOT="$TMP/symlink-log-root"
+mkdir -p "$SYMLINK_LOG_TARGET"
+chmod 0755 "$SYMLINK_LOG_TARGET"
+printf 'symlink root sentinel\n' > "$SYMLINK_LOG_TARGET/sentinel"
+ln -s "$SYMLINK_LOG_TARGET" "$SYMLINK_LOG_ROOT"
+printf 'must reject symlink log root\n' | \
+    AGY_TEST_LOG_DIR="$SYMLINK_LOG_ROOT" run_worker symlink-log-root \
+    > "$TMP/symlink-log-root.out" 2>/dev/null
+rc=$?
+if [[ "$rc" == "64" ]] \
+        && [[ "$(<"$SYMLINK_LOG_TARGET/sentinel")" == "symlink root sentinel" ]] \
+        && [[ ! -e "$SYMLINK_LOG_TARGET/symlink-log-root" ]] \
+        && [[ ! -e "$TMP/symlink-log-root.called" ]]; then
+    ok "symlink log root is rejected before prompt staging or agy"
+else
+    bad "symlink log root is rejected before prompt staging or agy"
+fi
+
+WEAK_ROOT_POLICY="$TMP/weak-root-policy"
+mkdir -p "$WEAK_ROOT_POLICY"
+cp -R "$ROOT/skills/agy-worker" "$WEAK_ROOT_POLICY/agy-worker"
+python3 - "$WEAK_ROOT_POLICY/agy-worker/runtime/agy-worker.sh" <<'PY'
+import sys
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as handle:
+    source = handle.read()
+old = 'if ! validate_log_root "$LOG_DIR"; then'
+new = 'if ! true; then  # TEST MUTATION: final log-root policy bypassed'
+if source.count(old) != 1:
+    raise SystemExit("expected exactly one final log-root policy call")
+with open(path, "w", encoding="utf-8") as handle:
+    handle.write(source.replace(old, new, 1))
+PY
+WEAK_ROOT_POLICY_LOG="$TMP/weak-root-policy-log"
+mkdir -p "$WEAK_ROOT_POLICY_LOG"
+chmod 0777 "$WEAK_ROOT_POLICY_LOG"
+printf 'mutation must be caught\n' | \
+    AGY_TEST_WORKER="$WEAK_ROOT_POLICY/agy-worker/runtime/agy-worker.sh" \
+    AGY_TEST_LOG_DIR="$WEAK_ROOT_POLICY_LOG" run_worker weak-root-policy \
+    > "$TMP/weak-root-policy.out" 2>/dev/null
+rc=$?
+if [[ "$rc" == "0" ]] \
+        && [[ -e "$TMP/weak-root-policy.called" ]] \
+        && private_tree_is_private "$WEAK_ROOT_POLICY_LOG/weak-root-policy" \
+        && ! log_root_is_acceptable "$WEAK_ROOT_POLICY_LOG" 2>/dev/null; then
+    ok "log-root acceptance rejects a runtime with final-root validation bypassed"
+else
+    bad "log-root acceptance rejects a runtime with final-root validation bypassed"
+fi
+
+WEAK_UMASK_ROOT="$TMP/weak-umask"
+mkdir -p "$WEAK_UMASK_ROOT"
+cp -R "$ROOT/skills/agy-worker" "$WEAK_UMASK_ROOT/agy-worker"
+python3 - "$WEAK_UMASK_ROOT/agy-worker/runtime/agy-worker.sh" <<'PY'
+import sys
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as handle:
+    source = handle.read()
+old = 'CALLER_UMASK="$(umask)"\numask 077\n'
+new = 'CALLER_UMASK="$(umask)"\n# TEST MUTATION: private creation mask removed.\n'
+if source.count(old) != 1:
+    raise SystemExit("expected exactly one private-mask block")
+with open(path, "w", encoding="utf-8") as handle:
+    handle.write(source.replace(old, new, 1))
+PY
+WEAK_UMASK_LOG="$TMP/weak-umask-log"
+mkdir -p "$WEAK_UMASK_LOG"
+chmod 0755 "$WEAK_UMASK_LOG"
+(
+    umask 000
+    printf 'mutation must be caught\n' | \
+        AGY_TEST_WORKER="$WEAK_UMASK_ROOT/agy-worker/runtime/agy-worker.sh" \
+        AGY_TEST_LOG_DIR="$WEAK_UMASK_LOG" run_worker weak-umask
+) > "$TMP/weak-umask.out" 2>/dev/null
+rc=$?
+if [[ "$rc" == "0" ]] \
+        && ! private_tree_is_private "$WEAK_UMASK_LOG/weak-umask" 2>/dev/null; then
+    ok "privacy acceptance rejects a runtime with the private creation mask removed"
+else
+    bad "privacy acceptance rejects a runtime with the private creation mask removed"
+fi
+
+COLLISION_LOG="$TMP/collision-log"
+mkdir -p "$COLLISION_LOG/existing-dir" "$TMP/symlink-target"
+chmod 0755 "$COLLISION_LOG"
+printf 'directory sentinel\n' > "$COLLISION_LOG/existing-dir/sentinel"
+printf 'file sentinel\n' > "$COLLISION_LOG/existing-file"
+printf 'symlink sentinel\n' > "$TMP/symlink-target/sentinel"
+ln -s "$TMP/symlink-target" "$COLLISION_LOG/existing-link"
+
+printf 'must reject existing directory\n' | \
+    AGY_TEST_LOG_DIR="$COLLISION_LOG" run_worker existing-dir \
+    > "$TMP/existing-dir.out" 2>/dev/null
+rc=$?
+if [[ "$rc" == "64" ]] \
+        && [[ "$(<"$COLLISION_LOG/existing-dir/sentinel")" == "directory sentinel" ]] \
+        && [[ ! -e "$TMP/existing-dir.called" ]]; then
+    ok "pre-existing job directory is rejected before invoking agy or touching its sentinel"
+else
+    bad "pre-existing job directory is rejected before invoking agy or touching its sentinel"
+fi
+
+printf 'must reject existing file\n' | \
+    AGY_TEST_LOG_DIR="$COLLISION_LOG" run_worker existing-file \
+    > "$TMP/existing-file.out" 2>/dev/null
+rc=$?
+if [[ "$rc" == "64" ]] \
+        && [[ "$(<"$COLLISION_LOG/existing-file")" == "file sentinel" ]] \
+        && [[ ! -e "$TMP/existing-file.called" ]]; then
+    ok "pre-existing job file is rejected before invoking agy or touching its sentinel"
+else
+    bad "pre-existing job file is rejected before invoking agy or touching its sentinel"
+fi
+
+printf 'must reject existing symlink\n' | \
+    AGY_TEST_LOG_DIR="$COLLISION_LOG" run_worker existing-link \
+    > "$TMP/existing-link.out" 2>/dev/null
+rc=$?
+if [[ "$rc" == "64" ]] \
+        && [[ "$(<"$TMP/symlink-target/sentinel")" == "symlink sentinel" ]] \
+        && [[ ! -e "$TMP/existing-link.called" ]]; then
+    ok "pre-existing job symlink is rejected before invoking agy or touching its target"
+else
+    bad "pre-existing job symlink is rejected before invoking agy or touching its target"
+fi
+
 printf 'must not edit\n' | run_worker readonly --mode accept-edits --persona diff-reviewer > "$TMP/readonly.out" 2>/dev/null
 rc=$?
 expect_exit "read-only persona rejects accept-edits" 64 "$rc"
@@ -216,13 +480,13 @@ if grep -q 'OVERSIZED_TASK_MARKER' "$TMP/logs/oversized/full-prompt.txt" \
 else
     bad "oversized staged prompt preserves task and persona"
 fi
-if grep -Fxq "$TMP/logs/oversized/staged" "$TMP/oversized.dirs" \
-        && ! grep -Fxq "$TMP/logs" "$TMP/oversized.dirs"; then
+if grep -Fxq "$LOGS_REAL/oversized/staged" "$TMP/oversized.dirs" \
+        && ! grep -Fxq "$LOGS_REAL" "$TMP/oversized.dirs"; then
     ok "oversized job grants only its staged prompt directory"
 else
     bad "oversized job grants only its staged prompt directory"
 fi
-if grep -Fq "$TMP/logs/oversized/staged/full-prompt.txt" "$TMP/oversized.prompt"; then
+if grep -Fq "$LOGS_REAL/oversized/staged/full-prompt.txt" "$TMP/oversized.prompt"; then
     ok "oversized dispatch points agy at the complete staged prompt"
 else
     bad "oversized dispatch points agy at the complete staged prompt"
@@ -232,7 +496,84 @@ if [[ "$(<"$TMP/oversized.stage-result")" == "blocked" ]]; then
 else
     bad "oversized staged prompt is read-only during agy execution"
 fi
+if private_tree_is_private "$TMP/logs/oversized"; then
+    ok "oversized staged prompt is private again after agy returns"
+else
+    bad "oversized staged prompt is private again after agy returns"
+fi
 expect_print_last "oversized prompt keeps --print and its value last" "$TMP/oversized.argv"
+
+WEAK_RESTORE_ROOT="$TMP/weak-restore"
+mkdir -p "$WEAK_RESTORE_ROOT"
+cp -R "$ROOT/skills/agy-worker" "$WEAK_RESTORE_ROOT/agy-worker"
+python3 - "$WEAK_RESTORE_ROOT/agy-worker/runtime/agy-worker.sh" <<'PY'
+import sys
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as handle:
+    source = handle.read()
+replacements = (
+    (
+        'chmod 0700 "$staged_dir" 2>/dev/null || true',
+        'chmod 0755 "$staged_dir" 2>/dev/null || true',
+    ),
+    (
+        'chmod 0600 "$staged_prompt_file" 2>/dev/null || true',
+        'chmod 0644 "$staged_prompt_file" 2>/dev/null || true',
+    ),
+)
+for old, new in replacements:
+    if source.count(old) != 1:
+        raise SystemExit(f"expected exactly one restore statement: {old}")
+    source = source.replace(old, new, 1)
+with open(path, "w", encoding="utf-8") as handle:
+    handle.write(source)
+PY
+WEAK_RESTORE_LOG="$TMP/weak-restore-log"
+mkdir -p "$WEAK_RESTORE_LOG"
+chmod 0755 "$WEAK_RESTORE_LOG"
+AGY_TEST_WORKER="$WEAK_RESTORE_ROOT/agy-worker/runtime/agy-worker.sh" \
+    AGY_TEST_LOG_DIR="$WEAK_RESTORE_LOG" \
+    run_worker weak-restore < "$TMP/large-task.txt" \
+    > "$TMP/weak-restore.out" 2>/dev/null
+rc=$?
+if [[ "$rc" == "0" ]] \
+        && ! private_tree_is_private "$WEAK_RESTORE_LOG/weak-restore" 2>/dev/null; then
+    ok "privacy acceptance rejects a runtime that restores staged artifacts publicly"
+else
+    bad "privacy acceptance rejects a runtime that restores staged artifacts publicly"
+fi
+
+FAKE_EXIT_CODE=23 AGY_WORKER_MAX_ATTEMPTS=1 \
+    run_worker staged-early-exit < "$TMP/large-task.txt" \
+    > "$TMP/staged-early-exit.out" 2>/dev/null
+rc=$?
+if [[ "$rc" == "5" ]] && private_tree_is_private "$TMP/logs/staged-early-exit"; then
+    ok "failed oversized child restores staged artifacts before the wrapper exits"
+else
+    bad "failed oversized child restores staged artifacts before the wrapper exits"
+fi
+
+signal_index=0
+for signal_name in HUP INT TERM; do
+    signal_index=$((signal_index+1))
+    case "$signal_name" in
+        HUP) expected_signal_rc=129 ;;
+        INT) expected_signal_rc=130 ;;
+        TERM) expected_signal_rc=143 ;;
+    esac
+    signal_job="staged-signal-$signal_index"
+    FAKE_SIGNAL_PARENT="$signal_name" FAKE_EXIT_CODE=23 AGY_WORKER_MAX_ATTEMPTS=1 \
+        run_worker "$signal_job" < "$TMP/large-task.txt" \
+        > "$TMP/$signal_job.out" 2>/dev/null
+    rc=$?
+    if [[ "$rc" == "$expected_signal_rc" ]] \
+            && private_tree_is_private "$TMP/logs/$signal_job"; then
+        ok "$signal_name restores staged artifacts and preserves signal exit semantics"
+    else
+        bad "$signal_name restores staged artifacts and preserves signal exit semantics"
+    fi
+done
 
 printf 'terminal failure\n' | PATH="$TMP/bin:$PATH" \
     AGY_WORKER_LOG_DIR="$TMP/logs" AGY_WORKER_JOB_ID=terminal \


### PR DESCRIPTION
## Summary

- create dispatcher-owned task, prompt, stream, stderr, staged-prompt, and envelope artifacts under an owner-only mask
- validate and physically resolve the final log root before writing
- reject unsafe final roots and pre-existing job paths before reading the prompt or invoking agy
- preserve the caller's original umask inside the agy child so candidate-file permissions do not change
- restore oversized staged-prompt artifacts to owner-only modes after normal return, early failure, HUP, INT, and TERM
- document the privacy boundary and update the dispatcher suite count from 60 to 77

## Security issue

Provider artifacts can contain prompts, repository content, model streams, stderr, and structured envelopes. Previously, their creation followed the caller's umask and job directories could be reused. Under a permissive local filesystem configuration, this could expose private evidence to other local users or allow a pre-existing job path to influence artifact placement.

This change makes privacy a creation-time invariant at the dispatcher-owned job boundary instead of repairing permissions after data has already been written.

## Exact behavior

- The dispatcher records the caller's umask and switches to `077` before creating its artifacts.
- A missing log root is created owner-only.
- An existing final log root must be a real directory owned by the current user and must not be group- or other-writable.
- A final log-root symlink is rejected, and accepted roots are resolved to physical paths.
- Each job directory is created exclusively; an existing directory, file, or symlink at that path fails closed with exit `64` before prompt staging or agy invocation.
- agy runs in a child subshell with the caller's original umask, preserving target-file behavior.
- An oversized prompt remains read-only while agy needs access, then returns to directory mode `0700` and file mode `0600`.
- Early child failure and handled HUP, INT, and TERM restore private modes before preserving the expected failure or signal status.
- `qa-gate.sh`, model selection, recommendation behavior, retries, and gate authority are unchanged.

## Verification

Independent verification: **ACCEPT**

Offline suites:

- `tests/test-qa-gate.sh`: 41/41
- `tests/test-agy-worker.sh`: 77/77
- `tests/test-update.sh`: 164/164, including 64 manifest cases
- `tests/test-reporting.sh`: 21/21
- `tests/test-packaging.sh`: 86/86
- `tests/test-doctor.sh`: 143/143
- `tests/test-proof-demo.sh`: 21/21

Additional checks:

- Bash 3.2 syntax checks passed
- Python compilation checks passed
- `git diff --check` passed
- `agents-md-auditor`: A, 98/100; root `AGENTS.md` remains 8,681 bytes

The dispatcher tests include positive and mutation/rejection coverage for permissive caller umasks, missing and existing roots, writable and symlink roots, job-path collisions, child-umask preservation, oversized prompt restoration, early failure, and HUP/INT/TERM handling.

## Limitations

- Validation covers the final log-root component; it does not validate the full ancestor chain.
- This does not claim to eliminate every filesystem time-of-check/time-of-use race.
- Caller-owned log roots and their ancestors are not rewritten.
- Passing tests and independent review are not a general security certification.
- This PR makes no claim about provider quality, cost, reliability, model ranking, authentication, or silent backend fallback.
- No raw provider prompt, stream, stderr, envelope, private path, credential, or synthetic-call artifact is included.
