### PR TITLE
Add durable evidence receipts

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,7 @@
 <!-- Include exact summaries; mark unrun checks and explain why. -->
 
 - [ ] `./tests/test-qa-gate.sh`
+- [ ] `./tests/test-evidence-receipt.sh`
 - [ ] `./tests/test-agy-worker.sh`
 - [ ] `./tests/test-update.sh`
 - [ ] `./tests/test-reporting.sh`

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,9 @@ jobs:
       - name: qa-gate suite
         run: ./tests/test-qa-gate.sh
 
+      - name: Evidence Receipt v1 suite
+        run: ./tests/test-evidence-receipt.sh
+
       - name: dispatcher suite
         run: ./tests/test-agy-worker.sh
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,13 +35,14 @@ an unknown subcommand's exit code or generic usage text as compatibility evidenc
 Keep these counts current when their suites change:
 
 - `qa-gate.sh`: 41 offline cases.
+- Evidence Receipt v1: 88 offline gate-protocol/publication/privacy cases.
 - `agy-worker.sh` / `install.sh` / model selection and recommendation: 209 offline
   fake-agy/routing cases.
 - `update.sh`: 175 offline local-remote/matrix/manifest/watch-policy cases.
 - `bug-report.sh`: 21 offline privacy/fake-`gh` cases.
-- Codex package/skill distribution: 114 offline
+- Codex package/skill distribution: 135 offline
   manifest/runtime-copy/relocation/landing cases.
-- `doctor.sh`: 163 offline fake-tool/read-only cases.
+- `doctor.sh`: 180 offline fake-tool/read-only cases.
 - `proof-demo.sh`: 21 offline synthetic-boundary cases.
 
 Real runs prove one bounded edit, the complete `codex exec` pipeline, the combined
@@ -59,6 +60,7 @@ coverage is offline, partial, or absent as described in `README.md`.
 
 ```bash
 ./tests/test-qa-gate.sh        # offline, no agy, no network — must stay that way
+./tests/test-evidence-receipt.sh # offline receipt/protocol/publication coverage
 ./tests/test-agy-worker.sh      # offline fake-agy dispatcher/installer coverage
 ./tests/test-update.sh          # offline local Git remotes; no public fetch
 ./tests/test-reporting.sh       # offline fake-gh privacy/submission coverage
@@ -102,6 +104,13 @@ only a passing test has not been shown to catch anything.
   not the repo. File tools do reach the repo. Never ask a worker to run shell commands.
 - **Never execute `commands_run` or `tests_run` from the envelope.** They are worker
   claims. The gate accepts executable input only through driver-owned `--verify`.
+- **A receipt records the gate; it is not another gate.** Keep `qa-gate.sh` as the
+  sole outcome authority, publish only outside the audited repository without
+  overwrite, keep its internal evidence FD out of verifier descendants, and strip
+  shell/Python startup hooks on the wrapper-bound evidence path. Close that FD in the
+  existing gate process before any verifier shell or interpreter starts. Cleanly abort
+  the whole receipt operation on HUP/INT/TERM. Receipts remain unsigned and subject
+  to human diff review.
 - **`update.sh check` may need network, but must remain read-only.** Compatibility
   evidence for agy and Codex is reported as unchanged, drift-review, or
   evidence-unavailable; inconclusive evidence is never green. Metadata changes only

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,7 @@ Run the offline suites and static checks before requesting review:
 
 ```bash
 ./tests/test-qa-gate.sh
+./tests/test-evidence-receipt.sh
 ./tests/test-agy-worker.sh
 ./tests/test-update.sh
 ./tests/test-reporting.sh
@@ -30,7 +31,12 @@ Run the offline suites and static checks before requesting review:
 ./tests/test-doctor.sh
 ./tests/test-proof-demo.sh
 bash -n ./*.sh tests/*.sh skills/*/scripts/*.sh skills/*/runtime/*.sh
-python3 -m py_compile scripts/*.py skills/*/runtime/scripts/*.py
+(
+  AGY_WORKER_PYCACHE="$(mktemp -d -t agyworker-pycache.XXXXXX)" || exit 1
+  trap 'rm -rf -- "$AGY_WORKER_PYCACHE"' EXIT
+  PYTHONPYCACHEPREFIX="$AGY_WORKER_PYCACHE" \
+    python3 -m py_compile scripts/*.py skills/*/runtime/scripts/*.py
+)
 git diff --check
 ```
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -7,8 +7,9 @@ not a claim about every version or configuration of the third-party tools it cal
 ## What the project itself does
 
 The repository does not operate a hosted service, collect analytics, or send
-telemetry on its own. Model-tier recommendations and all offline test suites run
-locally. Installing the skill copies its public workflow files and a local pointer to
+telemetry on its own. Model-tier recommendations, Evidence Receipt v1 creation and
+validation, and all offline test suites run locally without a network or provider.
+Installing the skill copies its public workflow files and a local pointer to
 the checkout; it does not contact a network service or change agy or Codex
 configuration.
 
@@ -35,6 +36,22 @@ full prompt, agy stream, stderr, staged oversized prompt, and extracted envelope
 Temporary worktrees and envelopes may also exist outside the repository. Sanitized
 bug-report drafts are local files with mode `0600` until a user explicitly confirms
 the exact SHA-256 and submits them.
+
+When explicitly requested, `verify-job.sh` creates one local receipt at a new path the
+user chose in an owner-private directory outside the audited repository. It records
+the immutable base; SHA-256 hashes of the exact envelope snapshot, ordered path
+policy, verifier commands, and candidate states; bounded gate outcome labels; and,
+when supplied, the validated caller model/tier selection and canonical pre-dispatch
+advisory (including its rationale, controlled evidence, and relative cost statement).
+It does not store source or diff content, repository paths, prompts, worker prose,
+raw logs, verifier commands or output, credentials, provider telemetry, or pricing.
+Receipts are mode `0600`, unsigned, not self-authenticating, and never uploaded by
+this command. The internal gate evidence descriptor is closed before any verifier
+shell or interpreter starts. The wrapper removes executable shell/Python startup
+controls only from the evidence-mode gate and verifier environment; it does not read
+or modify the caller's configuration. Handled HUP, INT, and TERM interruptions remove
+wrapper-owned snapshot, handoff, temporary, and partial receipt files. The user
+controls durable receipt retention just like other local artifacts.
 
 The project does not delete these artifacts automatically. The person running the
 tool controls retention and should review and remove unneeded artifacts according to

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ text, and it hashes the Git diff plus every nontracked path—including ignored 
 before and after verification so a passing verifier cannot silently rewrite the
 candidate.
 
-The seven offline suites need no agy process, network access, API key, or GitHub login.
+The eight offline suites need no agy process, network access, API key, or GitHub login.
 
 ## See the evidence boundary in under a minute
 
@@ -463,6 +463,64 @@ Gate controls:
 - Exit 15 is escalation, never acceptance. Read `open_questions` and decide whether
   one corrective dispatch is justified.
 
+### Preserve a local Evidence Receipt v1
+
+`verify-job.sh` runs the same canonical gate and, only for gate outcomes `0` and
+`10`–`15`, durably publishes a private JSON receipt. The receipt records hashes of
+the exact envelope snapshot, ordered path policy, and driver-owned verifier commands;
+the immutable base; the gate's initial and final candidate-state digests; and the
+gate's exact outcome. It contains deterministic labels such as `verify-001`, never
+the verifier command text or output.
+
+Create a new owner-private directory outside the audited repository and choose a new
+receipt path. The parent and path must already be canonical; the command rejects a
+symlink, overwrite, repository-contained target, or group/other-accessible parent.
+
+```bash
+umask 077
+RECEIPT_DIR="$(mktemp -d -t agyworker-receipts.XXXXXX)"
+
+./verify-job.sh --receipt "$RECEIPT_DIR/job.json" \
+  --envelope envelope.json --repo "$WT" --base "$BASE" \
+  --only 'tests/**' --expect-edits \
+  --verify "git -C '$WT' diff --check" \
+  --verify "cd '$WT' && python3 -m pytest -q tests/test_parser.py"
+```
+
+`--selection FILE` may bind one current, validated G1 selection record.
+`--pre-recommendation FILE` may independently bind one canonical `pre-dispatch`
+advisory; a post-gate, cross-stage, mismatched, or `applied: true` advisory is
+rejected. The command never creates or applies a recommendation. Both inputs are
+optional and at most once. There is no implicit scan of `logs/`.
+
+The receipt maps gate `0` to `gate-passed`, gate `10`–`14` to `rejected`, and gate
+`15` to `routed`, then returns that exact exit only after file `fsync`, atomic
+no-overwrite hard-link publication, and parent-directory `fsync`. Input or gate
+preflight errors return `64`; missing, malformed, mismatched, unknown, or interrupted
+gate evidence returns `70`; receipt validation or durable-publication failure returns
+`74`. Those failures publish no receipt. The evidence descriptor and capability are
+an internal `verify-job.sh` handoff, not a supported direct `qa-gate.sh` interface;
+direct gate use without them retains the existing output, side effects, and exits.
+The wrapper removes shell/Python startup controls before launching the evidence-mode
+gate, gate-owned Python runs isolated without site startup, and the gate parent closes
+the descriptor with a shell builtin before any verifier shell or interpreter starts.
+Verifier descendants therefore cannot observe or write the handoff. Other verifier
+environment values are preserved; the unsafe startup controls and internal handoff
+variables are intentionally absent. HUP, INT, or TERM from private
+snapshot creation through publication and cleanup returns `70`, closes and reaps an
+active gate/verifier process group, and removes wrapper-owned partial artifacts.
+
+Every receipt says explicitly that it is unsigned and not tamper-evident. Its
+existence does not make a candidate accepted, signed, authentic, correct, or safe.
+Only `qa-gate.sh` supplies the gate result, and human diff review remains required
+after `gate-passed`. The dependency-free validator can check a receipt and optionally
+bind the original envelope or a separately trusted candidate-state digest:
+
+```bash
+python3 -B skills/agy-worker/runtime/scripts/evidence_receipt.py validate \
+  --receipt "$RECEIPT_DIR/job.json" --envelope envelope.json
+```
+
 `--allow-slash-commands` exists for callers who fully control the entire prompt, but
 is intentionally omitted from normal examples. It disables protection against
 embedded `/skill` or slash-command text; leave slash expansion disabled for content
@@ -636,6 +694,7 @@ output, not its own recollection.
 ```
 agy-worker.sh                 dispatch a job, return a schema-valid envelope
 qa-gate.sh                    verify an envelope against the repo — the evidence
+verify-job.sh                 run the gate and durably publish Evidence Receipt v1
 proof-demo.sh                 offline starter proof of one gate pass and one rejection
 model-recommendation.sh       repository compatibility wrapper for the advisory
 model-selection.sh            repository compatibility wrapper for explicit resolution
@@ -659,12 +718,13 @@ SECURITY.md                   private vulnerability reporting policy
 CODE_OF_CONDUCT.md            enforceable participation standards
 .github/pull_request_template.md  review and verification checklist
 tests/test-qa-gate.sh         offline adversarial suite
+tests/test-evidence-receipt.sh  88-case offline receipt/publication/protocol suite
 tests/test-agy-worker.sh       offline dispatcher/installer/routing suite
 tests/test-update.sh          175-case offline local-remote/matrix/manifest updater suite
 tests/test-official-distribution.py  test-only stdlib manifest adversary harness
 tests/test-reporting.sh       offline privacy/fake-gh reporting suite
-tests/test-packaging.sh       114-case offline Codex package/relocation/landing suite
-tests/test-doctor.sh          163-case offline fake-tool/read-only doctor suite
+tests/test-packaging.sh       135-case offline Codex package/relocation/landing suite
+tests/test-doctor.sh          180-case offline fake-tool/read-only doctor suite
 tests/test-proof-demo.sh      21-case offline starter-proof adversarial suite
 .github/workflows/compatibility-watch.yml  observational weekly/manual fixed-source watch
 ```

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -18,8 +18,16 @@ driver task
   -> agy (untrusted worker)
   -> structured envelope
   -> skills/agy-worker/runtime/scripts/validate-envelope.py (shape and contract only)
-  -> qa-gate.sh (Git scope, immutable base, policy, escalation)
-  -> driver-owned --verify commands
+  -> one caller-chosen verification path:
+       -> verify-job.sh (receipt-producing wrapper)
+            -> sanitized, capability-bound launch with a pre-opened evidence FD
+               owned only by the gate parent
+            -> qa-gate.sh (Git scope, immutable base, policy, escalation)
+                 -> isolated gate helpers
+                 -> driver-owned --verify children started only after the evidence
+                    FD is closed in the existing gate process
+            -> validated unsigned receipt, atomic no-overwrite local publication
+       -> or direct qa-gate.sh (same gate and verifiers, no receipt)
   -> model-recommendation.sh --stage post-gate (visible advisory only)
   -> human diff review and deliberate integration
 ```
@@ -88,20 +96,21 @@ accept a candidate, replace human diff review, or certify correctness or securit
 | `agy-worker.sh`, `skills/agy-worker/runtime/agy-worker.sh` | Root compatibility entry plus strict selector-source parsing, canonical dispatch, frozen model/mode selection, bounded retries, private selection/prompt/log staging, envelope extraction | `tests/test-agy-worker.sh` (209 cases) |
 | `model-selection.sh`, `skills/agy-worker/runtime/model-selection.sh`, `skills/agy-worker/runtime/scripts/model_selection.py`, portable matrix/schema/SHA | Root compatibility entry plus canonical exact model/effort resolution, bounded installed-version preflight, and driver selection provenance | dispatcher, doctor, and packaging suites |
 | `model-recommendation.sh`, `skills/agy-worker/runtime/model-recommendation.sh`, `skills/agy-worker/runtime/scripts/model-recommendation.py` | Root compatibility entry plus side-effect-free pre/post recommendations; direct selections are labelled but unranked and never applied | `tests/test-agy-worker.sh` (209 cases) |
-| `doctor.sh`, `skills/agy-worker/runtime/doctor.sh`, `skills/agy-worker/runtime/scripts/doctor-metadata.py`, `skills/agy-worker/runtime/compat/` | Root compatibility entry plus deterministic offline prerequisite checks and byte-synchronized portable agy metadata | `tests/test-doctor.sh` (163 cases) plus packaging synchronization checks |
+| `doctor.sh`, `skills/agy-worker/runtime/doctor.sh`, `skills/agy-worker/runtime/scripts/doctor-metadata.py`, `skills/agy-worker/runtime/compat/` | Root compatibility entry plus deterministic offline prerequisite checks and byte-synchronized portable agy metadata | `tests/test-doctor.sh` (180 cases) plus packaging synchronization checks |
 | `install.sh`, `skills/agy-worker/`, `skills/agy-worker/scripts/resolve-pipeline.sh` | Install and resolve complete-plugin, explicit-checkout, or folder-only skill layouts without fetching code | dispatcher and packaging suites |
 | `skills/agy-worker/runtime/schemas/`, `skills/agy-worker/runtime/scripts/validate-envelope.py` | Dependency-free envelope contract validation | dispatcher and gate suites |
-| `qa-gate.sh`, `skills/agy-worker/runtime/qa-gate.sh` | Root compatibility entry plus canonical immutable-base Git audit, path policy, escalation, driver verification | `tests/test-qa-gate.sh` (41 cases) |
+| `qa-gate.sh`, `skills/agy-worker/runtime/qa-gate.sh` | Root compatibility entry plus canonical immutable-base Git audit, path policy, escalation, driver verification, and internal pre-opened structured evidence handoff | `tests/test-qa-gate.sh` (41 cases) plus receipt suite no-FD compatibility checks |
+| `verify-job.sh`, `skills/agy-worker/runtime/verify-job.sh`, `skills/agy-worker/runtime/scripts/evidence_receipt.py`, `skills/agy-worker/runtime/schemas/evidence-receipt.schema.json` | Root compatibility entry plus exact input hashing, strict selection/advisory binding, startup-isolated parent-exclusive gate evidence, interruption cleanup, unsigned receipt validation, and private durable no-overwrite publication | `tests/test-evidence-receipt.sh` (88 cases) |
 | `proof-demo.sh`, `demo/fixtures/` | Repository-only offline starter proof using two canonical synthetic envelopes and isolated temporary repositories | `tests/test-proof-demo.sh` (21 cases) |
 | `skills/agy-worker/runtime/agents/*.md` | Prompt-injected bounded personas; prompt text is guidance, not enforcement | dispatcher suite plus bounded real exercises |
 | `update.sh`, `scripts/compatibility.py`, `scripts/official_distribution.py`, `compat/` | Explicit project releases; fixed-source agy/Codex review; sanitized reconciliation records; bounded distribution-manifest canary; strict per-tool metadata and active-only-when-bound model/effort matrix | `tests/test-update.sh` (175 cases, including the test-only manifest adversary harness) |
 | `bug-report.sh`, `scripts/bug-report.py`, `.github/ISSUE_TEMPLATE/` | Local privacy filtering, exact review binding, optional issue submission | `tests/test-reporting.sh` (21 cases) |
-| `.codex-plugin/plugin.json` | Codex skills-only package identity retained for local validation; not a public listing | `tests/test-packaging.sh` (114 cases) plus platform validators |
-| `PRIVACY.md`, `TERMS.md`, `SUPPORT.md` | Public data disclosure, project policy, and support route | `tests/test-packaging.sh` (114 cases) plus review |
-| `docs/index.md`, `docs/_layouts/`, `docs/_config.yml`, `docs/sitemap.xml` | Static GitHub Pages landing, canonical metadata, and sitemap; enabling Pages and submitting the sitemap through Search Console remain external | `tests/test-packaging.sh` (114 cases) plus rendered review |
-| `docs/assets/brand/`, `scripts/validate-brand-assets.py` | Approved light/dark master marks, pixel-hinted micro variants, favicon PNGs, social preview, and dependency-free asset validation | `tests/test-packaging.sh` (114 cases) plus rendered review |
+| `.codex-plugin/plugin.json` | Codex skills-only package identity retained for local validation; not a public listing | `tests/test-packaging.sh` (135 cases) plus platform validators |
+| `PRIVACY.md`, `TERMS.md`, `SUPPORT.md` | Public data disclosure, project policy, and support route | `tests/test-packaging.sh` (135 cases) plus review |
+| `docs/index.md`, `docs/_layouts/`, `docs/_config.yml`, `docs/sitemap.xml` | Static GitHub Pages landing, canonical metadata, and sitemap; enabling Pages and submitting the sitemap through Search Console remain external | `tests/test-packaging.sh` (135 cases) plus rendered review |
+| `docs/assets/brand/`, `scripts/validate-brand-assets.py` | Approved light/dark master marks, pixel-hinted micro variants, favicon PNGs, social preview, and dependency-free asset validation | `tests/test-packaging.sh` (135 cases) plus rendered review |
 | `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, `.github/pull_request_template.md` | Contribution workflow, private vulnerability route, conduct enforcement, and review checklist | human review plus relevant offline suites |
-| `.github/workflows/test.yml` | macOS CI for syntax and all seven offline suites | exercised by GitHub Actions |
+| `.github/workflows/test.yml` | macOS CI for syntax and all eight offline suites | exercised by GitHub Actions |
 | `.github/workflows/compatibility-watch.yml` | Weekly/manual macOS observation of fixed official evidence; bounded Step Summary only, never a required PR or metadata/action path | static policy tests in `tests/test-update.sh` plus GitHub Actions observation |
 | `README.md` | User setup, examples, current capabilities and limitations | review plus relevant offline suites |
 | `docs/ROADMAP.md` | Planned dependency-ordered product slices, approval gates, and honest success measures; not current behavior | human review; implementation claims remain prohibited until their slices land |
@@ -116,6 +125,13 @@ accept a candidate, replace human diff review, or certify correctness or securit
   recommender is outside the dispatch and acceptance paths, cannot execute either,
   and never applies its output. Default/custom tiers and the highest named tier fail
   safely to `no-escalation` when no ordered higher tier can be proved.
+- An Evidence Receipt v1 is a private, unsigned serialization of one gate execution,
+  not another acceptance authority. `verify-job.sh` can bind hashes and bounded
+  optional G1/advisory data only after `qa-gate.sh` supplies the exact outcome through
+  its internal wrapper-bound pre-opened descriptor. Direct `qa-gate.sh` is the
+  no-receipt alternative; the evidence capability is not a public direct-call mode.
+  Receipt validation never converts a rejected/routed
+  result to `gate-passed`, and even `gate-passed` still needs human diff review.
 - The model/effort matrix is compatibility metadata only. It cannot select a tier,
   dispatch a worker, recommend escalation, or accept a candidate. Direct caller input
   may resolve through it only while exact bytes, version, source, schema, and installed
@@ -166,6 +182,12 @@ accept a candidate, replace human diff review, or certify correctness or securit
 - Temporary worktrees, envelopes, updater candidates, and bug drafts normally live
   outside the repository. Preserve accepted work before cleanup; force removal is only
   for deliberately rejected disposable changes.
+- Receipt files live only at a caller-selected new canonical path outside the audited
+  repository, under an owner-private real parent. They are published mode `0600` by
+  same-directory file `fsync`, atomic no-overwrite hard link, and parent `fsync`.
+  They contain hashes and bounded labels rather than source, paths, commands, output,
+  logs, or worker prose. They are unsigned and not self-authenticating; retain or
+  delete them according to the caller's local evidence policy.
 - `~/.gemini/` contains agy state. `~/.codex/skills/agy-worker/` is written only by an
   explicit `install.sh` or successful `update.sh apply`; its `.pipeline-root` is a
   local install artifact and must never enter the public skill bundle. Repository

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -363,6 +363,9 @@ remain separately approval-gated.
 
 #### P0-A — Evidence Receipt v1
 
+**Status:** Implemented as an isolated, offline-verified slice; merge and release
+remain separately approval-gated.
+
 - **User job:** Preserve what the driver checked, against which immutable base and
   policy, and what the gate concluded without sharing source, prompts, raw logs, or
   worker prose.
@@ -370,9 +373,11 @@ remain separately approval-gated.
   `skills/agy-worker/runtime/verify-job.sh`, root `verify-job.sh`,
   `skills/agy-worker/runtime/schemas/evidence-receipt.schema.json`, and a
   dependency-free receipt validator. The wrapper creates a private temporary receipt
-  and pre-opens a driver-owned structured-evidence sink, then invokes the gate with a
-  narrow optional `--evidence-fd FD`. When that option is absent, `qa-gate.sh` output,
-  side effects, and exit behavior remain identical to today. With it, the gate writes
+  and pre-opens a driver-owned structured-evidence sink, then invokes the gate with an
+  internal capability-bound `--evidence-fd FD` handoff. This evidence mode is owned by
+  `verify-job.sh`, not supported as an arbitrary direct-call interface. When that
+  option is absent, `qa-gate.sh` output, side effects, and exit behavior remain
+  identical to today. With it, the gate writes
   exactly one bounded JSON handoff to the already-open descriptor; it never owns or
   chooses the destination path. Optional `--pre-recommendation FILE` may bind an
   already-rendered pre-dispatch advisory. The receipt command never generates or
@@ -430,8 +435,8 @@ remain separately approval-gated.
   the wrapper returns that exact gate exit. A valid pre-dispatch advisory is bound
   without changing the selected input, matrix revision, resolved agy slug, or gate
   result. The tests never call a candidate accepted before human review. Direct
-  `qa-gate.sh` calls without `--evidence-fd` retain their current stdout/stderr and
-  exit contract.
+  `qa-gate.sh` calls without the internal evidence capability retain their
+  current stdout/stderr and exit contract.
 - **Minimum reject tests:** Scope failure, malformed envelope, untrusted command/test
   claim, missing edits, verifier failure/mutation, and human-required outcome retain
   their gate classification and are never rendered as acceptance. Reject overwrite,

--- a/docs/lessons_learned.md
+++ b/docs/lessons_learned.md
@@ -174,6 +174,51 @@ result as evidence for the fixed synthetic cases only: a gate pass is still not 
 human diff review, accepted candidate, correctness result, security certification,
 benchmark, or production validation.
 
+## Receipts bind observations; they do not create authority
+
+A useful receipt records the gate's own bounded structured handoff rather than
+parsing prose or reimplementing acceptance in an outer wrapper. Snapshot the exact
+envelope bytes the gate validates, retain the resolved immutable base and the gate's
+internal initial/final candidate-state digests, and cross-check the gate process exit
+against one unique handoff. Missing, duplicate, malformed, mismatched, interrupted,
+or unknown evidence is an internal protocol failure—not a result to reconstruct.
+
+Keep private data out by hashing ordered policy and verifier commands and assigning
+deterministic labels. An optional selection or pre-dispatch advisory must pass its
+own canonical policy and agree when both are supplied; it still cannot participate
+in acceptance or change the selected model. Never bind a later post-gate advisory by
+rewriting a one-pass receipt.
+
+Durability and non-overwrite are separate properties. Write and validate a same-dir
+mode-`0600` temporary, `fsync` it, publish with an atomic hard link that refuses an
+existing target, `fsync` the parent, remove the temporary, and `fsync` the parent
+again. On validation, link, or durability failure, remove every publisher-owned
+partial and never delete or overwrite a raced caller/attacker target. Revalidate the
+private parent immediately before linking.
+
+A pre-opened evidence descriptor is authority, not ordinary inherited process state.
+Validate it in the gate parent, then close it before every verifier child and
+descendant executes; otherwise a verifier can forge or corrupt the supposedly
+gate-owned handoff. Signal ownership must span the full receipt transaction, not just
+the gate wait: track private files and the pinned published inode before the atomic
+link, terminate and reap the active process group, and remove only wrapper-owned
+artifacts on HUP, INT, or TERM.
+
+Closing a sensitive descriptor in a newly started helper is already too late:
+Python `sitecustomize` or a shell `BASH_ENV` hook can execute before that helper's
+first statement. Bind evidence mode to the receipt wrapper, sanitize executable
+startup controls before launching the gate, run gate-owned Python with isolated/no-site
+startup, and close the numeric validated FD with a Bash builtin in the already-running
+gate process before starting the verifier shell. Preserve ordinary verifier environment
+values, but do not forward the stripped startup controls or internal capability.
+
+Schema validation detects malformed and internally inconsistent content, not an
+authorized rewrite. An unsigned JSON document can be changed and rehashed by anyone
+who can replace it. State that limitation in the document itself; require a separately
+trusted envelope or candidate digest when later tampering matters. Receipt existence
+does not replace `qa-gate.sh`, human diff review, signing, authenticity, correctness,
+or security evidence.
+
 ## Distribution must preserve the trust boundary
 
 A public skill cannot depend on a developer's absolute checkout path or assume that

--- a/skills/agy-worker/SKILL.md
+++ b/skills/agy-worker/SKILL.md
@@ -225,7 +225,10 @@ the gate or wrap dispatch in an unbounded retry loop.
 ### 5. Verify — this is the step that matters
 
 ```bash
-"$PIPELINE/qa-gate.sh" --envelope /tmp/envelope.json --repo "$WT" --base "$BASE" \
+RECEIPT_DIR="$(mktemp -d -t agyworker-receipts.XXXXXX)" || exit 1
+RECEIPT_DIR="$(CDPATH= cd -- "$RECEIPT_DIR" && pwd -P)" || exit 1
+"$PIPELINE/verify-job.sh" --receipt "$RECEIPT_DIR/job.json" \
+    --envelope /tmp/envelope.json --repo "$WT" --base "$BASE" \
     --only 'tests/**' --expect-edits \
     --verify "git -C '$WT' diff --check" \
     --verify "cd '$WT' && <the command from step 2>"
@@ -236,9 +239,24 @@ the worker envelope. Use `--only` whenever the task has a path policy, especiall
 for `bulk-test-writer`; its persona prompt is not enforcement. `--base` must be the
 full commit ID captured before dispatch, never `HEAD` or another mutable ref.
 
+`verify-job.sh` is the receipt-producing wrapper around the same canonical gate. Its
+required `--receipt` must be a new canonical absolute path outside the audited
+repository under an owner-private real parent. It hashes ordered policy and verifier
+commands, publishes mode `0600` without overwrite only after file and parent `fsync`,
+and never stores raw commands, output, source, paths, prompts, logs, or worker prose.
+The lower-level `qa-gate.sh` remains available when no receipt is wanted. Its evidence
+descriptor/capability is an internal `verify-job.sh` handoff, not a supported direct
+interface; direct no-receipt behavior is unchanged.
+
+One validated dispatcher `selection.json` may be supplied as `--selection FILE`.
+One canonical advisory captured before dispatch may independently be supplied as
+`--pre-recommendation FILE`. Neither is required; neither changes the gate result or
+selected model. Never bind a post-gate advisory or an advisory claiming `applied`.
+There is no implicit artifact discovery.
+
 | Exit | Meaning | Do |
 |---|---|---|
-| 0 | Evidence accepted | Review the diff; no merge or commit happened automatically |
+| 0 | Gate passed and receipt was durably published | Review the diff; no merge or commit happened automatically |
 | 10 | Scope mismatch, invalid path, or `--only` violation | Reject |
 | 11 | Worker reported a command or test | Reject; it was not executed |
 | 12 | Envelope failed the checked-in schema | Reject |
@@ -246,6 +264,22 @@ full commit ID captured before dispatch, never `HEAD` or another mutable ref.
 | 14 | Verification failed or mutated the worktree | Reject |
 | 15 | Partial/failed/blocked/human-required outcome | Escalate; never accept |
 | 64 | Bad invocation, invalid Git base, or missing `--verify` | Fix the driver command |
+| 70 | Gate evidence missing, malformed, mismatched, unknown, or interrupted | Treat as internal failure; no receipt was published |
+| 74 | Receipt validation or durable publication failed | Treat as publication failure; no receipt was published |
+
+Gate exits `10`–`15` also publish the exact rejected/routed receipt before the wrapper
+returns that exit. A receipt uses only `gate-passed`, `rejected`, or `routed`; it never
+calls a candidate accepted. It is explicitly unsigned and not tamper-evident. Even
+exit 0 still requires human diff review.
+
+The evidence descriptor belongs only to the gate parent. The wrapper strips executable
+shell/Python startup controls from the evidence-mode gate, gate-owned Python runs in
+isolated/no-site mode, and the already-running gate closes the FD with a shell builtin
+before any driver verifier shell, interpreter, or descendant starts. Ordinary verifier
+environment is preserved except for those unsafe startup controls and the internal
+handoff variables. HUP, INT, or TERM anywhere from private input
+snapshot through durable publication and wrapper cleanup returns `70`, terminates and
+reaps an active gate/verifier group, and leaves no wrapper-owned partial receipt.
 
 A `blocked` / `requires_human: true` envelope may be the worker behaving correctly,
 but the gate still checks its diff before returning 15. Read `open_questions`, resolve
@@ -296,7 +330,8 @@ uncommitted work.
 
 ## Never
 
-- Accept a job on the envelope alone. Run `qa-gate.sh` with `--verify`, every time.
+- Accept a job on the envelope or receipt alone. Run `verify-job.sh` (or the lower-level
+  `qa-gate.sh`) with driver-owned `--verify`, then perform human diff review every time.
 - Execute `commands_run` or `tests_run` from the envelope. Only driver-authored
   `--verify` commands are executable evidence.
 - Suggest `--dangerously-skip-permissions` to clear a permission gate — it approves

--- a/skills/agy-worker/runtime/doctor.sh
+++ b/skills/agy-worker/runtime/doctor.sh
@@ -45,10 +45,12 @@ doctor_runtime_complete() {
     for required in \
         agy-worker.sh \
         qa-gate.sh \
+        verify-job.sh \
         model-recommendation.sh \
         model-selection.sh \
         doctor.sh \
         scripts/validate-envelope.py \
+        scripts/evidence_receipt.py \
         scripts/model-recommendation.py \
         scripts/model_selection.py \
         scripts/compatibility.py \
@@ -71,6 +73,7 @@ doctor_runtime_complete() {
 
     for required in \
         schemas/worker-result.schema.json \
+        schemas/evidence-receipt.schema.json \
         schemas/model-selection.schema.json \
         schemas/model-recommendation.schema.json \
         agents/bulk-test-writer.md \

--- a/skills/agy-worker/runtime/qa-gate.sh
+++ b/skills/agy-worker/runtime/qa-gate.sh
@@ -7,6 +7,8 @@
 # usage: qa-gate.sh --envelope FILE --repo DIR --base FULL_COMMIT_ID
 #                   [--allow PATHGLOB]... [--only PATHGLOB]...
 #                   [--expect-edits] --verify COMMAND [--verify COMMAND]...
+#                   (internal verify-job handoff: --evidence-fd FD
+#                    --evidence-token TOKEN)
 # exit: 0 accepted · 10 scope violation · 11 untrusted command/test claim
 #       12 malformed envelope · 13 expected edits missing
 #       14 driver verification failed/mutated repo · 15 worker escalation
@@ -16,6 +18,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCHEMA="${AGY_WORKER_SCHEMA:-$SCRIPT_DIR/schemas/worker-result.schema.json}"
 
 envelope=""; repo="$PWD"; base=""; expect_edits=0
+evidence_fd=""; evidence_fd_seen=0; evidence_token=""; evidence_token_seen=0
+evidence_python=""
 allow=(); only=(); verify=()
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -30,6 +34,17 @@ while [[ $# -gt 0 ]]; do
             }
             verify+=("$2"); shift 2 ;;
         --expect-edits) expect_edits=1; shift ;;
+        --evidence-fd)
+            [[ $# -ge 2 && $evidence_fd_seen -eq 0 ]] || exit 64
+            case "$2" in ''|*[!0-9]*|0|1|2) exit 64 ;; esac
+            evidence_fd="$2"
+            evidence_fd_seen=1
+            shift 2 ;;
+        --evidence-token)
+            [[ $# -ge 2 && $evidence_token_seen -eq 0 ]] || exit 64
+            evidence_token="$2"
+            evidence_token_seen=1
+            shift 2 ;;
         *) echo "qa-gate.sh: unknown arg: $1" >&2; exit 64 ;;
     esac
 done
@@ -62,10 +77,186 @@ resolved_base="$(git -C "$repo" rev-parse --verify "$base^{commit}" 2>/dev/null)
     echo "qa-gate.sh: base did not resolve to the exact supplied commit" >&2; exit 64;
 }
 
-"$SCRIPT_DIR/scripts/validate-envelope.py" "$SCHEMA" "$envelope" || exit 12
+if [[ -n "$evidence_fd" ]]; then
+    case "$evidence_token" in
+        *[!0-9a-f]*|'') exit 64 ;;
+    esac
+    [[ ${#evidence_token} -eq 64 \
+        && "${AGY_WORKER_INTERNAL_EVIDENCE_TOKEN:-}" == "$evidence_token" ]] \
+        || exit 64
+    evidence_python="${AGY_WORKER_INTERNAL_PYTHON:-}"
+    [[ "$evidence_python" == /* && -f "$evidence_python" \
+        && ! -L "$evidence_python" && -x "$evidence_python" ]] || exit 64
+    "$evidence_python" -I -S -B - "$evidence_fd" <<'PY' || exit 64
+import fcntl
+import os
+import sys
+
+descriptor = int(sys.argv[1])
+try:
+    os.fstat(descriptor)
+    flags = fcntl.fcntl(descriptor, fcntl.F_GETFL)
+except (OSError, OverflowError, ValueError):
+    raise SystemExit(1)
+raise SystemExit(0 if flags & os.O_ACCMODE != os.O_RDONLY else 1)
+PY
+elif [[ -n "$evidence_token" ]]; then
+    exit 64
+fi
+
+gate_python() {
+    if [[ -n "$evidence_fd" ]]; then
+        "$evidence_python" -I -S -B "$@"
+    else
+        python3 "$@"
+    fi
+}
+
+evidence_workspace=""
+evidence_envelope_sha256=""
+evidence_initial_state_sha256=""
+
+gate_cleanup_evidence() {
+    local workspace="${evidence_workspace:-}"
+    [[ -n "$workspace" ]] || return 0
+    case "$workspace" in
+        /*/agy-worker-gate.*) ;;
+        *) return 1 ;;
+    esac
+    [[ -d "$workspace" && ! -L "$workspace" && -O "$workspace" ]] || return 1
+    /bin/rm -f -- "$workspace/envelope.snapshot" 2>/dev/null || return 1
+    /bin/rmdir "$workspace" 2>/dev/null || return 1
+    evidence_workspace=""
+}
+
+gate_signal() {
+    local signal_name="$1"
+    gate_cleanup_evidence >/dev/null 2>&1 || true
+    trap - "$signal_name"
+    kill -s "$signal_name" "$$"
+}
+
+gate_prepare_workspace() {
+    local base_dir canonical workspace old_umask rc
+    for base_dir in /private/tmp /private/var/tmp /tmp /var/tmp; do
+        [[ -d "$base_dir" && -w "$base_dir" ]] || continue
+        canonical="$(CDPATH= cd -- "$base_dir" 2>/dev/null && pwd -P)" || continue
+        case "$canonical" in
+            "$repo"|"$repo"/*) continue ;;
+        esac
+        old_umask="$(umask)"
+        umask 077
+        workspace="$(/usr/bin/mktemp -d \
+            "$canonical/agy-worker-gate.XXXXXX" 2>/dev/null)"
+        rc=$?
+        umask "$old_umask"
+        [[ "$rc" == 0 && -d "$workspace" && ! -L "$workspace" \
+            && -O "$workspace" ]] || continue
+        /bin/chmod 700 "$workspace" 2>/dev/null || {
+            /bin/rmdir "$workspace" 2>/dev/null || true
+            continue
+        }
+        evidence_workspace="$(CDPATH= cd -- "$workspace" && pwd -P)" || {
+            /bin/rmdir "$workspace" 2>/dev/null || true
+            continue
+        }
+        return 0
+    done
+    return 1
+}
+
+gate_snapshot_envelope() {
+    local source="$1" destination="$2"
+    gate_python - "$source" "$destination" 2>/dev/null <<'PY'
+import hashlib
+import os
+import stat
+import sys
+
+source, destination = sys.argv[1:3]
+digest = hashlib.sha256()
+source_fd = os.open(
+    source,
+    os.O_RDONLY
+    | getattr(os, "O_NOFOLLOW", 0)
+    | getattr(os, "O_NONBLOCK", 0),
+)
+destination_fd = -1
+try:
+    if not stat.S_ISREG(os.fstat(source_fd).st_mode):
+        raise OSError("envelope snapshot source is not regular")
+    destination_fd = os.open(
+        destination,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+        0o600,
+    )
+    os.fchmod(destination_fd, 0o600)
+    while True:
+        chunk = os.read(source_fd, 1024 * 1024)
+        if not chunk:
+            break
+        digest.update(chunk)
+        view = memoryview(chunk)
+        while view:
+            written = os.write(destination_fd, view)
+            if written <= 0:
+                raise OSError("short snapshot write")
+            view = view[written:]
+    os.fsync(destination_fd)
+finally:
+    os.close(source_fd)
+    if destination_fd >= 0:
+        os.close(destination_fd)
+print(digest.hexdigest())
+PY
+}
+
+gate_emit_evidence() {
+    local gate_exit="$1" gate_outcome="$2" final_state="$3" payload
+    payload="$(gate_python - \
+        "$resolved_base" "$evidence_envelope_sha256" \
+        "$evidence_initial_state_sha256" "$final_state" \
+        "$gate_exit" "$gate_outcome" <<'PY'
+import json
+import sys
+
+base, envelope, initial, final, gate_exit, outcome = sys.argv[1:]
+value = {
+    "schema_version": 1,
+    "kind": "agy-worker-gate-evidence",
+    "resolved_base": base,
+    "envelope_sha256": envelope,
+    "initial_candidate_state_sha256": initial,
+    "final_candidate_state_sha256": final,
+    "gate_exit": int(gate_exit),
+    "gate_outcome": outcome,
+}
+print(json.dumps(value, ensure_ascii=True, sort_keys=True, separators=(",", ":")))
+PY
+)" || return 1
+    [[ ${#payload} -le 4095 && "$payload" != *$'\n'* ]] || return 1
+    printf '%s\n' "$payload" >&"$evidence_fd" || return 1
+}
+
+gate_finish() {
+    local gate_exit="$1" gate_outcome="$2" final_state
+    if [[ -z "$evidence_fd" ]]; then
+        exit "$gate_exit"
+    fi
+    final_state="$(snapshot_repo)" || {
+        gate_cleanup_evidence >/dev/null 2>&1 || true
+        exit 70
+    }
+    gate_emit_evidence "$gate_exit" "$gate_outcome" "$final_state" || {
+        gate_cleanup_evidence >/dev/null 2>&1 || true
+        exit 70
+    }
+    gate_cleanup_evidence >/dev/null 2>&1 || exit 70
+    exit "$gate_exit"
+}
 
 scope_check() {
-    python3 - "$envelope" "$repo" "$base" "${#allow[@]}" "${#only[@]}" \
+    gate_python - "$envelope" "$repo" "$base" "${#allow[@]}" "${#only[@]}" \
         ${allow[@]+"${allow[@]}"} ${only[@]+"${only[@]}"} <<'PY'
 import fnmatch
 import json
@@ -184,7 +375,7 @@ PY
 }
 
 snapshot_repo() {
-    python3 - "$repo" "$base" <<'PY'
+    gate_python - "$repo" "$base" <<'PY'
 import hashlib
 import os
 import stat
@@ -235,30 +426,50 @@ print(digest.hexdigest())
 PY
 }
 
-claimed_count="$(scope_check)" || exit 10
+if [[ -n "$evidence_fd" ]]; then
+    gate_prepare_workspace || exit 70
+    trap 'gate_cleanup_evidence >/dev/null 2>&1 || true' EXIT
+    trap 'gate_signal HUP' HUP
+    trap 'gate_signal INT' INT
+    trap 'gate_signal TERM' TERM
+    evidence_envelope_sha256="$(gate_snapshot_envelope \
+        "$envelope" "$evidence_workspace/envelope.snapshot")" || exit 70
+    envelope="$evidence_workspace/envelope.snapshot"
+    evidence_initial_state_sha256="$(snapshot_repo)" || exit 70
+fi
 
-status="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["status"])' "$envelope")"
-requires_human="$(python3 -c 'import json,sys; print("true" if json.load(open(sys.argv[1]))["requires_human"] else "false")' "$envelope")"
+if [[ -n "$evidence_fd" ]]; then
+    gate_python "$SCRIPT_DIR/scripts/validate-envelope.py" "$SCHEMA" "$envelope" \
+        || gate_finish 12 invalid-envelope
+else
+    "$SCRIPT_DIR/scripts/validate-envelope.py" "$SCHEMA" "$envelope" \
+        || gate_finish 12 invalid-envelope
+fi
+
+claimed_count="$(scope_check)" || gate_finish 10 scope-violation
+
+status="$(gate_python -c 'import json,sys; print(json.load(open(sys.argv[1]))["status"])' "$envelope")"
+requires_human="$(gate_python -c 'import json,sys; print("true" if json.load(open(sys.argv[1]))["requires_human"] else "false")' "$envelope")"
 
 # Escalation is a valid worker outcome, but never accepted work. Scope has already
 # been checked so status cannot hide edits.
 if [[ "$status" != "completed" || "$requires_human" == "true" ]]; then
     echo "qa-gate: WORKER ESCALATION (status=$status requires_human=$requires_human)" >&2
-    exit 15
+    gate_finish 15 worker-escalation
 fi
 
 if (( expect_edits )) && [[ "$claimed_count" == "0" ]]; then
     echo "qa-gate: expected edits, but the completed worker changed nothing" >&2
-    exit 13
+    gate_finish 13 expected-edits-missing
 fi
 
 # Never execute commands supplied by the untrusted envelope. Workers are instructed
 # to leave this list empty; a non-empty list is a contract violation, not evidence.
-command_count="$(python3 -c 'import json,sys; print(len(json.load(open(sys.argv[1]))["commands_run"]))' "$envelope")"
-test_count="$(python3 -c 'import json,sys; print(len(json.load(open(sys.argv[1]))["tests_run"]))' "$envelope")"
+command_count="$(gate_python -c 'import json,sys; print(len(json.load(open(sys.argv[1]))["commands_run"]))' "$envelope")"
+test_count="$(gate_python -c 'import json,sys; print(len(json.load(open(sys.argv[1]))["tests_run"]))' "$envelope")"
 if [[ "$command_count" != "0" || "$test_count" != "0" ]]; then
     echo "qa-gate: UNTRUSTED COMMAND CLAIM - commands_run and tests_run must be empty; nothing from the envelope was executed" >&2
-    exit 11
+    gate_finish 11 untrusted-worker-claim
 fi
 
 if (( ${#verify[@]} == 0 )); then
@@ -266,23 +477,40 @@ if (( ${#verify[@]} == 0 )); then
     exit 64
 fi
 
-before_snapshot="$(snapshot_repo)" || exit 14
+before_snapshot="$(snapshot_repo)" || gate_finish 14 driver-verification-failed
 for (( i=0; i<${#verify[@]}; i++ )); do
     vcmd="${verify[$i]}"
     echo "qa-gate: driver verification: $vcmd" >&2
-    if ! bash -c "$vcmd"; then
+    if [[ -n "$evidence_fd" ]]; then
+        if (
+            builtin eval "exec ${evidence_fd}>&-" || exit 126
+            unset AGY_WORKER_INTERNAL_EVIDENCE_TOKEN AGY_WORKER_INTERNAL_PYTHON
+            exec /bin/bash -c "$vcmd"
+        ); then
+            verifier_rc=0
+        else
+            verifier_rc=$?
+        fi
+    else
+        if bash -c "$vcmd"; then
+            verifier_rc=0
+        else
+            verifier_rc=$?
+        fi
+    fi
+    if [[ "$verifier_rc" != 0 ]]; then
         echo "qa-gate: DRIVER VERIFICATION FAILED - '$vcmd'" >&2
-        exit 14
+        gate_finish 14 driver-verification-failed
     fi
 done
-after_snapshot="$(snapshot_repo)" || exit 14
+after_snapshot="$(snapshot_repo)" || gate_finish 14 driver-verification-failed
 if [[ "$before_snapshot" != "$after_snapshot" ]]; then
     echo "qa-gate: DRIVER VERIFICATION MUTATED THE WORKTREE" >&2
-    exit 14
+    gate_finish 14 driver-verification-failed
 fi
 
 # Re-check path policy after verification as defense in depth.
-scope_check >/dev/null || exit 10
+scope_check >/dev/null || gate_finish 10 scope-violation
 
 echo "qa-gate: ACCEPTED" >&2
-exit 0
+gate_finish 0 gate-passed

--- a/skills/agy-worker/runtime/schemas/evidence-receipt.schema.json
+++ b/skills/agy-worker/runtime/schemas/evidence-receipt.schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "agy-worker Evidence Receipt v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "kind",
+    "gate_authority",
+    "resolved_base",
+    "envelope_sha256",
+    "path_policy_sha256",
+    "verifiers",
+    "initial_candidate_state_sha256",
+    "final_candidate_state_sha256",
+    "gate_exit",
+    "gate_outcome",
+    "verdict",
+    "recommendations_participated_in_acceptance",
+    "integrity"
+  ],
+  "properties": {
+    "schema_version": {"type": "number", "enum": [1]},
+    "kind": {"type": "string", "enum": ["agy-worker-evidence-receipt"]},
+    "gate_authority": {"type": "string", "enum": ["qa-gate"]},
+    "resolved_base": {"type": "string", "minLength": 40, "maxLength": 64},
+    "envelope_sha256": {"type": "string", "minLength": 64, "maxLength": 64},
+    "path_policy_sha256": {"type": "string", "minLength": 64, "maxLength": 64},
+    "verifiers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["label", "command_sha256"],
+        "properties": {
+          "label": {"type": "string", "minLength": 10, "maxLength": 10},
+          "command_sha256": {"type": "string", "minLength": 64, "maxLength": 64}
+        }
+      }
+    },
+    "initial_candidate_state_sha256": {
+      "type": "string",
+      "minLength": 64,
+      "maxLength": 64
+    },
+    "final_candidate_state_sha256": {
+      "type": "string",
+      "minLength": 64,
+      "maxLength": 64
+    },
+    "gate_exit": {"type": "number", "minimum": 0, "maximum": 15},
+    "gate_outcome": {
+      "type": "string",
+      "enum": [
+        "gate-passed",
+        "scope-violation",
+        "untrusted-worker-claim",
+        "invalid-envelope",
+        "expected-edits-missing",
+        "driver-verification-failed",
+        "worker-escalation"
+      ]
+    },
+    "verdict": {
+      "type": "string",
+      "enum": ["gate-passed", "rejected", "routed"]
+    },
+    "caller_selection": {"type": "object"},
+    "pre_dispatch_recommendation": {"type": "object"},
+    "recommendations_participated_in_acceptance": {
+      "type": "boolean",
+      "enum": [false]
+    },
+    "integrity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["signed", "tamper_evident", "statement"],
+      "properties": {
+        "signed": {"type": "boolean", "enum": [false]},
+        "tamper_evident": {"type": "boolean", "enum": [false]},
+        "statement": {
+          "type": "string",
+          "enum": [
+            "Unsigned local record; schema-valid content can be rewritten and is not self-authenticating."
+          ]
+        }
+      }
+    }
+  }
+}

--- a/skills/agy-worker/runtime/scripts/evidence_receipt.py
+++ b/skills/agy-worker/runtime/scripts/evidence_receipt.py
@@ -1,0 +1,1223 @@
+#!/usr/bin/env python3
+"""Create and validate one private, unsigned Evidence Receipt v1.
+
+The gate remains the sole authority for its outcome.  This module binds the gate's
+structured handoff to caller-owned input hashes and publishes the resulting record;
+it does not reproduce acceptance logic or inspect gate prose.
+"""
+from __future__ import annotations
+
+import argparse
+from contextlib import contextmanager
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import secrets
+import signal
+import stat
+import subprocess
+import sys
+from typing import Any
+
+sys.dont_write_bytecode = True
+RUNTIME_SCRIPTS = str(Path(__file__).resolve(strict=True).parent)
+if RUNTIME_SCRIPTS not in sys.path:
+    sys.path.insert(0, RUNTIME_SCRIPTS)
+
+from model_selection import (  # noqa: E402
+    CallerError as SelectionError,
+    EvidenceUnavailable,
+    ReviewRequired,
+    validate_selection_record,
+)
+
+
+MAX_JSON_BYTES = 1024 * 1024
+MAX_HANDOFF_BYTES = 4096
+SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
+COMMIT_RE = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})\Z")
+LABEL_RE = re.compile(r"verify-[0-9]{3}\Z")
+GATE_OUTCOMES = {
+    0: "gate-passed",
+    10: "scope-violation",
+    11: "untrusted-worker-claim",
+    12: "invalid-envelope",
+    13: "expected-edits-missing",
+    14: "driver-verification-failed",
+    15: "worker-escalation",
+}
+VERDICTS = {
+    0: "gate-passed",
+    10: "rejected",
+    11: "rejected",
+    12: "rejected",
+    13: "rejected",
+    14: "rejected",
+    15: "routed",
+}
+INTEGRITY_STATEMENT = (
+    "Unsigned local record; schema-valid content can be rewritten and is not "
+    "self-authenticating."
+)
+
+
+class UsageFailure(ValueError):
+    pass
+
+
+class ProtocolFailure(ValueError):
+    pass
+
+
+class SignalInterruption(ProtocolFailure):
+    pass
+
+
+class PublicationFailure(OSError):
+    pass
+
+
+class ValidationFailure(ValueError):
+    pass
+
+
+HANDLED_SIGNALS = (signal.SIGHUP, signal.SIGINT, signal.SIGTERM)
+
+
+class SignalController:
+    def __init__(self) -> None:
+        self.previous: dict[int, Any] = {}
+        self.active_group: int | None = None
+        self.interrupted = False
+        self.signal_number: int | None = None
+        self.published_target: Path | None = None
+        self.published_identity: tuple[int, int] | None = None
+        self.published_descriptor = -1
+        self.private_paths: set[Path] = set()
+
+    def __enter__(self) -> "SignalController":
+        for signum in HANDLED_SIGNALS:
+            self.previous[signum] = signal.signal(signum, self._handle)
+        return self
+
+    def __exit__(self, _kind: Any, _value: Any, _traceback: Any) -> None:
+        for signum, handler in self.previous.items():
+            signal.signal(signum, handler)
+
+    def _handle(self, signum: int, _frame: Any) -> None:
+        if self.interrupted:
+            return
+        self.interrupted = True
+        self.signal_number = signum
+        if self.active_group is not None:
+            try:
+                os.killpg(self.active_group, signum)
+            except ProcessLookupError:
+                pass
+        raise SignalInterruption("receipt operation interrupted")
+
+    @contextmanager
+    def blocked(self):
+        previous_mask = signal.pthread_sigmask(signal.SIG_BLOCK, HANDLED_SIGNALS)
+        try:
+            yield
+        finally:
+            signal.pthread_sigmask(signal.SIG_SETMASK, previous_mask)
+
+    def set_group(self, group: int | None) -> None:
+        self.active_group = group
+
+    def register_publication(
+        self, target: Path, identity: tuple[int, int], descriptor: int
+    ) -> None:
+        self.published_target = target
+        self.published_identity = identity
+        self.published_descriptor = descriptor
+
+    def clear_publication(self) -> None:
+        if self.published_descriptor >= 0:
+            os.close(self.published_descriptor)
+            self.published_descriptor = -1
+        self.published_target = None
+        self.published_identity = None
+
+    def register_private(self, path: Path) -> None:
+        self.private_paths.add(path)
+
+    def clear_private(self, path: Path) -> None:
+        self.private_paths.discard(path)
+
+    def remove_registered_publication(self) -> None:
+        target = self.published_target
+        identity = self.published_identity
+        if target is None or identity is None:
+            self.clear_publication()
+            return
+        try:
+            metadata = target.lstat()
+            if (metadata.st_dev, metadata.st_ino) == identity:
+                target.unlink()
+        except OSError:
+            pass
+        self.clear_publication()
+
+    def cleanup_all(self) -> None:
+        parents: set[Path] = set()
+        if self.published_target is not None:
+            parents.add(self.published_target.parent)
+        self.remove_registered_publication()
+        for path in tuple(self.private_paths):
+            parents.add(path.parent)
+            try:
+                path.unlink()
+            except OSError:
+                pass
+            self.clear_private(path)
+        for parent in parents:
+            try:
+                descriptor = os.open(parent, os.O_RDONLY)
+                try:
+                    os.fsync(descriptor)
+                finally:
+                    os.close(descriptor)
+            except OSError:
+                pass
+
+
+def interruption_checkpoint(_name: str) -> None:
+    """No-op production hook monkeypatched by deterministic offline tests."""
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value, ensure_ascii=True, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+
+
+def published_bytes(value: Any) -> bytes:
+    return canonical_bytes(value) + b"\n"
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def reject_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValidationFailure(f"duplicate key {key!r}")
+        result[key] = value
+    return result
+
+
+def parse_json_bytes(payload: bytes, label: str) -> Any:
+    if not payload or len(payload) > MAX_JSON_BYTES:
+        raise ValidationFailure(f"{label} is empty or oversized")
+    try:
+        return json.loads(payload.decode("utf-8"), object_pairs_hook=reject_duplicates)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValidationFailure(f"{label} is not valid unique-key UTF-8 JSON") from exc
+
+
+def read_real_file(path: Path, label: str, maximum: int = MAX_JSON_BYTES) -> bytes:
+    descriptor = -1
+    try:
+        descriptor = os.open(
+            path,
+            os.O_RDONLY
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_NONBLOCK", 0),
+        )
+        metadata = os.fstat(descriptor)
+    except (OSError, ValueError) as exc:
+        if descriptor >= 0:
+            os.close(descriptor)
+        raise UsageFailure(f"{label} must be one existing real file") from exc
+    if not stat.S_ISREG(metadata.st_mode):
+        os.close(descriptor)
+        raise UsageFailure(f"{label} must be one existing real file")
+    if metadata.st_size > maximum:
+        os.close(descriptor)
+        raise UsageFailure(f"{label} exceeds the {maximum}-byte limit")
+    try:
+        chunks: list[bytes] = []
+        total = 0
+        while True:
+            chunk = os.read(descriptor, min(1024 * 1024, maximum + 1 - total))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            total += len(chunk)
+            if total > maximum:
+                raise UsageFailure(f"{label} exceeds the {maximum}-byte limit")
+        payload = b"".join(chunks)
+    except OSError as exc:
+        raise UsageFailure(f"{label} could not be read") from exc
+    finally:
+        os.close(descriptor)
+    return payload
+
+
+def require_exact_fields(value: dict[str, Any], expected: set[str], label: str) -> None:
+    if set(value) != expected:
+        raise ValidationFailure(f"{label} fields are inconsistent")
+
+
+def require_sha(value: Any, label: str) -> str:
+    if not isinstance(value, str) or SHA256_RE.fullmatch(value) is None:
+        raise ValidationFailure(f"{label} must be one lowercase SHA-256")
+    return value
+
+
+def require_unpadded_string(value: Any, label: str, maximum: int = 4096) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or value.strip() != value
+        or len(value) > maximum
+    ):
+        raise ValidationFailure(f"{label} must be one bounded unpadded string")
+    return value
+
+
+SCHEMA_KEYS = {
+    "$schema",
+    "title",
+    "type",
+    "additionalProperties",
+    "required",
+    "properties",
+    "items",
+    "enum",
+    "minLength",
+    "maxLength",
+    "minimum",
+    "maximum",
+}
+
+
+def preflight_schema(schema: Any, location: str = "$") -> None:
+    if not isinstance(schema, dict):
+        raise ValidationFailure(f"schema node at {location} is not an object")
+    unknown = set(schema) - SCHEMA_KEYS
+    if unknown:
+        raise ValidationFailure(f"schema has unsupported keys at {location}")
+    properties = schema.get("properties", {})
+    if not isinstance(properties, dict):
+        raise ValidationFailure(f"schema properties at {location} are invalid")
+    for key, child in properties.items():
+        preflight_schema(child, f"{location}.{key}")
+    if "items" in schema:
+        preflight_schema(schema["items"], f"{location}[]")
+
+
+def schema_type_matches(value: Any, expected: str) -> bool:
+    if expected == "object":
+        return isinstance(value, dict)
+    if expected == "array":
+        return isinstance(value, list)
+    if expected == "string":
+        return isinstance(value, str)
+    if expected == "boolean":
+        return type(value) is bool
+    if expected == "number":
+        return type(value) in (int, float)
+    raise ValidationFailure("schema contains an unknown type")
+
+
+def validate_schema(value: Any, schema: dict[str, Any], location: str = "$") -> None:
+    expected_type = schema.get("type")
+    if expected_type is not None and not schema_type_matches(value, expected_type):
+        raise ValidationFailure(f"{location} has the wrong type")
+    if "enum" in schema and value not in schema["enum"]:
+        raise ValidationFailure(f"{location} has a forbidden value")
+    if isinstance(value, str):
+        if len(value) < schema.get("minLength", 0):
+            raise ValidationFailure(f"{location} is too short")
+        if len(value) > schema.get("maxLength", len(value)):
+            raise ValidationFailure(f"{location} is too long")
+    if type(value) in (int, float):
+        if value < schema.get("minimum", value):
+            raise ValidationFailure(f"{location} is below minimum")
+        if value > schema.get("maximum", value):
+            raise ValidationFailure(f"{location} is above maximum")
+    if isinstance(value, list) and "items" in schema:
+        for index, item in enumerate(value):
+            validate_schema(item, schema["items"], f"{location}[{index}]")
+    if isinstance(value, dict):
+        required = set(schema.get("required", []))
+        if required - set(value):
+            raise ValidationFailure(f"{location} is missing required fields")
+        properties = schema.get("properties", {})
+        if schema.get("additionalProperties") is False and set(value) - set(properties):
+            raise ValidationFailure(f"{location} has unexpected fields")
+        for key, child in properties.items():
+            if key in value:
+                validate_schema(value[key], child, f"{location}.{key}")
+
+
+def load_schema(schema_path: Path) -> dict[str, Any]:
+    schema = parse_json_bytes(read_real_file(schema_path, "receipt schema"), "receipt schema")
+    if not isinstance(schema, dict):
+        raise ValidationFailure("receipt schema root must be an object")
+    preflight_schema(schema)
+    return schema
+
+
+def validate_integrity(value: Any) -> None:
+    if not isinstance(value, dict):
+        raise ValidationFailure("integrity must be an object")
+    require_exact_fields(value, {"signed", "tamper_evident", "statement"}, "integrity")
+    if value != {
+        "signed": False,
+        "tamper_evident": False,
+        "statement": INTEGRITY_STATEMENT,
+    }:
+        raise ValidationFailure("integrity must state the fixed unsigned limitation")
+
+
+def recommendation_argv(value: dict[str, Any]) -> list[str]:
+    if value.get("stage") != "pre-dispatch":
+        raise ValidationFailure("only a pre-dispatch recommendation may be bound")
+    evidence = value.get("evidence")
+    if not isinstance(evidence, dict) or set(evidence) != {"owner", "code", "description"}:
+        raise ValidationFailure("recommendation evidence is invalid")
+    code = require_unpadded_string(evidence.get("code"), "recommendation evidence code", 64)
+    argv = ["--stage", "pre-dispatch"]
+    tier = value.get("selected_tier")
+    model = value.get("user_model")
+    if (tier is None) == (model is None):
+        raise ValidationFailure("recommendation must contain exactly one selection mode")
+    if tier is not None:
+        argv += ["--selected-tier", require_unpadded_string(tier, "selected tier", 128)]
+        if "user_effort" in value:
+            raise ValidationFailure("tier recommendation cannot contain effort")
+    else:
+        argv += ["--selected-model", require_unpadded_string(model, "user model", 128)]
+        if "user_effort" in value:
+            argv += [
+                "--selected-effort",
+                require_unpadded_string(value["user_effort"], "user effort", 16),
+            ]
+    argv += ["--evidence", code]
+    return argv
+
+
+def validate_recommendation(
+    value: Any, recommendation_script: Path
+) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValidationFailure("pre-dispatch recommendation must be an object")
+    argv = recommendation_argv(value)
+    try:
+        completed = subprocess.run(
+            [sys.executable, "-B", str(recommendation_script), *argv],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise ValidationFailure("canonical recommendation validation failed") from exc
+    if completed.returncode != 0 or len(completed.stdout) > MAX_JSON_BYTES:
+        raise ValidationFailure("recommendation is not canonical")
+    expected = parse_json_bytes(completed.stdout, "canonical recommendation")
+    if value != expected:
+        raise ValidationFailure("recommendation differs from canonical policy output")
+    return value
+
+
+def selection_matches_recommendation(
+    selection: dict[str, Any], recommendation: dict[str, Any]
+) -> bool:
+    if selection["selection_mode"] == "tier":
+        return (
+            recommendation.get("selected_tier") == selection["selected_tier"]
+            and "user_model" not in recommendation
+        )
+    keys = [
+        "user_model",
+        "resolved_agy_model",
+        "matrix_sha256",
+        "matrix_agy_version",
+        "matrix_source_revision",
+    ]
+    if any(recommendation.get(key) != selection.get(key) for key in keys):
+        return False
+    return recommendation.get("user_effort") == selection.get("user_effort")
+
+
+def validate_receipt(
+    value: Any,
+    schema: dict[str, Any],
+    recommendation_script: Path,
+) -> dict[str, Any]:
+    validate_schema(value, schema)
+    if not isinstance(value, dict):
+        raise ValidationFailure("receipt must be one object")
+    if type(value.get("schema_version")) is not int or value["schema_version"] != 1:
+        raise ValidationFailure("schema_version must be integer 1")
+    resolved_base = value.get("resolved_base")
+    if not isinstance(resolved_base, str) or COMMIT_RE.fullmatch(resolved_base) is None:
+        raise ValidationFailure("resolved_base is invalid")
+    for key in (
+        "envelope_sha256",
+        "path_policy_sha256",
+        "initial_candidate_state_sha256",
+        "final_candidate_state_sha256",
+    ):
+        require_sha(value.get(key), key)
+    gate_exit = value.get("gate_exit")
+    if type(gate_exit) is not int or gate_exit not in GATE_OUTCOMES:
+        raise ValidationFailure("gate_exit is not a receiptable gate result")
+    if value.get("gate_outcome") != GATE_OUTCOMES[gate_exit]:
+        raise ValidationFailure("gate outcome and exit are inconsistent")
+    if value.get("verdict") != VERDICTS[gate_exit]:
+        raise ValidationFailure("receipt verdict and exit are inconsistent")
+    if value.get("gate_authority") != "qa-gate":
+        raise ValidationFailure("gate authority is invalid")
+    if value.get("recommendations_participated_in_acceptance") is not False:
+        raise ValidationFailure("recommendation cannot participate in acceptance")
+    validate_integrity(value.get("integrity"))
+    verifiers = value.get("verifiers")
+    if not isinstance(verifiers, list) or not verifiers:
+        raise ValidationFailure("receipt needs at least one verifier hash")
+    for index, verifier in enumerate(verifiers, 1):
+        if not isinstance(verifier, dict):
+            raise ValidationFailure("verifier entry must be an object")
+        require_exact_fields(verifier, {"label", "command_sha256"}, "verifier")
+        if verifier.get("label") != f"verify-{index:03d}" or LABEL_RE.fullmatch(
+            verifier.get("label", "")
+        ) is None:
+            raise ValidationFailure("verifier labels are not deterministic")
+        require_sha(verifier.get("command_sha256"), "verifier command hash")
+    selection = value.get("caller_selection")
+    if selection is not None:
+        try:
+            # Semantic validation against the active G1 contract is performed on
+            # publication input.  Receipt-only validation still enforces exact
+            # selector shape below without re-probing agy.
+            if not isinstance(selection, dict):
+                raise SelectionError("selection record must be one object")
+            from model_selection import validate_selection_record
+
+            validate_selection_record(selection)
+        except (SelectionError, ReviewRequired, EvidenceUnavailable) as exc:
+            raise ValidationFailure("caller selection is not a valid G1 record") from exc
+    recommendation = value.get("pre_dispatch_recommendation")
+    if recommendation is not None:
+        recommendation = validate_recommendation(recommendation, recommendation_script)
+    if selection is not None and recommendation is not None:
+        if not selection_matches_recommendation(selection, recommendation):
+            raise ValidationFailure("selection and recommendation are inconsistent")
+    return value
+
+
+def load_selection(path: Path) -> dict[str, Any]:
+    try:
+        value = parse_json_bytes(
+            read_real_file(path, "selection input"), "selection input"
+        )
+        if not isinstance(value, dict):
+            raise SelectionError("selection record must be one object")
+        validate_selection_record(value)
+        return value
+    except (
+        SelectionError,
+        ReviewRequired,
+        EvidenceUnavailable,
+        ValidationFailure,
+    ) as exc:
+        raise UsageFailure("selection input is not a current valid G1 record") from exc
+
+
+def load_recommendation(path: Path, recommendation_script: Path) -> dict[str, Any]:
+    try:
+        value = parse_json_bytes(
+            read_real_file(path, "pre-dispatch recommendation"),
+            "pre-dispatch recommendation",
+        )
+        return validate_recommendation(value, recommendation_script)
+    except ValidationFailure as exc:
+        raise UsageFailure("pre-dispatch recommendation is not canonical") from exc
+
+
+def validate_target(target: Path, repo: Path) -> tuple[Path, str]:
+    if not target.is_absolute() or "\n" in str(target) or "\r" in str(target):
+        raise UsageFailure("--receipt must be one canonical absolute path")
+    if target.exists() or target.is_symlink():
+        raise UsageFailure("--receipt must name a new path and never overwrites")
+    try:
+        parent_text = os.path.abspath(str(target.parent))
+        parent = target.parent.resolve(strict=True)
+        repo_resolved = repo.resolve(strict=True)
+        metadata = parent.lstat()
+    except OSError as exc:
+        raise UsageFailure("receipt parent and repository must exist") from exc
+    if str(parent) != parent_text:
+        raise UsageFailure("receipt parent must be a canonical real directory")
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or metadata.st_uid != os.geteuid()
+        or stat.S_IMODE(metadata.st_mode) & 0o077
+        or stat.S_IMODE(metadata.st_mode) & 0o700 != 0o700
+    ):
+        raise UsageFailure("receipt parent must be an owner-private real directory")
+    try:
+        if os.path.commonpath((str(parent / target.name), str(repo_resolved))) == str(
+            repo_resolved
+        ):
+            raise UsageFailure("receipt must be outside the audited repository")
+    except ValueError as exc:
+        raise UsageFailure("receipt and repository paths are incompatible") from exc
+    return parent, target.name
+
+
+def require_private_parent(parent: Path) -> None:
+    try:
+        metadata = parent.lstat()
+        canonical = parent.resolve(strict=True)
+    except OSError as exc:
+        raise PublicationFailure("receipt parent became unavailable") from exc
+    if (
+        canonical != parent
+        or not stat.S_ISDIR(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or metadata.st_uid != os.geteuid()
+        or stat.S_IMODE(metadata.st_mode) & 0o077
+        or stat.S_IMODE(metadata.st_mode) & 0o700 != 0o700
+    ):
+        raise PublicationFailure("receipt parent is no longer owner-private")
+
+
+def private_file(
+    parent: Path,
+    stem: str,
+    payload: bytes = b"",
+    controller: SignalController | None = None,
+    checkpoint: str | None = None,
+) -> tuple[Path, int]:
+    for counter in range(100):
+        path = parent / f".{stem}.{os.getpid()}.{counter}"
+        descriptor = -1
+        try:
+            if controller is None:
+                descriptor = os.open(
+                    path,
+                    os.O_WRONLY
+                    | os.O_CREAT
+                    | os.O_EXCL
+                    | getattr(os, "O_NOFOLLOW", 0),
+                    0o600,
+                )
+                os.fchmod(descriptor, 0o600)
+            else:
+                with controller.blocked():
+                    descriptor = os.open(
+                        path,
+                        os.O_WRONLY
+                        | os.O_CREAT
+                        | os.O_EXCL
+                        | getattr(os, "O_NOFOLLOW", 0),
+                        0o600,
+                    )
+                    os.fchmod(descriptor, 0o600)
+                    controller.register_private(path)
+        except FileExistsError:
+            continue
+        except SignalInterruption:
+            if descriptor >= 0:
+                os.close(descriptor)
+            try:
+                path.unlink()
+            except OSError:
+                pass
+            if controller is not None:
+                controller.clear_private(path)
+            raise
+        except OSError as exc:
+            if descriptor >= 0:
+                os.close(descriptor)
+            try:
+                path.unlink()
+            except OSError:
+                pass
+            if controller is not None:
+                controller.clear_private(path)
+            raise PublicationFailure("could not create a private temporary file") from exc
+        try:
+            if checkpoint is not None:
+                interruption_checkpoint(checkpoint)
+            if payload:
+                view = memoryview(payload)
+                while view:
+                    written = os.write(descriptor, view)
+                    if written <= 0:
+                        raise OSError("short private-file write")
+                    view = view[written:]
+            return path, descriptor
+        except BaseException:
+            os.close(descriptor)
+            try:
+                path.unlink()
+            except OSError:
+                pass
+            if controller is not None:
+                controller.clear_private(path)
+            raise
+    raise PublicationFailure("could not create a private temporary file")
+
+
+def snapshot_file(
+    source: Path, parent: Path, controller: SignalController
+) -> tuple[Path, str]:
+    try:
+        metadata = source.lstat()
+    except OSError as exc:
+        raise UsageFailure("envelope must be one existing real file") from exc
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+        raise UsageFailure("envelope must be one existing real file")
+    path, descriptor = private_file(
+        parent,
+        "agy-receipt-envelope",
+        controller=controller,
+        checkpoint="snapshot-created",
+    )
+    source_descriptor = -1
+    digest = hashlib.sha256()
+    try:
+        source_descriptor = os.open(
+            source,
+            os.O_RDONLY
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_NONBLOCK", 0),
+        )
+        if not stat.S_ISREG(os.fstat(source_descriptor).st_mode):
+            raise OSError("envelope snapshot source is not regular")
+        while True:
+            chunk = os.read(source_descriptor, 1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+            view = memoryview(chunk)
+            while view:
+                written = os.write(descriptor, view)
+                if written <= 0:
+                    raise OSError("short envelope snapshot write")
+                view = view[written:]
+        interruption_checkpoint("snapshot-before-fsync")
+        os.fsync(descriptor)
+    except (OSError, SignalInterruption) as exc:
+        try:
+            path.unlink()
+        except OSError:
+            pass
+        controller.clear_private(path)
+        if isinstance(exc, SignalInterruption):
+            raise
+        raise UsageFailure("could not snapshot envelope") from exc
+    finally:
+        if source_descriptor >= 0:
+            os.close(source_descriptor)
+        os.close(descriptor)
+    return path, digest.hexdigest()
+
+
+def parse_handoff(payload: bytes) -> dict[str, Any]:
+    if not payload or len(payload) > MAX_HANDOFF_BYTES:
+        raise ProtocolFailure("gate evidence is missing or oversized")
+    if not payload.endswith(b"\n") or payload.count(b"\n") != 1:
+        raise ProtocolFailure("gate evidence must be exactly one JSON line")
+    try:
+        value = parse_json_bytes(payload[:-1], "gate evidence")
+    except ValidationFailure as exc:
+        raise ProtocolFailure("gate evidence is malformed") from exc
+    fields = {
+        "schema_version",
+        "kind",
+        "resolved_base",
+        "envelope_sha256",
+        "initial_candidate_state_sha256",
+        "final_candidate_state_sha256",
+        "gate_exit",
+        "gate_outcome",
+    }
+    if not isinstance(value, dict) or set(value) != fields:
+        raise ProtocolFailure("gate evidence fields are inconsistent")
+    if type(value.get("schema_version")) is not int or value["schema_version"] != 1:
+        raise ProtocolFailure("gate evidence version is invalid")
+    if value.get("kind") != "agy-worker-gate-evidence":
+        raise ProtocolFailure("gate evidence kind is invalid")
+    if not isinstance(value.get("resolved_base"), str) or COMMIT_RE.fullmatch(
+        value["resolved_base"]
+    ) is None:
+        raise ProtocolFailure("gate evidence base is invalid")
+    for key in (
+        "envelope_sha256",
+        "initial_candidate_state_sha256",
+        "final_candidate_state_sha256",
+    ):
+        try:
+            require_sha(value.get(key), key)
+        except ValidationFailure as exc:
+            raise ProtocolFailure("gate evidence digest is invalid") from exc
+    gate_exit = value.get("gate_exit")
+    if type(gate_exit) is not int or gate_exit not in GATE_OUTCOMES:
+        raise ProtocolFailure("gate evidence exit is unknown")
+    if value.get("gate_outcome") != GATE_OUTCOMES[gate_exit]:
+        raise ProtocolFailure("gate evidence outcome is inconsistent")
+    return value
+
+
+def publish_receipt(
+    target: Path,
+    parent: Path,
+    value: dict[str, Any],
+    schema: dict[str, Any],
+    recommendation_script: Path,
+    controller: SignalController | None = None,
+) -> None:
+    owns_controller = controller is None
+    controller = controller or SignalController()
+    require_private_parent(parent)
+    payload = published_bytes(value)
+    temporary, descriptor = private_file(
+        parent,
+        f"{target.name}.receipt",
+        payload,
+        controller=controller,
+        checkpoint="publication-temp-created",
+    )
+    directory_fd = -1
+    try:
+        interruption_checkpoint("publication-before-file-fsync")
+        os.fsync(descriptor)
+        candidate_payload = read_real_file(temporary, "temporary receipt")
+        candidate = parse_json_bytes(candidate_payload, "temporary receipt")
+        validate_receipt(candidate, schema, recommendation_script)
+        if candidate != value or candidate_payload != payload:
+            raise PublicationFailure("temporary receipt bytes changed")
+        require_private_parent(parent)
+        temporary_metadata = os.fstat(descriptor)
+        published_identity = (
+            temporary_metadata.st_dev,
+            temporary_metadata.st_ino,
+        )
+        controller.register_publication(target, published_identity, descriptor)
+        descriptor = -1
+        interruption_checkpoint("publication-before-link")
+        with controller.blocked():
+            os.link(temporary, target, follow_symlinks=False)
+            interruption_checkpoint("publication-after-link")
+        with controller.blocked():
+            directory_fd = os.open(parent, os.O_RDONLY)
+        interruption_checkpoint("publication-before-first-parent-fsync")
+        os.fsync(directory_fd)
+        temporary.unlink()
+        controller.clear_private(temporary)
+        interruption_checkpoint("publication-before-second-parent-fsync")
+        os.fsync(directory_fd)
+        os.close(directory_fd)
+        directory_fd = -1
+    except (
+        OSError,
+        ValidationFailure,
+        PublicationFailure,
+        SignalInterruption,
+    ) as exc:
+        controller.remove_registered_publication()
+        if directory_fd >= 0:
+            os.close(directory_fd)
+        if descriptor >= 0:
+            os.close(descriptor)
+        try:
+            temporary.unlink()
+        except OSError:
+            pass
+        controller.clear_private(temporary)
+        try:
+            cleanup_fd = os.open(parent, os.O_RDONLY)
+            try:
+                os.fsync(cleanup_fd)
+            finally:
+                os.close(cleanup_fd)
+        except OSError:
+            pass
+        if isinstance(exc, SignalInterruption):
+            raise
+        raise PublicationFailure("receipt publication failed") from exc
+    if owns_controller:
+        controller.clear_publication()
+
+
+class UsageParser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:
+        self.print_usage(sys.stderr)
+        self.exit(64, f"verify-job: {message}\n")
+
+
+def one(parser: UsageParser, values: list[str] | None, flag: str, required: bool) -> str | None:
+    if not values:
+        if required:
+            parser.error(f"{flag} is required")
+        return None
+    if len(values) != 1:
+        parser.error(f"{flag} must be provided at most once")
+    return values[0]
+
+
+def build_parser() -> UsageParser:
+    parser = UsageParser(prog="verify-job.sh", add_help=True)
+    parser.add_argument("--receipt", action="append")
+    parser.add_argument("--envelope", action="append")
+    parser.add_argument("--repo", action="append")
+    parser.add_argument("--base", action="append")
+    parser.add_argument("--allow", action="append", default=[])
+    parser.add_argument("--only", action="append", default=[])
+    parser.add_argument("--verify", action="append", default=[])
+    parser.add_argument("--expect-edits", action="count", default=0)
+    parser.add_argument("--selection", action="append")
+    parser.add_argument("--pre-recommendation", action="append")
+    return parser
+
+
+def sanitized_gate_environment() -> dict[str, str]:
+    gate_environment = os.environ.copy()
+    unsafe_shell = {
+        "BASH_ENV",
+        "ENV",
+        "SHELLOPTS",
+        "BASHOPTS",
+        "PS4",
+        "CDPATH",
+        "GLOBIGNORE",
+        "BASH_LOADABLES_PATH",
+        "BASH_XTRACEFD",
+        "BASH_COMPAT",
+    }
+    for key in tuple(gate_environment):
+        if (
+            key in unsafe_shell
+            or key.startswith("PYTHON")
+            or key.startswith("BASH_FUNC_")
+        ):
+            gate_environment.pop(key, None)
+    gate_environment.pop("AGY_WORKER_SCHEMA", None)
+    return gate_environment
+
+
+def run_gate(
+    gate: Path,
+    args: list[str],
+    evidence_fd: int,
+    controller: SignalController,
+) -> int:
+    child: subprocess.Popen[bytes] | None = None
+    try:
+        gate_environment = sanitized_gate_environment()
+        evidence_token = secrets.token_hex(32)
+        gate_environment["AGY_WORKER_INTERNAL_EVIDENCE_TOKEN"] = evidence_token
+        gate_environment["AGY_WORKER_INTERNAL_PYTHON"] = str(
+            Path(sys.executable).resolve(strict=True)
+        )
+        child = subprocess.Popen(
+            [
+                "/bin/bash",
+                str(gate),
+                *args,
+                "--evidence-fd",
+                str(evidence_fd),
+                "--evidence-token",
+                evidence_token,
+            ],
+            stdin=subprocess.DEVNULL,
+            pass_fds=(evidence_fd,),
+            start_new_session=True,
+            env=gate_environment,
+        )
+        controller.set_group(child.pid)
+        gate_exit = child.wait()
+        return gate_exit
+    except SignalInterruption:
+        if child is not None:
+            try:
+                os.killpg(child.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            try:
+                child.wait(timeout=5)
+            except (subprocess.TimeoutExpired, OSError):
+                pass
+        raise
+    except OSError as exc:
+        raise ProtocolFailure("gate could not start") from exc
+    finally:
+        controller.set_group(None)
+
+
+def verify_main(
+    argv: list[str], runtime_root: Path, controller: SignalController
+) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    receipt_text = one(parser, args.receipt, "--receipt", True)
+    envelope_text = one(parser, args.envelope, "--envelope", True)
+    repo_text = one(parser, args.repo, "--repo", True)
+    base = one(parser, args.base, "--base", True)
+    selection_text = one(parser, args.selection, "--selection", False)
+    recommendation_text = one(
+        parser, args.pre_recommendation, "--pre-recommendation", False
+    )
+    if args.expect_edits > 1:
+        parser.error("--expect-edits must be provided at most once")
+    if not args.verify or any(not value.strip() for value in args.verify):
+        parser.error("at least one non-empty --verify command is required")
+    if len(args.verify) > 999:
+        parser.error("at most 999 verifier commands are supported")
+    assert receipt_text and envelope_text and repo_text and base
+
+    target = Path(receipt_text)
+    repo = Path(repo_text)
+    parent, _name = validate_target(target, repo)
+    schema_path = runtime_root / "schemas/evidence-receipt.schema.json"
+    recommendation_script = runtime_root / "scripts/model-recommendation.py"
+    schema = load_schema(schema_path)
+    selection = load_selection(Path(selection_text)) if selection_text else None
+    recommendation = (
+        load_recommendation(Path(recommendation_text), recommendation_script)
+        if recommendation_text
+        else None
+    )
+    if selection is not None and recommendation is not None:
+        if not selection_matches_recommendation(selection, recommendation):
+            raise UsageFailure("selection and recommendation inputs do not match")
+
+    envelope_snapshot: Path | None = None
+    handoff_path: Path | None = None
+    write_fd = -1
+    result: int | None = None
+    try:
+        envelope_snapshot, envelope_sha256 = snapshot_file(
+            Path(envelope_text), parent, controller
+        )
+        handoff_path, write_fd = private_file(
+            parent,
+            "agy-receipt-handoff",
+            controller=controller,
+            checkpoint="handoff-created",
+        )
+        gate_args = [
+            "--envelope",
+            str(envelope_snapshot),
+            "--repo",
+            repo_text,
+            "--base",
+            base,
+        ]
+        for value in args.allow:
+            gate_args += ["--allow", value]
+        for value in args.only:
+            gate_args += ["--only", value]
+        if args.expect_edits:
+            gate_args.append("--expect-edits")
+        for value in args.verify:
+            gate_args += ["--verify", value]
+
+        try:
+            gate_rc = run_gate(
+                runtime_root / "qa-gate.sh", gate_args, write_fd, controller
+            )
+        finally:
+            if write_fd >= 0:
+                os.close(write_fd)
+                write_fd = -1
+        if gate_rc == 64:
+            result = 64
+            return result
+        if gate_rc not in GATE_OUTCOMES:
+            raise ProtocolFailure("gate returned an internal or interrupted result")
+        try:
+            handoff_payload = read_real_file(
+                handoff_path, "gate evidence", MAX_HANDOFF_BYTES
+            )
+        except UsageFailure as exc:
+            raise ProtocolFailure("gate evidence is unavailable") from exc
+        handoff = parse_handoff(handoff_payload)
+        if handoff["gate_exit"] != gate_rc:
+            raise ProtocolFailure("gate process exit and evidence exit differ")
+        if handoff["resolved_base"] != base:
+            raise ProtocolFailure("gate resolved a different base")
+        if handoff["envelope_sha256"] != envelope_sha256:
+            raise ProtocolFailure("gate validated a different envelope snapshot")
+
+        policy = {
+            "allow": args.allow,
+            "only": args.only,
+            "expect_edits": bool(args.expect_edits),
+        }
+        receipt: dict[str, Any] = {
+            "schema_version": 1,
+            "kind": "agy-worker-evidence-receipt",
+            "gate_authority": "qa-gate",
+            "resolved_base": handoff["resolved_base"],
+            "envelope_sha256": handoff["envelope_sha256"],
+            "path_policy_sha256": sha256_bytes(canonical_bytes(policy)),
+            "verifiers": [
+                {
+                    "label": f"verify-{index:03d}",
+                    "command_sha256": sha256_bytes(command.encode("utf-8")),
+                }
+                for index, command in enumerate(args.verify, 1)
+            ],
+            "initial_candidate_state_sha256": handoff[
+                "initial_candidate_state_sha256"
+            ],
+            "final_candidate_state_sha256": handoff[
+                "final_candidate_state_sha256"
+            ],
+            "gate_exit": gate_rc,
+            "gate_outcome": handoff["gate_outcome"],
+            "verdict": VERDICTS[gate_rc],
+            "recommendations_participated_in_acceptance": False,
+            "integrity": {
+                "signed": False,
+                "tamper_evident": False,
+                "statement": INTEGRITY_STATEMENT,
+            },
+        }
+        if selection is not None:
+            receipt["caller_selection"] = selection
+        if recommendation is not None:
+            receipt["pre_dispatch_recommendation"] = recommendation
+        validate_receipt(receipt, schema, recommendation_script)
+        publish_receipt(
+            target,
+            parent,
+            receipt,
+            schema,
+            recommendation_script,
+            controller,
+        )
+        result = gate_rc
+    except SignalInterruption:
+        controller.remove_registered_publication()
+        raise
+    finally:
+        interruption_checkpoint("wrapper-cleanup-start")
+        if write_fd >= 0:
+            os.close(write_fd)
+        for private_path in (envelope_snapshot, handoff_path):
+            if private_path is not None:
+                try:
+                    private_path.unlink(missing_ok=True)
+                except OSError:
+                    pass
+                controller.clear_private(private_path)
+        try:
+            cleanup_fd = os.open(parent, os.O_RDONLY)
+            try:
+                interruption_checkpoint("wrapper-cleanup-parent-fsync")
+                os.fsync(cleanup_fd)
+            finally:
+                os.close(cleanup_fd)
+        except OSError:
+            pass
+    if result is None:
+        raise ProtocolFailure("gate result was not established")
+    controller.clear_publication()
+    return result
+
+
+def validate_main(argv: list[str], runtime_root: Path) -> int:
+    parser = UsageParser(prog="evidence-receipt-validator")
+    parser.add_argument("--receipt", action="append")
+    parser.add_argument("--envelope", action="append")
+    parser.add_argument("--selection", action="append")
+    parser.add_argument("--pre-recommendation", action="append")
+    parser.add_argument("--initial-state-digest", action="append")
+    parser.add_argument("--final-state-digest", action="append")
+    parsed = parser.parse_args(argv)
+    receipt_text = one(parser, parsed.receipt, "--receipt", True)
+    envelope_text = one(parser, parsed.envelope, "--envelope", False)
+    selection_text = one(parser, parsed.selection, "--selection", False)
+    recommendation_text = one(
+        parser, parsed.pre_recommendation, "--pre-recommendation", False
+    )
+    initial_digest = one(
+        parser, parsed.initial_state_digest, "--initial-state-digest", False
+    )
+    final_digest = one(
+        parser, parsed.final_state_digest, "--final-state-digest", False
+    )
+    assert receipt_text
+    schema = load_schema(runtime_root / "schemas/evidence-receipt.schema.json")
+    recommendation_script = runtime_root / "scripts/model-recommendation.py"
+    value = parse_json_bytes(
+        read_real_file(Path(receipt_text), "receipt"), "receipt"
+    )
+    receipt = validate_receipt(value, schema, recommendation_script)
+    if envelope_text:
+        payload = read_real_file(Path(envelope_text), "bound envelope")
+        if sha256_bytes(payload) != receipt["envelope_sha256"]:
+            raise ValidationFailure("bound envelope digest does not match receipt")
+    if selection_text:
+        selection = load_selection(Path(selection_text))
+        if receipt.get("caller_selection") != selection:
+            raise ValidationFailure("bound selection does not match receipt")
+    if recommendation_text:
+        recommendation = load_recommendation(
+            Path(recommendation_text), recommendation_script
+        )
+        if receipt.get("pre_dispatch_recommendation") != recommendation:
+            raise ValidationFailure("bound recommendation does not match receipt")
+    if initial_digest:
+        require_sha(initial_digest, "bound initial state digest")
+        if receipt["initial_candidate_state_sha256"] != initial_digest:
+            raise ValidationFailure("bound initial state digest does not match receipt")
+    if final_digest:
+        require_sha(final_digest, "bound final state digest")
+        if receipt["final_candidate_state_sha256"] != final_digest:
+            raise ValidationFailure("bound final state digest does not match receipt")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    runtime_root = Path(__file__).resolve().parent.parent
+    if not arguments or arguments[0] not in ("verify", "validate"):
+        print("usage: evidence_receipt.py verify|validate ...", file=sys.stderr)
+        return 64
+    command = arguments.pop(0)
+    try:
+        if command == "verify":
+            with SignalController() as controller:
+                try:
+                    return verify_main(arguments, runtime_root, controller)
+                except SignalInterruption:
+                    controller.cleanup_all()
+                    raise
+        return validate_main(arguments, runtime_root)
+    except UsageFailure as exc:
+        print(f"verify-job: invalid input - {exc}", file=sys.stderr)
+        return 64
+    except ProtocolFailure:
+        print("verify-job: gate evidence protocol failed", file=sys.stderr)
+        return 70
+    except ValidationFailure as exc:
+        if command == "validate":
+            print(f"evidence receipt invalid: {exc}", file=sys.stderr)
+            return 1
+        print("verify-job: receipt publication failed", file=sys.stderr)
+        return 74
+    except PublicationFailure:
+        print("verify-job: receipt publication failed", file=sys.stderr)
+        return 74
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/agy-worker/runtime/verify-job.sh
+++ b/skills/agy-worker/runtime/verify-job.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Run the canonical gate and publish one private Evidence Receipt v1.
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+exec python3 -I -S -B "$SCRIPT_DIR/scripts/evidence_receipt.py" verify "$@"

--- a/skills/agy-worker/scripts/resolve-pipeline.sh
+++ b/skills/agy-worker/scripts/resolve-pipeline.sh
@@ -26,7 +26,7 @@ is_pipeline() {
     fi
     pipeline_runtime_complete "$runtime_root" || return 1
 
-    for required in agy-worker.sh qa-gate.sh model-recommendation.sh model-selection.sh doctor.sh; do
+    for required in agy-worker.sh qa-gate.sh verify-job.sh model-recommendation.sh model-selection.sh doctor.sh; do
         [[ -f "$pipeline_root/$required" && -x "$pipeline_root/$required" \
             && ! -L "$pipeline_root/$required" ]] || return 1
     done
@@ -53,10 +53,12 @@ pipeline_runtime_complete() {
     for required in \
         agy-worker.sh \
         qa-gate.sh \
+        verify-job.sh \
         model-recommendation.sh \
         model-selection.sh \
         doctor.sh \
         scripts/validate-envelope.py \
+        scripts/evidence_receipt.py \
         scripts/model-recommendation.py \
         scripts/model_selection.py \
         scripts/compatibility.py \
@@ -79,6 +81,7 @@ pipeline_runtime_complete() {
 
     for required in \
         schemas/worker-result.schema.json \
+        schemas/evidence-receipt.schema.json \
         schemas/model-selection.schema.json \
         schemas/model-recommendation.schema.json \
         agents/bulk-test-writer.md \

--- a/tests/test-doctor.sh
+++ b/tests/test-doctor.sh
@@ -659,9 +659,12 @@ done
 
 for specification in \
     'qa-gate.sh:executable' \
+    'verify-job.sh:executable' \
     'scripts/validate-envelope.py:executable' \
+    'scripts/evidence_receipt.py:executable' \
     'scripts/model_selection.py:executable' \
     'schemas/worker-result.schema.json:data' \
+    'schemas/evidence-receipt.schema.json:data' \
     'agents/repo-inventory.md:data' \
     'compat/agy-verified-version.txt:data' \
     'compat/agy-model-effort-matrix.json:data'; do
@@ -744,8 +747,10 @@ fi
 
 for dependency in \
     'scripts/validate-envelope.py:python-helper' \
+    'scripts/evidence_receipt.py:receipt-helper' \
     'scripts/model_selection.py:model-resolver' \
     'schemas/worker-result.schema.json:schema' \
+    'schemas/evidence-receipt.schema.json:receipt-schema' \
     'schemas/model-selection.schema.json:selection-schema' \
     'agents/repo-inventory.md:persona' \
     'compat/agy-upstream-head.txt:source-record' \

--- a/tests/test-evidence-receipt.sh
+++ b/tests/test-evidence-receipt.sh
@@ -1,0 +1,1015 @@
+#!/usr/bin/env bash
+# Offline adversarial suite for Evidence Receipt v1: no agy, network, or provider.
+set -uo pipefail
+
+HERE="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+ROOT="$(CDPATH= cd -- "$HERE/.." && pwd -P)"
+VERIFY="$ROOT/verify-job.sh"
+GATE="$ROOT/qa-gate.sh"
+VALIDATOR="$ROOT/skills/agy-worker/runtime/scripts/evidence_receipt.py"
+INTERNAL_EVIDENCE_TOKEN="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+INTERNAL_PYTHON="$(python3 -I -S -B -c 'import pathlib,sys; print(pathlib.Path(sys.executable).resolve())')"
+TMP="$(mktemp -d -t agyworker-receipt.XXXXXX)"
+trap 'rm -rf -- "$TMP"' EXIT
+pass=0; fail=0
+
+ok() { printf '  ok   %s\n' "$1"; pass=$((pass + 1)); }
+bad() { printf '  FAIL %s\n' "$1"; fail=$((fail + 1)); }
+
+REPO="$TMP/repo"
+RECEIPTS="$TMP/receipts"
+mkdir -m 700 "$REPO" "$RECEIPTS"
+RECEIPTS="$(CDPATH= cd -- "$RECEIPTS" && pwd -P)"
+git -C "$REPO" init -q
+git -C "$REPO" config user.email test@example.com
+git -C "$REPO" config user.name test
+printf 'original\n' > "$REPO/a.txt"
+printf 'ignored.tmp\n' > "$REPO/.gitignore"
+git -C "$REPO" add -A
+git -C "$REPO" commit -qm init
+BASE="$(git -C "$REPO" rev-parse HEAD)"
+
+reset_repo() {
+    git -C "$REPO" checkout -q -- .
+    git -C "$REPO" clean -qfdx
+}
+
+write_envelope() { printf '%s\n' "$2" > "$TMP/$1"; }
+
+run_internal_gate() {
+    AGY_WORKER_INTERNAL_EVIDENCE_TOKEN="$INTERNAL_EVIDENCE_TOKEN" \
+    AGY_WORKER_INTERNAL_PYTHON="$INTERNAL_PYTHON" \
+        "$GATE" --evidence-token "$INTERNAL_EVIDENCE_TOKEN" "$@"
+}
+
+HONEST='{"status":"completed","summary":"PRIVATE-WORKER-PROSE","files_changed":[{"path":"a.txt","change":"modified"}],"commands_run":[],"tests_run":[],"risks":[],"open_questions":[],"confidence":1,"requires_human":false}'
+COMMAND_CLAIM='{"status":"completed","summary":"done","files_changed":[{"path":"a.txt","change":"modified"}],"commands_run":["PRIVATE-UNTRUSTED-COMMAND"],"tests_run":[],"risks":[],"open_questions":[],"confidence":1,"requires_human":false}'
+NO_EDITS='{"status":"completed","summary":"done","files_changed":[],"commands_run":[],"tests_run":[],"risks":[],"open_questions":[],"confidence":1,"requires_human":false}'
+PARTIAL='{"status":"partial","summary":"PRIVATE-PARTIAL-PROSE","files_changed":[{"path":"a.txt","change":"modified"}],"commands_run":[],"tests_run":[],"risks":[],"open_questions":["PRIVATE-QUESTION"],"confidence":0.4,"requires_human":true}'
+write_envelope honest.json "$HONEST"
+write_envelope command.json "$COMMAND_CLAIM"
+write_envelope no-edits.json "$NO_EDITS"
+write_envelope partial.json "$PARTIAL"
+printf '{not json\n' > "$TMP/malformed.json"
+
+assert_receipt() {
+    local name="$1" target="$2" expected_exit="$3" expected_outcome="$4" expected_verdict="$5"
+    if python3 -B - "$target" "$expected_exit" "$expected_outcome" "$expected_verdict" "$BASE" <<'PY'
+import json
+import os
+import stat
+import sys
+
+path, expected_exit, expected_outcome, expected_verdict, base = sys.argv[1:]
+raw = open(path, "rb").read()
+value = json.loads(raw)
+assert raw.endswith(b"\n") and raw.count(b"\n") == 1
+assert value["schema_version"] == 1
+assert value["kind"] == "agy-worker-evidence-receipt"
+assert value["gate_authority"] == "qa-gate"
+assert value["resolved_base"] == base
+assert value["gate_exit"] == int(expected_exit)
+assert value["gate_outcome"] == expected_outcome
+assert value["verdict"] == expected_verdict
+assert value["recommendations_participated_in_acceptance"] is False
+assert value["integrity"]["signed"] is False
+assert value["integrity"]["tamper_evident"] is False
+assert value["verifiers"][0]["label"] == "verify-001"
+assert stat.S_IMODE(os.lstat(path).st_mode) == 0o600
+for key in (
+    "envelope_sha256", "path_policy_sha256",
+    "initial_candidate_state_sha256", "final_candidate_state_sha256",
+    "command_sha256",
+):
+    digest = value["verifiers"][0][key] if key == "command_sha256" else value[key]
+    assert len(digest) == 64 and set(digest) <= set("0123456789abcdef")
+for forbidden in (
+    "PRIVATE-WORKER-PROSE", "PRIVATE-UNTRUSTED-COMMAND",
+    "PRIVATE-PARTIAL-PROSE", "PRIVATE-QUESTION", base,
+):
+    if forbidden == base:
+        continue
+    assert forbidden not in raw.decode("utf-8")
+PY
+    then ok "$name"; else bad "$name"; fi
+}
+
+run_receipt_case() {
+    local name="$1" label="$2" expected_exit="$3" outcome="$4" verdict="$5" envelope="$6"
+    shift 6
+    local target="$RECEIPTS/$label.json" rc
+    rm -f -- "$target"
+    "$VERIFY" --receipt "$target" --envelope "$TMP/$envelope" \
+        --repo "$REPO" --base "$BASE" "$@" \
+        > "$TMP/$label.out" 2> "$TMP/$label.err"
+    rc=$?
+    if [[ "$rc" == "$expected_exit" && -f "$target" ]]; then
+        assert_receipt "$name" "$target" "$expected_exit" "$outcome" "$verdict"
+    else
+        bad "$name (exit $rc, receipt=$([[ -f "$target" ]] && echo yes || echo no))"
+    fi
+}
+
+echo "Evidence Receipt v1 offline test suite"
+echo
+echo "durable gate outcome matrix:"
+reset_repo; printf 'worker edit\n' > "$REPO/a.txt"
+run_receipt_case "exit 0 publishes gate-passed" pass 0 gate-passed gate-passed honest.json \
+    --only a.txt --expect-edits --verify true
+
+reset_repo; printf 'worker edit\n' > "$REPO/a.txt"
+run_receipt_case "exit 10 publishes rejected scope result" scope 10 scope-violation rejected honest.json \
+    --only 'tests/**' --verify true
+
+reset_repo; printf 'worker edit\n' > "$REPO/a.txt"
+run_receipt_case "exit 11 publishes rejected claim result" claim 11 untrusted-worker-claim rejected command.json \
+    --verify true
+
+reset_repo; printf 'worker edit\n' > "$REPO/a.txt"
+run_receipt_case "exit 12 publishes rejected envelope result" malformed 12 invalid-envelope rejected malformed.json \
+    --verify true
+
+reset_repo
+run_receipt_case "exit 13 publishes rejected missing-edit result" missing 13 expected-edits-missing rejected no-edits.json \
+    --expect-edits --verify true
+
+reset_repo; printf 'worker edit\n' > "$REPO/a.txt"
+run_receipt_case "exit 14 publishes rejected verifier result" verifier 14 driver-verification-failed rejected honest.json \
+    --verify false
+
+reset_repo; printf 'worker edit\n' > "$REPO/a.txt"
+run_receipt_case "exit 15 publishes routed worker escalation" routed 15 worker-escalation routed partial.json \
+    --verify true
+
+echo
+echo "legacy gate behavior and narrow FD handoff:"
+reset_repo; printf 'worker edit\n' > "$REPO/a.txt"
+"$GATE" --envelope "$TMP/honest.json" --repo "$REPO" --base "$BASE" \
+    --only a.txt --expect-edits --verify true \
+    > "$TMP/direct.out" 2> "$TMP/direct.err"
+direct_rc=$?
+cat > "$TMP/direct.expected" <<'EOF'
+qa-gate: scope OK (1 file(s) changed)
+qa-gate: driver verification: true
+qa-gate: scope OK (1 file(s) changed)
+qa-gate: ACCEPTED
+EOF
+if [[ "$direct_rc" == 0 && ! -s "$TMP/direct.out" ]] \
+        && cmp -s "$TMP/direct.expected" "$TMP/direct.err"; then
+    ok "direct gate without evidence FD retains exact output and exit"
+else
+    bad "direct gate without evidence FD retains exact output and exit"
+fi
+
+cat > "$TMP/unsupported-worker-schema.json" <<'EOF'
+{"type":"object","pattern":"worker-controlled schema must not govern receipts"}
+EOF
+AGY_WORKER_SCHEMA="$TMP/unsupported-worker-schema.json" \
+    "$GATE" --envelope "$TMP/honest.json" --repo "$REPO" --base "$BASE" \
+        --only a.txt --verify true >/dev/null 2>&1
+override_gate_rc=$?
+schema_target="$RECEIPTS/canonical-schema.json"
+AGY_WORKER_SCHEMA="$TMP/unsupported-worker-schema.json" \
+    "$VERIFY" --receipt "$schema_target" --envelope "$TMP/honest.json" \
+        --repo "$REPO" --base "$BASE" --only a.txt --verify true \
+        >/dev/null 2>&1
+override_wrapper_rc=$?
+if [[ "$override_gate_rc" == 12 && "$override_wrapper_rc" == 0 \
+        && -f "$schema_target" ]]; then
+    ok "receipt wrapper isolates the gate from a caller schema override"
+else
+    bad "receipt wrapper isolates the gate from a caller schema override"
+fi
+
+exec 9> "$TMP/direct-handoff.jsonl"
+run_internal_gate --envelope "$TMP/honest.json" --repo "$REPO" --base "$BASE" \
+    --only a.txt --verify true --evidence-fd 9 \
+    > "$TMP/fd.out" 2> "$TMP/fd.err"
+fd_rc=$?
+exec 9>&-
+if [[ "$fd_rc" == 0 ]] && python3 -B - "$TMP/direct-handoff.jsonl" "$BASE" <<'PY'
+import json, sys
+raw=open(sys.argv[1], 'rb').read()
+value=json.loads(raw)
+assert raw.endswith(b'\n') and raw.count(b'\n') == 1
+assert value['kind']=='agy-worker-gate-evidence'
+assert value['resolved_base']==sys.argv[2]
+assert value['gate_exit']==0 and value['gate_outcome']=='gate-passed'
+assert set(value)=={
+ 'schema_version','kind','resolved_base','envelope_sha256',
+ 'initial_candidate_state_sha256','final_candidate_state_sha256',
+ 'gate_exit','gate_outcome'}
+PY
+then ok "optional evidence FD receives exactly one bounded gate JSON line"; else bad "optional evidence FD receives exactly one bounded gate JSON line"; fi
+
+exec 9> "$TMP/unbound-handoff.jsonl"
+"$GATE" --envelope "$TMP/honest.json" --repo "$REPO" --base "$BASE" \
+    --only a.txt --verify true --evidence-fd 9 >/dev/null 2>&1
+unbound_fd_rc=$?
+exec 9>&-
+if [[ "$unbound_fd_rc" == 64 && ! -s "$TMP/unbound-handoff.jsonl" ]]; then
+    ok "direct evidence FD without the wrapper-bound capability fails before gate work"
+else
+    bad "direct evidence FD without the wrapper-bound capability fails before gate work"
+fi
+
+fd_probe='printf child >&8; if { printf forged >&9; } 2>/dev/null; then exit 41; fi; /bin/bash -c '\''printf descendant >&8; if { printf forged >&9; } 2>/dev/null; then exit 42; fi'\'''
+exec 8> "$TMP/fd-control.txt"
+exec 9> "$TMP/exclusive-handoff.jsonl"
+run_internal_gate --envelope "$TMP/honest.json" --repo "$REPO" --base "$BASE" \
+    --only a.txt --verify "$fd_probe" --evidence-fd 9 \
+    > "$TMP/exclusive-fd.out" 2> "$TMP/exclusive-fd.err"
+exclusive_fd_rc=$?
+exec 9>&-
+exec 8>&-
+if [[ "$exclusive_fd_rc" == 0 \
+        && "$(<"$TMP/fd-control.txt")" == childdescendant ]] \
+        && python3 -B - "$TMP/exclusive-handoff.jsonl" <<'PY'
+import json, sys
+raw=open(sys.argv[1], 'rb').read()
+assert raw.count(b'\n') == 1 and b'forged' not in raw
+assert json.loads(raw)['kind'] == 'agy-worker-gate-evidence'
+PY
+then
+    ok "verifier child and descendant cannot observe or write the evidence FD"
+else
+    bad "verifier child and descendant cannot observe or write the evidence FD"
+fi
+
+LEAK_RUNTIME="$TMP/leaky-runtime"
+mkdir "$LEAK_RUNTIME"
+cp -R "$ROOT/skills/agy-worker/runtime/scripts" "$LEAK_RUNTIME/scripts"
+cp -R "$ROOT/skills/agy-worker/runtime/schemas" "$LEAK_RUNTIME/schemas"
+cp -R "$ROOT/skills/agy-worker/runtime/compat" "$LEAK_RUNTIME/compat"
+cp "$ROOT/skills/agy-worker/runtime/verify-job.sh" "$LEAK_RUNTIME/verify-job.sh"
+sed 's/builtin eval "exec ${evidence_fd}>&-"/:/' \
+    "$ROOT/skills/agy-worker/runtime/qa-gate.sh" > "$LEAK_RUNTIME/qa-gate.sh"
+chmod +x "$LEAK_RUNTIME/qa-gate.sh"
+exec 9> "$TMP/leaky-handoff.jsonl"
+AGY_WORKER_INTERNAL_EVIDENCE_TOKEN="$INTERNAL_EVIDENCE_TOKEN" \
+AGY_WORKER_INTERNAL_PYTHON="$INTERNAL_PYTHON" \
+"$LEAK_RUNTIME/qa-gate.sh" --evidence-token "$INTERNAL_EVIDENCE_TOKEN" \
+    --envelope "$TMP/honest.json" --repo "$REPO" --base "$BASE" \
+    --only a.txt --verify 'printf forged >&9' --evidence-fd 9 \
+    >"$TMP/leaky.out" 2>"$TMP/leaky.err"
+leaky_fd_rc=$?
+exec 9>&-
+if [[ "$leaky_fd_rc" == 0 ]] \
+        && grep -Fq forged "$TMP/leaky-handoff.jsonl" \
+        && ! python3 -B -c 'import json,sys; json.load(open(sys.argv[1]))' \
+            "$TMP/leaky-handoff.jsonl" >/dev/null 2>&1; then
+    ok "removing the child close makes the inheritance probe detect forged evidence"
+else
+    bad "removing the child close makes the inheritance probe detect forged evidence (exit $leaky_fd_rc, bytes=$(wc -c < "$TMP/leaky-handoff.jsonl"))"
+fi
+
+leaky_receipt="$RECEIPTS/leaky-wrapper.json"
+leak_scan="python3 -B -c 'import os
+for descriptor in range(3, 256):
+    try: os.write(descriptor, b\"forged\")
+    except OSError: pass'"
+"$LEAK_RUNTIME/verify-job.sh" --receipt "$leaky_receipt" \
+    --envelope "$TMP/honest.json" --repo "$REPO" --base "$BASE" \
+    --only a.txt --verify "$leak_scan" >/dev/null 2>&1
+leaky_wrapper_rc=$?
+if [[ "$leaky_wrapper_rc" == 70 && ! -e "$leaky_receipt" ]]; then
+    ok "wrapper rejects a close mutation that lets a verifier scan and forge the FD"
+else
+    bad "wrapper rejects a close mutation that lets a verifier scan and forge the FD"
+fi
+
+HOSTILE_PYTHON="$TMP/hostile-python"
+mkdir "$HOSTILE_PYTHON"
+cat > "$HOSTILE_PYTHON/sitecustomize.py" <<'PY'
+import os
+from pathlib import Path
+
+sentinel = os.environ.get("HOSTILE_STARTUP_SENTINEL")
+if sentinel:
+    Path(sentinel).open("ab").write(b"python-startup\n")
+for descriptor in range(3, 256):
+    try:
+        os.write(descriptor, b"python-forged")
+    except OSError:
+        pass
+PY
+cat > "$TMP/hostile-bash-env.sh" <<'SH'
+if [[ -n "${HOSTILE_STARTUP_SENTINEL:-}" ]]; then
+    printf 'bash-startup\n' >> "$HOSTILE_STARTUP_SENTINEL"
+fi
+for hostile_fd in 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
+    builtin eval "printf bash-forged >&${hostile_fd}" 2>/dev/null || true
+done
+SH
+hostile_sentinel="$TMP/hostile-startup-sentinel.txt"
+hostile_target="$RECEIPTS/hostile-startup.json"
+startup_verifier='test "$SAFE_VERIFIER_ENV" = keep; test -z "${BASH_ENV+x}"; test -z "${PYTHONPATH+x}"; test -z "${AGY_WORKER_INTERNAL_EVIDENCE_TOKEN+x}"; test -z "${AGY_WORKER_INTERNAL_PYTHON+x}"; python3 -c '\''print(1)'\'' >/dev/null; /bin/bash -c true'
+BASH_ENV="$TMP/hostile-bash-env.sh" \
+ENV="$TMP/hostile-bash-env.sh" \
+PYTHONPATH="$HOSTILE_PYTHON" \
+PYTHONHOME="$HOSTILE_PYTHON/missing-home" \
+PYTHONSTARTUP="$HOSTILE_PYTHON/sitecustomize.py" \
+PYTHONINSPECT=1 \
+PYTHONWARNINGS=default \
+HOSTILE_STARTUP_SENTINEL="$hostile_sentinel" \
+SAFE_VERIFIER_ENV=keep \
+    "$VERIFY" --receipt "$hostile_target" --envelope "$TMP/honest.json" \
+        --repo "$REPO" --base "$BASE" --only a.txt \
+        --verify "$startup_verifier" \
+        >"$TMP/hostile-startup.out" 2>"$TMP/hostile-startup.err"
+hostile_startup_rc=$?
+if [[ "$hostile_startup_rc" == 0 && -f "$hostile_target" ]] \
+        && ! grep -Eq 'python-forged|bash-forged' "$hostile_target" \
+        && ! grep -Fq python-startup "$hostile_sentinel" \
+        && python3 -I -S -B "$VALIDATOR" validate --receipt "$hostile_target" \
+            >/dev/null 2>&1; then
+    ok "wrapper isolates evidence from hostile Python and Bash startup controls"
+else
+    bad "wrapper isolates evidence from hostile Python and Bash startup controls"
+fi
+
+UNSANITIZED_RUNTIME="$TMP/unsanitized-runtime"
+cp -R "$ROOT/skills/agy-worker/runtime" "$UNSANITIZED_RUNTIME"
+sed 's/gate_environment = sanitized_gate_environment()/gate_environment = os.environ.copy()/' \
+    "$UNSANITIZED_RUNTIME/scripts/evidence_receipt.py" \
+    > "$TMP/unsanitized-helper.py"
+mv "$TMP/unsanitized-helper.py" \
+    "$UNSANITIZED_RUNTIME/scripts/evidence_receipt.py"
+chmod +x "$UNSANITIZED_RUNTIME/scripts/evidence_receipt.py"
+unsanitized_target="$RECEIPTS/unsanitized-startup.json"
+BASH_ENV="$TMP/hostile-bash-env.sh" \
+ENV="$TMP/hostile-bash-env.sh" \
+PYTHONPATH="$HOSTILE_PYTHON" \
+HOSTILE_STARTUP_SENTINEL="$hostile_sentinel" \
+    "$UNSANITIZED_RUNTIME/verify-job.sh" --receipt "$unsanitized_target" \
+        --envelope "$TMP/honest.json" --repo "$REPO" --base "$BASE" \
+        --only a.txt --verify true >/dev/null 2>&1
+unsanitized_rc=$?
+if [[ "$unsanitized_rc" == 70 && ! -e "$unsanitized_target" ]]; then
+    ok "removing gate environment sanitization contaminates evidence and returns 70"
+else
+    bad "removing gate environment sanitization contaminates evidence and returns 70"
+fi
+
+exec 9> "$TMP/duplicate-fd.jsonl"
+run_internal_gate --envelope "$TMP/honest.json" --repo "$REPO" --base "$BASE" \
+    --verify true --evidence-fd 9 --evidence-fd 9 >/dev/null 2>&1
+duplicate_fd_rc=$?
+exec 9>&-
+if [[ "$duplicate_fd_rc" == 64 && ! -s "$TMP/duplicate-fd.jsonl" ]]; then
+    ok "duplicate evidence FD is usage failure with no handoff"
+else
+    bad "duplicate evidence FD is usage failure with no handoff"
+fi
+
+run_internal_gate --envelope "$TMP/honest.json" --repo "$REPO" --base "$BASE" \
+    --verify true --evidence-fd 999999999999999999999 >/dev/null 2>&1
+if [[ $? == 64 ]]; then ok "closed or overflowing evidence FD fails before gate work"; else bad "closed or overflowing evidence FD fails before gate work"; fi
+
+exec 8< "$TMP/direct-handoff.jsonl"
+run_internal_gate --envelope "$TMP/honest.json" --repo "$REPO" --base "$BASE" \
+    --verify true --evidence-fd 8 >/dev/null 2>&1
+readonly_fd_rc=$?
+exec 8>&-
+if [[ "$readonly_fd_rc" == 64 ]]; then ok "read-only evidence FD fails before gate work"; else bad "read-only evidence FD fails before gate work"; fi
+
+echo
+echo "wrapper preflight and safe target policy:"
+no_receipt="$RECEIPTS/no-verify.json"
+"$VERIFY" --receipt "$no_receipt" --envelope "$TMP/honest.json" \
+    --repo "$REPO" --base "$BASE" >/dev/null 2>&1
+if [[ $? == 64 && ! -e "$no_receipt" ]]; then ok "missing verifier exits 64 with no receipt"; else bad "missing verifier exits 64 with no receipt"; fi
+
+existing="$RECEIPTS/existing.json"
+printf 'keep-me\n' > "$existing"
+"$VERIFY" --receipt "$existing" --envelope "$TMP/honest.json" \
+    --repo "$REPO" --base "$BASE" --verify true >/dev/null 2>&1
+if [[ $? == 64 && "$(<"$existing")" == keep-me ]]; then ok "existing target is never overwritten"; else bad "existing target is never overwritten"; fi
+
+symlink_target="$RECEIPTS/symlink.json"
+ln -s "$TMP/nowhere" "$symlink_target"
+"$VERIFY" --receipt "$symlink_target" --envelope "$TMP/honest.json" \
+    --repo "$REPO" --base "$BASE" --verify true >/dev/null 2>&1
+if [[ $? == 64 && -L "$symlink_target" ]]; then ok "symlink receipt target is rejected without following"; else bad "symlink receipt target is rejected without following"; fi
+
+mkdir -m 700 "$TMP/real-receipt-parent"
+ln -s "$TMP/real-receipt-parent" "$TMP/linked-receipt-parent"
+linked_parent_target="$TMP/linked-receipt-parent/receipt.json"
+"$VERIFY" --receipt "$linked_parent_target" --envelope "$TMP/honest.json" \
+    --repo "$REPO" --base "$BASE" --verify true >/dev/null 2>&1
+if [[ $? == 64 && ! -e "$linked_parent_target" ]]; then ok "symlinked receipt parent is rejected"; else bad "symlinked receipt parent is rejected"; fi
+
+ln -s "$TMP/honest.json" "$TMP/envelope-link.json"
+linked_envelope_target="$RECEIPTS/linked-envelope.json"
+"$VERIFY" --receipt "$linked_envelope_target" --envelope "$TMP/envelope-link.json" \
+    --repo "$REPO" --base "$BASE" --verify true >/dev/null 2>&1
+if [[ $? == 64 && ! -e "$linked_envelope_target" ]]; then ok "symlinked envelope input is rejected before gate"; else bad "symlinked envelope input is rejected before gate"; fi
+
+in_repo="$REPO/receipt.json"
+"$VERIFY" --receipt "$in_repo" --envelope "$TMP/honest.json" \
+    --repo "$REPO" --base "$BASE" --verify true >/dev/null 2>&1
+if [[ $? == 64 && ! -e "$in_repo" ]]; then ok "receipt target inside audited repository is rejected"; else bad "receipt target inside audited repository is rejected"; fi
+
+mkdir -m 755 "$TMP/public-parent"
+public_target="$(CDPATH= cd -- "$TMP/public-parent" && pwd -P)/receipt.json"
+"$VERIFY" --receipt "$public_target" --envelope "$TMP/honest.json" \
+    --repo "$REPO" --base "$BASE" --verify true >/dev/null 2>&1
+if [[ $? == 64 && ! -e "$public_target" ]]; then ok "non-private receipt parent is rejected"; else bad "non-private receipt parent is rejected"; fi
+
+mkdir -m 300 "$TMP/owner-incomplete"
+owner_incomplete_parent="$(CDPATH= cd -- "$TMP/owner-incomplete" && pwd -P)"
+owner_incomplete_target="$owner_incomplete_parent/receipt.json"
+"$VERIFY" --receipt "$owner_incomplete_target" --envelope "$TMP/honest.json" \
+    --repo "$REPO" --base "$BASE" --verify true >/dev/null 2>&1
+owner_incomplete_rc=$?
+chmod 700 "$owner_incomplete_parent"
+if [[ "$owner_incomplete_rc" == 64 && ! -e "$owner_incomplete_target" ]]; then
+    ok "receipt parent without full owner access is rejected before gate"
+else
+    bad "receipt parent without full owner access is rejected before gate"
+fi
+
+"$VERIFY" --receipt relative-receipt.json --envelope "$TMP/honest.json" \
+    --repo "$REPO" --base "$BASE" --verify true >/dev/null 2>&1
+if [[ $? == 64 && ! -e relative-receipt.json ]]; then ok "relative receipt target is rejected"; else bad "relative receipt target is rejected"; fi
+
+duplicate_target="$RECEIPTS/duplicate-option.json"
+"$VERIFY" --receipt "$duplicate_target" --receipt "$duplicate_target" \
+    --envelope "$TMP/honest.json" --repo "$REPO" --base "$BASE" --verify true \
+    >/dev/null 2>&1
+if [[ $? == 64 && ! -e "$duplicate_target" ]]; then ok "singleton wrapper options reject repetition"; else bad "singleton wrapper options reject repetition"; fi
+
+echo
+echo "selection and recommendation bindings:"
+"$ROOT/model-selection.sh" --tier bulk --tier-source cli > "$TMP/selection.json"
+"$ROOT/model-recommendation.sh" --stage pre-dispatch --selected-tier bulk \
+    --evidence batched-mechanical > "$TMP/recommendation.json"
+reset_repo; printf 'worker edit\n' > "$REPO/a.txt"
+bound="$RECEIPTS/bound.json"
+"$VERIFY" --receipt "$bound" --envelope "$TMP/honest.json" --repo "$REPO" \
+    --base "$BASE" --selection "$TMP/selection.json" \
+    --pre-recommendation "$TMP/recommendation.json" --verify true \
+    > "$TMP/bound.out" 2> "$TMP/bound.err"
+if [[ $? == 0 ]] && python3 -B - "$bound" "$TMP/selection.json" "$TMP/recommendation.json" <<'PY'
+import json,sys
+receipt=json.load(open(sys.argv[1]))
+assert receipt['caller_selection']==json.load(open(sys.argv[2]))
+assert receipt['pre_dispatch_recommendation']==json.load(open(sys.argv[3]))
+assert receipt['recommendations_participated_in_acceptance'] is False
+PY
+then ok "valid selection and pre-dispatch advisory bind without gate authority"; else bad "valid selection and pre-dispatch advisory bind without gate authority"; fi
+
+for optional_mode in selection recommendation; do
+    reset_repo; printf 'worker edit\n' > "$REPO/a.txt"
+    optional_target="$RECEIPTS/$optional_mode-only.json"
+    optional_args=()
+    if [[ "$optional_mode" == selection ]]; then
+        optional_args=(--selection "$TMP/selection.json")
+    else
+        optional_args=(--pre-recommendation "$TMP/recommendation.json")
+    fi
+    "$VERIFY" --receipt "$optional_target" --envelope "$TMP/honest.json" \
+        --repo "$REPO" --base "$BASE" "${optional_args[@]}" --verify true \
+        >/dev/null 2>&1
+    if [[ $? == 0 && -f "$optional_target" ]]; then ok "$optional_mode input is independently optional"; else bad "$optional_mode input is independently optional"; fi
+done
+
+"$ROOT/model-recommendation.sh" --stage post-gate --selected-tier bulk \
+    --evidence gate-accepted > "$TMP/post.json"
+post_target="$RECEIPTS/post.json"
+"$VERIFY" --receipt "$post_target" --envelope "$TMP/honest.json" --repo "$REPO" \
+    --base "$BASE" --pre-recommendation "$TMP/post.json" --verify true >/dev/null 2>&1
+if [[ $? == 64 && ! -e "$post_target" ]]; then ok "post-gate advisory cannot bind in P0-A"; else bad "post-gate advisory cannot bind in P0-A"; fi
+
+python3 -B - "$TMP/recommendation.json" "$TMP/applied.json" <<'PY'
+import json,sys
+value=json.load(open(sys.argv[1])); value['applied']=True
+json.dump(value,open(sys.argv[2],'w'))
+PY
+applied_target="$RECEIPTS/applied.json"
+"$VERIFY" --receipt "$applied_target" --envelope "$TMP/honest.json" --repo "$REPO" \
+    --base "$BASE" --pre-recommendation "$TMP/applied.json" --verify true >/dev/null 2>&1
+if [[ $? == 64 && ! -e "$applied_target" ]]; then ok "advisory claiming application is rejected before gate"; else bad "advisory claiming application is rejected before gate"; fi
+
+"$ROOT/model-recommendation.sh" --stage pre-dispatch --selected-tier cheap \
+    --evidence bounded-routine > "$TMP/mismatch-recommendation.json"
+mismatch_target="$RECEIPTS/mismatch-selection.json"
+"$VERIFY" --receipt "$mismatch_target" --envelope "$TMP/honest.json" --repo "$REPO" \
+    --base "$BASE" --selection "$TMP/selection.json" \
+    --pre-recommendation "$TMP/mismatch-recommendation.json" --verify true >/dev/null 2>&1
+if [[ $? == 64 && ! -e "$mismatch_target" ]]; then ok "selection and advisory mismatch is rejected before gate"; else bad "selection and advisory mismatch is rejected before gate"; fi
+
+mkdir -p "$TMP/selection-bin"
+cat > "$TMP/selection-bin/agy" <<'SH'
+#!/usr/bin/env bash
+[[ "$*" == "--version" ]] || exit 97
+printf '1.1.10\n'
+SH
+chmod +x "$TMP/selection-bin/agy"
+PATH="$TMP/selection-bin:$PATH" "$ROOT/model-selection.sh" \
+    --model gemini-3.6-flash --effort high > "$TMP/direct-selection.json"
+"$ROOT/model-recommendation.sh" --stage pre-dispatch \
+    --selected-model gemini-3.6-flash --selected-effort high \
+    --evidence batched-mechanical > "$TMP/direct-recommendation.json"
+reset_repo; printf 'worker edit\n' > "$REPO/a.txt"
+direct_target="$RECEIPTS/direct-selection.json"
+"$VERIFY" --receipt "$direct_target" --envelope "$TMP/honest.json" \
+    --repo "$REPO" --base "$BASE" --selection "$TMP/direct-selection.json" \
+    --pre-recommendation "$TMP/direct-recommendation.json" --verify true \
+    >/dev/null 2>&1
+if [[ $? == 0 ]] && python3 -B - "$direct_target" <<'PY'
+import json,sys
+value=json.load(open(sys.argv[1]))
+selection=value['caller_selection']
+assert selection['selection_mode']=='model-effort'
+assert selection['user_model']=='gemini-3.6-flash'
+assert selection['user_effort']=='high'
+assert selection['resolved_agy_model']=='gemini-3.6-flash-high'
+assert value['pre_dispatch_recommendation']['recommendation_only'] is True
+assert value['pre_dispatch_recommendation']['applied'] is False
+PY
+then ok "direct model/effort provenance binds without changing selection"; else bad "direct model/effort provenance binds without changing selection"; fi
+
+for direct_mutation in resolved provenance matrix; do
+    python3 -B - "$TMP/direct-selection.json" "$TMP/direct-$direct_mutation.json" \
+        "$direct_mutation" <<'PY'
+import json,sys
+source,target,mode=sys.argv[1:]
+value=json.load(open(source))
+if mode=='resolved': value['resolved_agy_model']='gemini-3.6-flash-low'
+elif mode=='provenance': del value['user_effort_source']
+elif mode=='matrix': value['matrix_sha256']='0'*64
+json.dump(value,open(target,'w'),sort_keys=True); open(target,'a').write('\n')
+PY
+    invalid_direct_target="$RECEIPTS/direct-$direct_mutation.json"
+    "$VERIFY" --receipt "$invalid_direct_target" --envelope "$TMP/honest.json" \
+        --repo "$REPO" --base "$BASE" --selection "$TMP/direct-$direct_mutation.json" \
+        --verify true >/dev/null 2>&1
+    if [[ $? == 64 && ! -e "$invalid_direct_target" ]]; then ok "direct $direct_mutation mutation is rejected before gate"; else bad "direct $direct_mutation mutation is rejected before gate"; fi
+done
+
+echo
+echo "privacy, canonical hashing, and mutation evidence:"
+reset_repo; printf 'worker edit\n' > "$REPO/a.txt"
+private_target="$RECEIPTS/privacy.json"
+private_command="printf PRIVATE-VERIFY-SECRET >/dev/null"
+"$VERIFY" --receipt "$private_target" --envelope "$TMP/honest.json" --repo "$REPO" \
+    --base "$BASE" --allow first --allow second --only a.txt \
+    --verify "$private_command" --verify true >/dev/null 2>&1
+if [[ $? == 0 ]] && python3 -B - "$private_target" "$REPO" "$TMP" "$private_command" <<'PY'
+import hashlib,json,sys
+raw=open(sys.argv[1],'rb').read(); value=json.loads(raw)
+for forbidden in sys.argv[2:]: assert forbidden.encode() not in raw
+assert value['verifiers']==[
+ {'label':'verify-001','command_sha256':hashlib.sha256(sys.argv[4].encode()).hexdigest()},
+ {'label':'verify-002','command_sha256':hashlib.sha256(b'true').hexdigest()}]
+assert not any(k in value for k in ('repo','command','diff','prompt','log','provider'))
+PY
+then ok "receipt exposes hashes and labels but no paths, commands, prose, or logs"; else bad "receipt exposes hashes and labels but no paths, commands, prose, or logs"; fi
+
+reset_repo; printf 'worker edit\n' > "$REPO/a.txt"
+mutation_target="$RECEIPTS/mutation.json"
+"$VERIFY" --receipt "$mutation_target" --envelope "$TMP/honest.json" --repo "$REPO" \
+    --base "$BASE" --verify "printf mutation >> '$REPO/a.txt'" >/dev/null 2>&1
+if [[ $? == 14 ]] && python3 -B - "$mutation_target" <<'PY'
+import json,sys
+value=json.load(open(sys.argv[1]))
+assert value['verdict']=='rejected'
+assert value['initial_candidate_state_sha256'] != value['final_candidate_state_sha256']
+PY
+then ok "verifier mutation is rejected and gate digests preserve the change"; else bad "verifier mutation is rejected and gate digests preserve the change"; fi
+
+reset_repo; printf 'worker edit\n' > "$REPO/a.txt"
+first_order="$RECEIPTS/order-one.json"; second_order="$RECEIPTS/order-two.json"
+"$VERIFY" --receipt "$first_order" --envelope "$TMP/honest.json" --repo "$REPO" \
+    --base "$BASE" --allow one --allow two --verify true >/dev/null 2>&1
+"$VERIFY" --receipt "$second_order" --envelope "$TMP/honest.json" --repo "$REPO" \
+    --base "$BASE" --allow two --allow one --verify true >/dev/null 2>&1
+if python3 -B - "$first_order" "$second_order" <<'PY'
+import json,sys
+one=json.load(open(sys.argv[1])); two=json.load(open(sys.argv[2]))
+assert one['path_policy_sha256'] != two['path_policy_sha256']
+PY
+then ok "ordered path policy changes its canonical binding hash"; else bad "ordered path policy changes its canonical binding hash"; fi
+
+echo
+echo "receipt validation and trusted external bindings:"
+python3 -B "$VALIDATOR" validate --receipt "$RECEIPTS/pass.json" \
+    --envelope "$TMP/honest.json" >/dev/null 2>&1
+if [[ $? == 0 ]]; then ok "validator accepts receipt with matching envelope binding"; else bad "validator accepts receipt with matching envelope binding"; fi
+
+write_envelope other.json "$NO_EDITS"
+python3 -B "$VALIDATOR" validate --receipt "$RECEIPTS/pass.json" \
+    --envelope "$TMP/other.json" >/dev/null 2>&1
+if [[ $? == 1 ]]; then ok "validator rejects separately bound envelope mismatch"; else bad "validator rejects separately bound envelope mismatch"; fi
+
+pass_initial="$(python3 -B -c 'import json,sys; print(json.load(open(sys.argv[1]))["initial_candidate_state_sha256"])' "$RECEIPTS/pass.json")"
+pass_final="$(python3 -B -c 'import json,sys; print(json.load(open(sys.argv[1]))["final_candidate_state_sha256"])' "$RECEIPTS/pass.json")"
+python3 -B "$VALIDATOR" validate --receipt "$RECEIPTS/pass.json" \
+    --initial-state-digest "$pass_initial" >/dev/null 2>&1
+if [[ $? == 0 ]]; then ok "validator accepts separately trusted candidate digest"; else bad "validator accepts separately trusted candidate digest"; fi
+python3 -B "$VALIDATOR" validate --receipt "$RECEIPTS/pass.json" \
+    --initial-state-digest "$(printf 'f%.0s' {1..64})" >/dev/null 2>&1
+if [[ $? == 1 ]]; then ok "validator rejects separately trusted candidate digest mismatch"; else bad "validator rejects separately trusted candidate digest mismatch"; fi
+
+python3 -B "$VALIDATOR" validate --receipt "$RECEIPTS/pass.json" \
+    --final-state-digest "$pass_final" >/dev/null 2>&1
+if [[ $? == 0 ]]; then ok "validator accepts separately trusted final candidate digest"; else bad "validator accepts separately trusted final candidate digest"; fi
+python3 -B "$VALIDATOR" validate --receipt "$RECEIPTS/pass.json" \
+    --final-state-digest "$(printf 'e%.0s' {1..64})" >/dev/null 2>&1
+if [[ $? == 1 ]]; then ok "validator rejects final candidate digest mismatch"; else bad "validator rejects final candidate digest mismatch"; fi
+
+python3 -B "$VALIDATOR" validate --receipt "$bound" \
+    --selection "$TMP/selection.json" \
+    --pre-recommendation "$TMP/recommendation.json" >/dev/null 2>&1
+if [[ $? == 0 ]]; then ok "validator accepts matching selection and advisory bindings"; else bad "validator accepts matching selection and advisory bindings"; fi
+"$ROOT/model-selection.sh" --tier cheap --tier-source cli > "$TMP/cheap-selection.json"
+python3 -B "$VALIDATOR" validate --receipt "$bound" \
+    --selection "$TMP/cheap-selection.json" >/dev/null 2>&1
+if [[ $? == 1 ]]; then ok "validator rejects separately bound selection mismatch"; else bad "validator rejects separately bound selection mismatch"; fi
+python3 -B "$VALIDATOR" validate --receipt "$bound" \
+    --pre-recommendation "$TMP/mismatch-recommendation.json" >/dev/null 2>&1
+if [[ $? == 1 ]]; then ok "validator rejects separately bound advisory mismatch"; else bad "validator rejects separately bound advisory mismatch"; fi
+
+for mutation in schema extra outcome duplicate; do
+    mutated="$TMP/receipt-$mutation.json"
+    python3 -B - "$RECEIPTS/pass.json" "$mutated" "$mutation" <<'PY'
+import json,sys
+source,target,mode=sys.argv[1:]
+raw=open(source).read()
+value=json.loads(raw)
+if mode=='schema': value['schema_version']=2
+elif mode=='extra': value['private_path']='/PRIVATE/PATH'
+elif mode=='outcome': value['gate_outcome']='human-required'
+if mode=='duplicate':
+    open(target,'w').write('{"schema_version":1,'+raw[1:])
+else:
+    json.dump(value,open(target,'w'),sort_keys=True,separators=(',',':'))
+    open(target,'a').write('\n')
+PY
+    python3 -B "$VALIDATOR" validate --receipt "$mutated" >/dev/null 2>&1
+    if [[ $? == 1 ]]; then ok "validator rejects $mutation receipt mutation"; else bad "validator rejects $mutation receipt mutation"; fi
+done
+
+python3 -B - "$RECEIPTS/pass.json" "$TMP/unsigned-rewrite.json" <<'PY'
+import json,sys
+value=json.load(open(sys.argv[1])); value['envelope_sha256']='f'*64
+json.dump(value,open(sys.argv[2],'w'),sort_keys=True,separators=(',',':')); open(sys.argv[2],'a').write('\n')
+PY
+python3 -B "$VALIDATOR" validate --receipt "$TMP/unsigned-rewrite.json" >/dev/null 2>&1
+unsigned_rc=$?
+python3 -B "$VALIDATOR" validate --receipt "$TMP/unsigned-rewrite.json" \
+    --envelope "$TMP/honest.json" >/dev/null 2>&1
+bound_unsigned_rc=$?
+if [[ "$unsigned_rc" == 0 && "$bound_unsigned_rc" == 1 ]] \
+        && grep -Fq '"tamper_evident":false' "$TMP/unsigned-rewrite.json"; then
+    ok "unsigned rewrite needs a separately trusted binding and is never called tamper-evident"
+else
+    bad "unsigned rewrite needs a separately trusted binding and is never called tamper-evident"
+fi
+
+echo
+echo "gate protocol failures publish nothing:"
+FAKE_RUNTIME="$TMP/fake-runtime"
+cp -R "$ROOT/skills/agy-worker/runtime" "$FAKE_RUNTIME"
+cat > "$FAKE_RUNTIME/qa-gate.sh" <<'SH'
+#!/usr/bin/env bash
+set -uo pipefail
+fd=''; base=''; envelope=''
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --evidence-fd) fd="$2"; shift 2 ;;
+        --evidence-token) token="$2"; shift 2 ;;
+        --base) base="$2"; shift 2 ;;
+        --envelope) envelope="$2"; shift 2 ;;
+        *) if [[ $# -ge 2 && "$1" != --expect-edits ]]; then shift 2; else shift; fi ;;
+    esac
+done
+case "${FAKE_GATE_MODE:-missing}" in
+    exit64) exit 64 ;;
+    unknown) exit 99 ;;
+    signal) kill -TERM "$$" ;;
+    missing) exit 0 ;;
+    malformed) printf '{bad\n' >&"$fd"; exit 0 ;;
+esac
+payload="$(python3 -B - "$base" "$envelope" "${FAKE_GATE_MODE:-}" <<'PY'
+import hashlib,json,sys
+base,envelope,mode=sys.argv[1:]
+envelope_hash=hashlib.sha256(open(envelope,'rb').read()).hexdigest()
+gate_exit=10 if mode=='wrong-exit' else 0
+value={'schema_version':1,'kind':'agy-worker-gate-evidence','resolved_base':base,
+ 'envelope_sha256':'0'*64 if mode=='mismatch' else envelope_hash,
+ 'initial_candidate_state_sha256':'1'*64,'final_candidate_state_sha256':'1'*64,
+ 'gate_exit':gate_exit,'gate_outcome':'scope-violation' if gate_exit==10 else 'gate-passed'}
+print(json.dumps(value,sort_keys=True,separators=(',',':')))
+PY
+)"
+printf '%s\n' "$payload" >&"$fd"
+if [[ "${FAKE_GATE_MODE:-}" == duplicate ]]; then printf '%s\n' "$payload" >&"$fd"; fi
+exit 0
+SH
+chmod +x "$FAKE_RUNTIME/qa-gate.sh"
+for protocol_mode in missing malformed duplicate mismatch wrong-exit unknown signal; do
+    protocol_target="$RECEIPTS/protocol-$protocol_mode.json"
+    FAKE_GATE_MODE="$protocol_mode" \
+        "$FAKE_RUNTIME/verify-job.sh" --receipt "$protocol_target" \
+        --envelope "$TMP/honest.json" --repo "$REPO" --base "$BASE" --verify true \
+        >/dev/null 2>&1
+    if [[ $? == 70 && ! -e "$protocol_target" ]]; then ok "$protocol_mode gate protocol failure exits 70 with no receipt"; else bad "$protocol_mode gate protocol failure exits 70 with no receipt"; fi
+done
+protocol64_target="$RECEIPTS/protocol-64.json"
+FAKE_GATE_MODE=exit64 "$FAKE_RUNTIME/verify-job.sh" --receipt "$protocol64_target" \
+    --envelope "$TMP/honest.json" --repo "$REPO" --base "$BASE" --verify true \
+    >/dev/null 2>&1
+if [[ $? == 64 && ! -e "$protocol64_target" ]]; then ok "gate preflight 64 passes through with no receipt"; else bad "gate preflight 64 passes through with no receipt"; fi
+
+echo
+echo "real wrapper interruption publishes nothing and closes the gate group:"
+for signal_name in HUP INT TERM; do
+    reset_repo; printf 'worker edit\n' > "$REPO/a.txt"
+    signal_target="$RECEIPTS/signal-$signal_name.json"
+    signal_ready="$TMP/signal-$signal_name.ready"
+    signal_child="$TMP/signal-$signal_name.child"
+    signal_command="printf '%s\\n' \"\$\$\" > '$signal_child'; : > '$signal_ready'; while :; do /bin/sleep 1; done"
+    "$VERIFY" --receipt "$signal_target" --envelope "$TMP/honest.json" \
+        --repo "$REPO" --base "$BASE" --verify "$signal_command" \
+        > "$TMP/signal-$signal_name.out" 2> "$TMP/signal-$signal_name.err" &
+    wrapper_pid=$!
+    ready=0
+    for (( poll=0; poll<100; poll++ )); do
+        if [[ -s "$signal_child" && -e "$signal_ready" ]]; then ready=1; break; fi
+        /bin/sleep 0.05
+    done
+    if (( ready )); then kill -s "$signal_name" "$wrapper_pid" 2>/dev/null || true; fi
+    completed=0
+    for (( poll=0; poll<100; poll++ )); do
+        if ! kill -0 "$wrapper_pid" 2>/dev/null; then completed=1; break; fi
+        /bin/sleep 0.05
+    done
+    if (( completed )); then wait "$wrapper_pid"; signal_rc=$?; else signal_rc=99; fi
+    verifier_pid="$(cat "$signal_child" 2>/dev/null || true)"
+    child_gone=0
+    for (( poll=0; poll<40; poll++ )); do
+        if [[ -n "$verifier_pid" ]] && ! kill -0 "$verifier_pid" 2>/dev/null; then child_gone=1; break; fi
+        /bin/sleep 0.05
+    done
+    if (( ready && completed && child_gone )) \
+            && [[ "$signal_rc" == 70 && ! -e "$signal_target" ]]; then
+        ok "$signal_name interruption exits 70, publishes nothing, and closes verifier"
+    else
+        bad "$signal_name interruption exits 70, publishes nothing, and closes verifier"
+        kill -KILL "$wrapper_pid" "$verifier_pid" 2>/dev/null || true
+        wait "$wrapper_pid" 2>/dev/null || true
+    fi
+done
+
+echo
+echo "deterministic wrapper-lifetime interruption cleanup:"
+SIGNAL_PARENT="$TMP/checkpoint-signals"
+mkdir -m 700 "$SIGNAL_PARENT"
+SIGNAL_PARENT="$(CDPATH= cd -- "$SIGNAL_PARENT" && pwd -P)"
+checkpoint_stages=(
+    snapshot-created
+    snapshot-before-fsync
+    handoff-created
+    publication-temp-created
+    publication-before-file-fsync
+    publication-before-link
+    publication-after-link
+    publication-before-first-parent-fsync
+    publication-before-second-parent-fsync
+    wrapper-cleanup-start
+    wrapper-cleanup-parent-fsync
+)
+reset_repo; printf 'worker edit\n' > "$REPO/a.txt"
+for checkpoint_stage in "${checkpoint_stages[@]}"; do
+    if python3 -B - "$ROOT/skills/agy-worker/runtime/scripts" \
+            "$checkpoint_stage" "$SIGNAL_PARENT" "$TMP/honest.json" \
+            "$REPO" "$BASE" >"$TMP/checkpoint-$checkpoint_stage.out" \
+            2>"$TMP/checkpoint-$checkpoint_stage.err" <<'PY'
+import importlib.util
+import os
+from pathlib import Path
+import signal
+import sys
+
+scripts,stage,parent_text,envelope,repo,base=sys.argv[1:]
+sys.path.insert(0,scripts)
+spec=importlib.util.spec_from_file_location(
+    'receipt_module',Path(scripts)/'evidence_receipt.py')
+module=importlib.util.module_from_spec(spec); spec.loader.exec_module(module)
+parent=Path(parent_text)
+for signal_name in ('HUP','INT','TERM'):
+    target=parent/f'{stage}-{signal_name}.json'
+    triggered={'value':False}
+    def checkpoint(name):
+        if name == stage and not triggered['value']:
+            triggered['value']=True
+            os.kill(os.getpid(), getattr(signal, f'SIG{signal_name}'))
+    module.interruption_checkpoint=checkpoint
+    rc=module.main([
+        'verify','--receipt',str(target),'--envelope',envelope,
+        '--repo',repo,'--base',base,'--only','a.txt','--verify','true'])
+    assert triggered['value'] and rc == 70
+    assert not target.exists() and not target.is_symlink()
+    assert not tuple(parent.iterdir())
+PY
+    then
+        ok "$checkpoint_stage handles HUP/INT/TERM with exit 70 and no artifact"
+    else
+        bad "$checkpoint_stage handles HUP/INT/TERM with exit 70 and no artifact"
+    fi
+done
+
+if python3 -B - "$ROOT/skills/agy-worker/runtime/scripts" \
+        "$SIGNAL_PARENT" "$TMP/honest.json" "$REPO" "$BASE" \
+        >"$TMP/signal-replacement.out" 2>"$TMP/signal-replacement.err" <<'PY'
+import importlib.util
+import os
+from pathlib import Path
+import signal
+import sys
+
+scripts,parent_text,envelope,repo,base=sys.argv[1:]
+sys.path.insert(0,scripts)
+spec=importlib.util.spec_from_file_location(
+    'receipt_module',Path(scripts)/'evidence_receipt.py')
+module=importlib.util.module_from_spec(spec); spec.loader.exec_module(module)
+parent=Path(parent_text); target=parent/'attacker-replacement.json'
+triggered={'value':False}
+def checkpoint(name):
+    if name == 'wrapper-cleanup-start' and not triggered['value']:
+        triggered['value']=True
+        target.unlink()
+        target.write_bytes(b'attacker replacement\n')
+        os.kill(os.getpid(), signal.SIGTERM)
+module.interruption_checkpoint=checkpoint
+rc=module.main([
+    'verify','--receipt',str(target),'--envelope',envelope,
+    '--repo',repo,'--base',base,'--only','a.txt','--verify','true'])
+assert triggered['value'] and rc == 70
+assert target.read_bytes() == b'attacker replacement\n'
+assert tuple(parent.iterdir()) == (target,)
+target.unlink()
+PY
+then
+    ok "signal cleanup preserves a raced attacker replacement by pinned inode"
+else
+    bad "signal cleanup preserves a raced attacker replacement by pinned inode"
+fi
+
+echo
+echo "atomic no-overwrite publication failure cleanup:"
+INJECT_PARENT="$TMP/injection"
+mkdir -m 700 "$INJECT_PARENT"
+INJECT_PARENT="$(CDPATH= cd -- "$INJECT_PARENT" && pwd -P)"
+if python3 -B - "$ROOT/skills/agy-worker/runtime/scripts" \
+        "$ROOT/skills/agy-worker/runtime/schemas/evidence-receipt.schema.json" \
+        "$ROOT/skills/agy-worker/runtime/scripts/model-recommendation.py" \
+        "$RECEIPTS/pass.json" "$INJECT_PARENT" <<'PY'
+import importlib.util
+import json
+import os
+from pathlib import Path
+import stat
+import sys
+
+scripts,schema_path,recommender,receipt_path,parent_text=sys.argv[1:]
+sys.path.insert(0,scripts)
+spec=importlib.util.spec_from_file_location('receipt_module',Path(scripts)/'evidence_receipt.py')
+module=importlib.util.module_from_spec(spec); spec.loader.exec_module(module)
+parent=Path(parent_text); target=parent/'restrictive-umask.json'
+value=json.load(open(receipt_path)); schema=module.load_schema(Path(schema_path))
+old_umask=os.umask(0o777)
+try:
+    module.publish_receipt(target,parent,value,schema,Path(recommender))
+finally:
+    os.umask(old_umask)
+assert stat.S_IMODE(target.lstat().st_mode)==0o600
+target.unlink()
+PY
+then ok "publication forces exact mode 0600 under a restrictive umask"; else bad "publication forces exact mode 0600 under a restrictive umask"; fi
+for injection in validation file-fsync link parent-fsync; do
+    if python3 -B - "$ROOT/skills/agy-worker/runtime/scripts" \
+            "$ROOT/skills/agy-worker/runtime/schemas/evidence-receipt.schema.json" \
+            "$ROOT/skills/agy-worker/runtime/scripts/model-recommendation.py" \
+            "$RECEIPTS/pass.json" "$INJECT_PARENT" "$injection" <<'PY'
+import importlib.util
+import json
+import os
+from pathlib import Path
+import sys
+
+scripts,schema_path,recommender,receipt_path,parent_text,mode=sys.argv[1:]
+sys.path.insert(0,scripts)
+spec=importlib.util.spec_from_file_location('receipt_module',Path(scripts)/'evidence_receipt.py')
+module=importlib.util.module_from_spec(spec); spec.loader.exec_module(module)
+parent=Path(parent_text); target=parent/f'{mode}.json'
+value=json.load(open(receipt_path)); schema=module.load_schema(Path(schema_path))
+original_validate=module.validate_receipt
+original_fsync=module.os.fsync
+original_link=module.os.link
+calls={'fsync':0}
+if mode=='validation':
+    def reject(*_args,**_kwargs): raise module.ValidationFailure('injected')
+    module.validate_receipt=reject
+elif mode in ('file-fsync','parent-fsync'):
+    def fail_fsync(fd):
+        calls['fsync']+=1
+        if (mode=='file-fsync' and calls['fsync']==1) or (mode=='parent-fsync' and calls['fsync']==2):
+            raise OSError('injected')
+        return original_fsync(fd)
+    module.os.fsync=fail_fsync
+elif mode=='link':
+    def fail_link(*_args,**_kwargs): raise OSError('injected')
+    module.os.link=fail_link
+try:
+    try:
+        module.publish_receipt(target,parent,value,schema,Path(recommender))
+    except module.PublicationFailure:
+        pass
+    else:
+        raise AssertionError('injection unexpectedly published')
+finally:
+    module.validate_receipt=original_validate
+    module.os.fsync=original_fsync
+    module.os.link=original_link
+assert not target.exists() and not target.is_symlink()
+assert not list(parent.glob(f'.{target.name}.receipt.*'))
+PY
+    then ok "$injection failure leaves no final or partial receipt"; else bad "$injection failure leaves no final or partial receipt"; fi
+done
+
+if python3 -B - "$ROOT/skills/agy-worker/runtime/scripts" \
+        "$ROOT/skills/agy-worker/runtime/schemas/evidence-receipt.schema.json" \
+        "$ROOT/skills/agy-worker/runtime/scripts/model-recommendation.py" \
+        "$RECEIPTS/pass.json" "$INJECT_PARENT" <<'PY'
+import importlib.util
+import json
+import os
+from pathlib import Path
+import sys
+
+scripts,schema_path,recommender,receipt_path,parent_text=sys.argv[1:]
+sys.path.insert(0,scripts)
+spec=importlib.util.spec_from_file_location('receipt_module',Path(scripts)/'evidence_receipt.py')
+module=importlib.util.module_from_spec(spec); spec.loader.exec_module(module)
+parent=Path(parent_text); target=parent/'replacement-during-fsync.json'
+value=json.load(open(receipt_path)); schema=module.load_schema(Path(schema_path))
+original_fsync=module.os.fsync
+calls={'fsync':0}
+def replace_then_fail(fd):
+    calls['fsync']+=1
+    if calls['fsync']==2:
+        target.unlink()
+        target.write_bytes(b'attacker replacement\n')
+        raise OSError('injected')
+    return original_fsync(fd)
+module.os.fsync=replace_then_fail
+try:
+    try:
+        module.publish_receipt(target,parent,value,schema,Path(recommender))
+    except module.PublicationFailure:
+        pass
+    else:
+        raise AssertionError('injection unexpectedly published')
+finally:
+    module.os.fsync=original_fsync
+assert target.read_bytes()==b'attacker replacement\n'
+assert not list(parent.glob(f'.{target.name}.receipt.*'))
+target.unlink()
+PY
+then ok "cleanup preserves a raced replacement after publication identity changes"; else bad "cleanup preserves a raced replacement after publication identity changes"; fi
+
+reset_repo; printf 'worker edit\n' > "$REPO/a.txt"
+race_target="$RECEIPTS/race.json"
+"$VERIFY" --receipt "$race_target" --envelope "$TMP/honest.json" --repo "$REPO" \
+    --base "$BASE" --verify "printf attacker > '$race_target'" >/dev/null 2>&1
+race_rc=$?
+if [[ "$race_rc" == 74 && "$(<"$race_target")" == attacker ]]; then
+    ok "atomic hard-link publication refuses a raced target without overwriting it"
+else
+    bad "atomic hard-link publication refuses a raced target without overwriting it"
+fi
+rm -f -- "$race_target"
+
+reset_repo; printf 'worker edit\n' > "$REPO/a.txt"
+mode_target="$RECEIPTS/parent-mode.json"
+"$VERIFY" --receipt "$mode_target" --envelope "$TMP/honest.json" --repo "$REPO" \
+    --base "$BASE" --verify "chmod 755 '$RECEIPTS'" >/dev/null 2>&1
+mode_rc=$?
+chmod 700 "$RECEIPTS"
+if [[ "$mode_rc" == 74 && ! -e "$mode_target" ]]; then ok "parent privacy drift before publication exits 74 with no receipt"; else bad "parent privacy drift before publication exits 74 with no receipt"; fi
+
+if [[ -z "$(find "$RECEIPTS" -maxdepth 1 -name '.*receipt*' -print -quit)" ]]; then
+    ok "successful and failed runs leave no private publication temporary"
+else
+    bad "successful and failed runs leave no private publication temporary"
+fi
+
+echo
+if (( fail )); then
+    echo "FAILED: $fail failed, $pass passed"
+    exit 1
+fi
+echo "PASSED: $pass tests"

--- a/tests/test-packaging.sh
+++ b/tests/test-packaging.sh
@@ -79,18 +79,30 @@ else
     bad "root and portable packages include the canonical explicit selector"
 fi
 
+if [[ -x "$ROOT/verify-job.sh" ]] \
+        && [[ -x "$ROOT/skills/agy-worker/runtime/verify-job.sh" ]] \
+        && [[ -x "$ROOT/skills/agy-worker/runtime/scripts/evidence_receipt.py" ]] \
+        && [[ -f "$ROOT/skills/agy-worker/runtime/schemas/evidence-receipt.schema.json" ]]; then
+    ok "root and portable packages include Evidence Receipt v1"
+else
+    bad "root and portable packages include Evidence Receipt v1"
+fi
+
 required_runtime_dependencies=(
     agy-worker.sh
     qa-gate.sh
+    verify-job.sh
     model-recommendation.sh
     model-selection.sh
     doctor.sh
     scripts/validate-envelope.py
+    scripts/evidence_receipt.py
     scripts/model-recommendation.py
     scripts/model_selection.py
     scripts/compatibility.py
     scripts/doctor-metadata.py
     schemas/worker-result.schema.json
+    schemas/evidence-receipt.schema.json
     schemas/model-selection.schema.json
     schemas/model-recommendation.schema.json
     agents/bulk-test-writer.md
@@ -189,9 +201,12 @@ done
 
 for specification in \
     'qa-gate.sh:executable' \
+    'verify-job.sh:executable' \
     'scripts/validate-envelope.py:executable' \
+    'scripts/evidence_receipt.py:executable' \
     'scripts/model_selection.py:executable' \
     'schemas/worker-result.schema.json:data' \
+    'schemas/evidence-receipt.schema.json:data' \
     'agents/repo-inventory.md:data' \
     'compat/agy-verified-version.txt:data' \
     'compat/agy-model-effort-matrix.json:data'; do
@@ -348,6 +363,12 @@ if grep -Fq 'run: ./tests/test-proof-demo.sh' "$ROOT/.github/workflows/test.yml"
     ok "macOS CI runs the dedicated offline starter-proof suite"
 else
     bad "macOS CI runs the dedicated offline starter-proof suite"
+fi
+
+if grep -Fq 'run: ./tests/test-evidence-receipt.sh' "$ROOT/.github/workflows/test.yml"; then
+    ok "macOS CI runs the dedicated Evidence Receipt v1 suite"
+else
+    bad "macOS CI runs the dedicated Evidence Receipt v1 suite"
 fi
 
 if grep -Fq './proof-demo.sh' "$ROOT/README.md" \
@@ -548,6 +569,49 @@ else
     bad "skill-folder-only copy resolves and runs a bounded offline advisory"
 fi
 
+mkdir -p "$TMP/portable-receipt-repo" "$TMP/portable-receipts" \
+    "$TMP/receipt-no-network-bin"
+chmod 700 "$TMP/portable-receipts"
+for command_name in agy curl wget npm npx; do
+    printf '#!/usr/bin/env bash\n: > "$NETWORK_MARKER"\nexit 99\n' \
+        > "$TMP/receipt-no-network-bin/$command_name"
+    chmod +x "$TMP/receipt-no-network-bin/$command_name"
+done
+git -C "$TMP/portable-receipt-repo" init -q
+git -C "$TMP/portable-receipt-repo" config user.email test@example.com
+git -C "$TMP/portable-receipt-repo" config user.name test
+printf 'before\n' > "$TMP/portable-receipt-repo/a.txt"
+git -C "$TMP/portable-receipt-repo" add a.txt
+git -C "$TMP/portable-receipt-repo" commit -qm init
+portable_receipt_base="$(git -C "$TMP/portable-receipt-repo" rev-parse HEAD)"
+printf 'after\n' > "$TMP/portable-receipt-repo/a.txt"
+printf '%s\n' '{"status":"completed","summary":"done","files_changed":[{"path":"a.txt","change":"modified"}],"commands_run":[],"tests_run":[],"risks":[],"open_questions":[],"confidence":1,"requires_human":false}' \
+    > "$TMP/portable-envelope.json"
+portable_receipt_parent="$(cd "$TMP/portable-receipts" && pwd -P)"
+PATH="$TMP/receipt-no-network-bin:$PATH" NETWORK_MARKER="$TMP/receipt-network-called" \
+    "$copied_pipeline/verify-job.sh" \
+    --receipt "$portable_receipt_parent/receipt.json" \
+    --envelope "$TMP/portable-envelope.json" \
+    --repo "$TMP/portable-receipt-repo" --base "$portable_receipt_base" \
+    --only a.txt --expect-edits --verify true \
+    > "$TMP/portable-receipt.out" 2> "$TMP/portable-receipt.err"
+portable_receipt_rc=$?
+if [[ "$portable_receipt_rc" == 0 && ! -e "$TMP/receipt-network-called" ]] \
+        && python3 -B - "$portable_receipt_parent/receipt.json" <<'PY'
+import json
+import sys
+value = json.load(open(sys.argv[1], encoding="utf-8"))
+assert value["gate_exit"] == 0
+assert value["verdict"] == "gate-passed"
+assert value["gate_authority"] == "qa-gate"
+assert value["integrity"]["signed"] is False
+PY
+then
+    ok "skill-folder-only copy publishes a bounded receipt offline"
+else
+    bad "skill-folder-only copy publishes a bounded receipt offline"
+fi
+
 mkdir -p "$TMP/selector-bin"
 printf '%s\n' '#!/usr/bin/env bash' \
     '[[ "$*" == "--version" ]] || exit 97' \
@@ -685,6 +749,7 @@ fi
 
 required_suite_paths=(
     tests/test-qa-gate.sh
+    tests/test-evidence-receipt.sh
     tests/test-agy-worker.sh
     tests/test-update.sh
     tests/test-reporting.sh
@@ -705,9 +770,9 @@ if [[ "$governance_lists_all_suites" == "1" ]] \
         && grep -Fq 'logs/' "$ROOT/PRIVACY.md" \
         && grep -Fq 'GitHub Issues' "$ROOT/SUPPORT.md" \
         && grep -Fq 'not legal advice' "$ROOT/TERMS.md"; then
-    ok "governance docs require all seven suites and disclose public policy boundaries"
+    ok "governance docs require all eight suites and disclose public policy boundaries"
 else
-    bad "governance docs require all seven suites and disclose public policy boundaries"
+    bad "governance docs require all eight suites and disclose public policy boundaries"
 fi
 
 python3 "$ROOT/scripts/validate-brand-assets.py" "$ROOT/docs/assets/brand" \

--- a/verify-job.sh
+++ b/verify-job.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Compatibility entry point; the distributable skill owns the receipt runtime.
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+exec "$SCRIPT_DIR/skills/agy-worker/runtime/verify-job.sh" "$@"


### PR DESCRIPTION
## What changed

Add Evidence Receipt v1 as a durable, private record of one canonical `qa-gate.sh` execution.

- Add the repository and portable-skill `verify-job.sh` wrappers, the receipt schema, and a dependency-free validator.
- Keep `qa-gate.sh` as the sole outcome authority. The wrapper consumes one capability-bound, bounded internal evidence handoff instead of parsing gate prose or reproducing acceptance logic.
- Record only bounded driver evidence: the resolved immutable base; SHA-256 hashes of the exact envelope snapshot, ordered path policy, verifier commands, and initial/final candidate state; deterministic verifier labels; and the gate's exact exit, outcome, and verdict.
- Optionally bind one validated caller-selection record and one canonical pre-dispatch advisory without generating, applying, ranking, or redispatching a recommendation.
- Preserve direct `qa-gate.sh` behavior when the internal evidence capability is absent.
- Validate the complete handoff and receipt contract, rejecting missing, duplicate, malformed, unknown, interrupted, or mismatched evidence.
- Publish only to a new canonical path outside the audited repository under an owner-private real parent. Receipts are mode `0600` and overwrite, symlink, in-repository, and permissive-parent targets are rejected.
- Validate and `fsync` a same-directory private temporary file, publish with an atomic no-overwrite hard link, `fsync` the parent, remove the temporary, and `fsync` the parent again before returning the gate exit.
- Add paired accept/reject, mutation, publication-failure, protocol, privacy, startup-hook, signal, portability, and no-spill coverage.
- Update README, public skill guidance, privacy disclosure, contributor guidance, repository map, roadmap, lessons learned, CI, packaging, and repository instructions.

## Trust boundary and scope

- Affected paths: the canonical gate's internal evidence protocol, receipt wrapper/schema/validator, portable skill packaging, offline tests, CI, privacy and contributor documentation, roadmap, repository map, lessons, and concise repository guidance.
- Trust boundary affected: durable serialization of facts already decided by `qa-gate.sh`. A receipt is not another gate and cannot convert a rejection or routed result into acceptance.
- Gate outcomes `0` and `10`–`15` publish a validated receipt and return that exact exit. Exit `0` maps to `gate-passed`, `10`–`14` to `rejected`, and `15` to `routed`.
- Invocation or gate preflight errors return `64` with no receipt. Missing, malformed, mismatched, unknown, or interrupted internal evidence returns `70` with no receipt. Receipt validation or durable-publication failure returns `74` with no final or partial receipt.
- The internal evidence descriptor is validated by the gate parent and closed with a shell builtin before any verifier shell, interpreter, or descendant starts.
- Evidence-mode children strip executable shell/Python startup controls and use isolated/no-site gate-owned Python; ordinary verifier environment values remain available except those unsafe controls and internal handoff variables.
- HUP, INT, and TERM are handled from private snapshot creation through publication and cleanup: an active gate/verifier process group is terminated and reaped, wrapper-owned partial artifacts are removed, and the wrapper returns `70`.
- Startup code that runs before the wrapper process begins, uncatchable termination such as SIGKILL, host failure, and storage/filesystem failure outside the successful durability sequence remain outside the handled signal contract.

## Privacy and limitations

- Receipts contain hashes and bounded labels, not source or diff content, prompts, worker prose, raw logs, repository paths, verifier command text/output, credentials, provider telemetry, or pricing.
- Receipts are local and never uploaded by this command.
- Every receipt states that it is unsigned, not self-authenticating, and not tamper-evident. Schema validation detects malformed or inconsistent data, not a schema-valid authorized rewrite; later tamper detection requires a separately trusted bound artifact or digest.
- A `gate-passed` receipt does not prove correctness, security, authenticity, or human approval. Human diff review remains required.
- No routing behavior, model selection, provider call, backend claim, release, tag, signing mechanism, or external publication is added.

## Verification

Independent verification accepted the committed tree.

- [x] `./tests/test-qa-gate.sh` — 41/41
- [x] `./tests/test-evidence-receipt.sh` — 88/88
- [x] `./tests/test-agy-worker.sh` — 209/209
- [x] `./tests/test-update.sh` — 175/175
- [x] `./tests/test-reporting.sh` — 21/21
- [x] `./tests/test-packaging.sh` — 135/135
- [x] `./tests/test-doctor.sh` — 180/180
- [x] `./tests/test-proof-demo.sh` — 21/21
- [x] Paired accept/reject coverage for every new receipt protocol and publication policy
- [x] Gate/verifier mutation and candidate-state binding coverage
- [x] File and parent durability, no-overwrite race, validation failure, and cleanup injection coverage
- [x] Startup-hook stripping, evidence-FD isolation, HUP/INT/TERM cleanup, and process-group reaping coverage
- [x] Complete plugin, standalone install, and folder-only portable-skill coverage
- [x] Bash 3.2 syntax checks
- [x] Python stdlib compile checks with external bytecode isolation
- [x] `git diff --check`
- [x] Human diff review completed
- [x] Independent verifier verdict: ACCEPT
- [x] `agents-md-auditor` pre/post review completed

## Safety and release

- [x] No worker-reported command or test was treated as evidence.
- [x] `qa-gate.sh` remains the sole gate authority.
- [x] No permission, authentication, privacy, routing, or path-policy boundary was weakened.
- [x] No recommendation participates in acceptance or changes caller selection.
- [x] No runtime dependency beyond Bash 3.2, Python stdlib, and git was added.
- [x] No merge, release, tag, issue submission, provider call, or external distribution/search setting change is implied by this pull request.
