### PR TITLE
Harden compatibility watch evidence transport

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Keep these counts current when their suites change:
 - Evidence Receipt v1: 88 offline gate-protocol/publication/privacy cases.
 - `agy-worker.sh` / `install.sh` / model selection and recommendation: 209 offline
   fake-agy/routing cases.
-- `update.sh`: 175 offline local-remote/matrix/manifest/watch-policy cases.
+- `update.sh`: 278 offline transport/process/local-remote/matrix/manifest/watch-policy cases.
 - `bug-report.sh`: 21 offline privacy/fake-`gh` cases.
 - Codex package/skill distribution: 135 offline
   manifest/runtime-copy/relocation/landing cases.
@@ -118,6 +118,11 @@ only a passing test has not been shown to catch anything.
   bounded real job when behavior changed. Production origins, release channels, and
   review cadence are not environment-overridable. The weekly watcher never advances
   metadata or takes an external action. `apply` is always an explicit action.
+- **A GitHub URL is not fixed evidence when Git transport is ambient.** Read-only
+  check/watch must use the exact proxyless, redirect-rejecting, bounded GitHub REST
+  helper and bounded process-group/version supervisor; never restore `git ls-remote`
+  there. Preserve HUP/INT/TERM status and sanitized output. The explicit apply-time
+  Git fetch remains outside that isolation boundary and must be documented as such.
 - **The agy distribution manifest is only a canary.** Its endpoint is fixed; reject
   proxies, redirects, oversized/malformed responses, and unexpected archive URLs.
   Never request the archive. The checked-in tuple detects drift but cannot advance a

--- a/README.md
+++ b/README.md
@@ -546,6 +546,16 @@ established drift, a due review, or a missing installed tool. Exit `2` means evi
 is unavailable or malformed, so the result is inconclusive—not green. Both tools are
 reported before those results are aggregated, with `2` taking precedence over `3`.
 
+Project, agy, and Codex release/source evidence comes from exact fixed
+`https://api.github.com/repos/...` REST paths. The stdlib-only client disables ambient
+HTTP proxies, refuses redirects, validates strict JSON and response metadata, and
+captures responses under time and byte limits. The supervisor also bounds installed
+`agy --version` and `codex --version` probes, discards their raw stderr, and terminates
+the complete child process group on timeout, output overflow, or HUP/INT/TERM. Neither
+`check` nor `check --watch` makes a Git network request, so repository or global
+`url.*.insteadOf`, credential helpers, and Git proxy settings cannot redirect their
+official release/source evidence.
+
 The release origins, upstream sources, distribution-manifest endpoint, release
 channels, and 30-day cadence are fixed in the updater rather than overridable through
 arguments, environment variables, or configuration. The check never fetches into
@@ -570,8 +580,11 @@ Only after those checks does it fast-forward the current branch and rerun `insta
 against the real Codex skill destination. A real-destination permission failure cannot
 be rolled back safely after the Git fast-forward: `apply` exits 4, reports **PARTIAL
 UPDATE**, and tells you to fix the destination and rerun this checkout's `install.sh`.
-This verifies GitHub transport/ref consistency; release maintainers must still protect
-the GitHub account and tag-publishing process.
+The fixed API commit must match the commit fetched during `apply`, but the explicit
+apply path still uses `git fetch` and therefore honors the caller's Git transport
+configuration, including URL rewrites and Git proxies. The read-only transport
+isolation described above does not harden that mutating path. Release maintainers must
+also protect the GitHub account and tag-publishing process.
 
 The fixed primary sources and exact reviewed revisions are recorded in
 [`compat/sources.md`](compat/sources.md). A separate weekly/manual macOS compatibility
@@ -704,6 +717,8 @@ update.sh                     explicit release + agy/Codex compatibility check/a
 bug-report.sh                 sanitized local draft/preview/optional submission
 compat/                       per-tool baselines, reviewed evidence, and active exact matrix
 scripts/compatibility.py      stdlib metadata/matrix validation and exact resolution
+scripts/compatibility_probe.py bounded process-group supervisor for fixed evidence/version probes
+scripts/official_github.py    fixed, proxyless, redirect-free GitHub REST evidence client
 scripts/official_distribution.py  fixed, bounded agy distribution-manifest canary
 scripts/bug-report.py         privacy filter and SHA-bound gh submission
 skills/agy-worker/            canonical self-contained Agent Skill and runtime
@@ -720,7 +735,9 @@ CODE_OF_CONDUCT.md            enforceable participation standards
 tests/test-qa-gate.sh         offline adversarial suite
 tests/test-evidence-receipt.sh  88-case offline receipt/publication/protocol suite
 tests/test-agy-worker.sh       offline dispatcher/installer/routing suite
-tests/test-update.sh          175-case offline local-remote/matrix/manifest updater suite
+tests/test-update.sh          278-case offline transport/process/local-remote/matrix/manifest updater suite
+tests/test-official-github.py test-only fixed-endpoint transport adversary harness
+tests/test-compatibility-probe.py test-only timeout/output/signal/version adversary harness
 tests/test-official-distribution.py  test-only stdlib manifest adversary harness
 tests/test-reporting.sh       offline privacy/fake-gh reporting suite
 tests/test-packaging.sh       135-case offline Codex package/relocation/landing suite

--- a/compat/sources.md
+++ b/compat/sources.md
@@ -5,6 +5,20 @@ interval. Environment variables cannot replace these sources or the cadence. The
 check is read-only: it never fetches into the checkout, advances metadata, or takes
 an external action.
 
+Stable-release and source-revision observations use exact fixed GitHub REST endpoints
+under `https://api.github.com/repos/`. The Python standard-library client ignores
+ambient proxies, rejects redirects, requires strict bounded JSON response metadata,
+and exposes only validated version/tag and revision fields through a bounded
+process-group supervisor. Installed `agy --version` and `codex --version` probes use
+the same supervisor with smaller time and byte limits. Read-only check/watch performs
+no Git network operation, so Git URL rewrites, credential helpers, and Git proxy
+configuration are not evidence inputs.
+
+This transport boundary covers observation only. Explicit `update.sh apply` still
+uses the caller's `git fetch` transport after resolving the expected release commit
+through the fixed API, so ambient Git transport configuration remains part of that
+separately authorized mutation path.
+
 ## agy (Antigravity CLI)
 
 - Verified stable release: `agy-verified-version.txt`
@@ -56,3 +70,9 @@ bounded real job requires separate approval. The weekly watcher only reports
 `unchanged`, `drift-review`, or `evidence-unavailable`; it cannot approve or write a
 baseline. A future version or source change disables resolution until another human
 reconciliation is accepted.
+
+agy `1.1.11` remains unreconciled in the checked-in metadata. The transport and
+process-boundary hardening needed to evaluate it does not itself advance version,
+source, review date, manifest, or matrix records; `1.1.10` continues to fail closed
+on observed drift until the separate inventory/provider evidence is authorized and
+accepted.

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -63,6 +63,11 @@ accept a candidate, replace human diff review, or certify correctness or securit
   changing files. A disabled or stale matrix is drift-review; malformed or missing
   matrix evidence is inconclusive. The manifest helper requests no archive and its
   observational tuple cannot advance a baseline.
+  GitHub release/source observations use exact fixed REST paths through a proxyless,
+  redirect-rejecting strict JSON client and a bounded process-group supervisor.
+  Installed version probes use the same supervisor with smaller limits. Check/watch
+  makes no Git network request, so ambient Git URL rewrites and transport helpers are
+  outside its evidence path.
   Its `--watch` mode needs no installed tools and preserves the same
   unchanged/drift-review/evidence-unavailable exit contract. `update.sh apply [TAG]`
   remains explicit: it verifies a
@@ -103,7 +108,7 @@ accept a candidate, replace human diff review, or certify correctness or securit
 | `verify-job.sh`, `skills/agy-worker/runtime/verify-job.sh`, `skills/agy-worker/runtime/scripts/evidence_receipt.py`, `skills/agy-worker/runtime/schemas/evidence-receipt.schema.json` | Root compatibility entry plus exact input hashing, strict selection/advisory binding, startup-isolated parent-exclusive gate evidence, interruption cleanup, unsigned receipt validation, and private durable no-overwrite publication | `tests/test-evidence-receipt.sh` (88 cases) |
 | `proof-demo.sh`, `demo/fixtures/` | Repository-only offline starter proof using two canonical synthetic envelopes and isolated temporary repositories | `tests/test-proof-demo.sh` (21 cases) |
 | `skills/agy-worker/runtime/agents/*.md` | Prompt-injected bounded personas; prompt text is guidance, not enforcement | dispatcher suite plus bounded real exercises |
-| `update.sh`, `scripts/compatibility.py`, `scripts/official_distribution.py`, `compat/` | Explicit project releases; fixed-source agy/Codex review; sanitized reconciliation records; bounded distribution-manifest canary; strict per-tool metadata and active-only-when-bound model/effort matrix | `tests/test-update.sh` (175 cases, including the test-only manifest adversary harness) |
+| `update.sh`, `scripts/compatibility.py`, `scripts/compatibility_probe.py`, `scripts/official_github.py`, `scripts/official_distribution.py`, `compat/` | Explicit project releases; exact fixed-REST agy/Codex observation; bounded process-group/version probes; sanitized reconciliation records; bounded distribution-manifest canary; strict per-tool metadata and active-only-when-bound model/effort matrix. Explicit apply-time Git fetch remains ambient-configuration-aware. | `tests/test-update.sh` (278 cases, including fixed transport, supervisor, and manifest adversary harnesses) |
 | `bug-report.sh`, `scripts/bug-report.py`, `.github/ISSUE_TEMPLATE/` | Local privacy filtering, exact review binding, optional issue submission | `tests/test-reporting.sh` (21 cases) |
 | `.codex-plugin/plugin.json` | Codex skills-only package identity retained for local validation; not a public listing | `tests/test-packaging.sh` (135 cases) plus platform validators |
 | `PRIVACY.md`, `TERMS.md`, `SUPPORT.md` | Public data disclosure, project policy, and support route | `tests/test-packaging.sh` (135 cases) plus review |
@@ -144,15 +149,21 @@ accept a candidate, replace human diff review, or certify correctness or securit
 - Scheduled compatibility evidence is observational. Missing or malformed official
   evidence is inconclusive, and neither the watcher nor a release/version name can
   advance a human-reviewed baseline.
+- Read-only GitHub evidence never uses Git transport. `scripts/official_github.py`
+  owns the exact API repository/path policy and response validation;
+  `scripts/compatibility_probe.py` owns process, time, byte, environment, and signal
+  bounds. These guarantees do not extend to the explicit `update.sh apply` Git fetch.
 - The fixed agy distribution manifest is a drift canary, not executable or source
   evidence. Its validated archive tuple is never requested, opened, hashed, or run;
   the observational snapshot detects same-version build/hash changes but cannot
   activate the model/effort matrix.
 - `--workdir` is the single audited repository. User-supplied `--add-dir` roots must
   resolve inside it; multi-repository mutation is unsupported.
-- Release tags are trusted only through the fixed official origin and exact ref/commit
-  checks. Candidate validation executes release code and therefore relies on the
-  maintainer account and tag-publishing boundary.
+- Release tags are observed through fixed official REST endpoints and an apply
+  candidate must match that observed commit. The apply-time Git fetch still honors
+  ambient Git transport settings. Candidate validation executes release code and
+  therefore relies on that transport plus the maintainer account and tag-publishing
+  boundary.
 - Sanitization reduces accidental disclosure but does not replace exact human review.
   The reviewed hash must bind the bytes actually sent.
 - A plugin install is local enablement, not consent to send repository content.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -133,6 +133,16 @@ an earlier implementation because it shares a schema or helper.
 
 ### G0 — Compatibility Reconciliation & Watch
 
+**G0-F2 status:** Provider-independent transport hardening is implemented offline for
+review. Read-only project/agy/Codex release and source observations now use exact
+fixed GitHub REST paths with no ambient proxy or redirect path, and a bounded
+process-group supervisor also contains installed version probes. Check/watch makes no
+Git network request. The explicit `apply` fetch remains a separately authorized
+ambient-Git transport path and is not claimed hardened by this slice. No agy `1.1.11`
+version, revision, review date, manifest, or matrix record is advanced; `1.1.10`
+remains the active fail-closed baseline until separately authorized inventory and
+provider evidence is accepted.
+
 - **User job:** Learn that Codex or agy has drifted before a normal dispatch breaks,
   while keeping every check read-only and requiring a human to reconcile behavior.
 - **Intended surface:** Extend the fixed-source compatibility contract in `update.sh`,
@@ -153,6 +163,14 @@ an earlier implementation because it shares a schema or helper.
   drift or review is due, and `2` when network or source evidence is unavailable or
   malformed. Exit `2` is **inconclusive**, never green. The command changes no file,
   pulls nothing, applies nothing, and does not update its own baseline.
+- **Read-only transport contract:** Project, agy, and Codex observations use only
+  fixed `api.github.com` repository REST paths through a proxyless, redirect-rejecting,
+  strict bounded JSON client. A fixed-profile supervisor incrementally caps both
+  streams, applies a hard timeout, sanitizes output, and kills/reaps the entire child
+  process group. Installed version probes use the same boundary. Mutation-sensitive
+  offline controls prove that ambient Git URL rewrites, credentials, and proxies
+  cannot redirect check/watch, which performs no Git network query. This does not
+  make the explicit apply-time `git fetch` independent of ambient Git configuration.
 - **Watch workflow contract:** The workflow runs only on `macos-latest`, declares
   `permissions: contents: read`, uses no secrets, installs no package or CLI, invokes
   no model, and performs no apply, pull, issue, PR, commit, or baseline write. A
@@ -253,6 +271,9 @@ an earlier implementation because it shares a schema or helper.
   Reject a matrix with an unbound/mismatched version or revision, an unsupported pair,
   a provider-table-only claim, an inferred capability for an unknown model, a missing
   exact output slug, or an adjustable effort entry for a fixed/no-level model.
+  Reject alternate GitHub repositories or endpoint shapes, redirects, proxies,
+  duplicate/oversized/malformed REST evidence, unbounded version output, timeout,
+  descendant pipe retention, or swallowed HUP/INT/TERM status in read-only probes.
 - **Docs and AGENTS impact:** README compatibility semantics and limitations,
   `compat/sources.md`, REPO_MAP ownership/data flow, lessons learned on inconclusive
   evidence, and concise durable AGENTS probing rules. Run `agents-md-auditor` before

--- a/docs/lessons_learned.md
+++ b/docs/lessons_learned.md
@@ -37,6 +37,19 @@ environment-overridable. Report established drift separately from unavailable or
 malformed evidence: the latter is inconclusive and must outrank a known drift result
 rather than becoming green. Always report both tools before aggregating.
 
+A literal GitHub URL passed to `git ls-remote` is not a fixed-source guarantee: Git
+still honors repository and global `url.*.insteadOf`, proxy, credential, and transport
+configuration. Read-only compatibility evidence therefore uses an exact
+`api.github.com` REST repository/path allowlist, a proxyless redirect-rejecting strict
+JSON client, and no Git network command. Keep the explicit apply-time fetch limitation
+visible; observation hardening does not silently harden mutation.
+
+Bounding a parent command is insufficient when stdout/stderr pipes or descendants can
+outlive it. Capture both streams incrementally, cap them independently, impose a hard
+deadline, create a fresh process group, and kill/reap that group on timeout, overflow,
+or HUP/INT/TERM. Return only parsed canonical fields; never surface raw child output
+as compatibility evidence or diagnostics.
+
 Reconcile each tool's official CLI documentation, stable release, exact source
 revision, and installed semantic command inventory before advancing its separate
 version/revision/review-date metadata. An unknown command that exits zero or prints

--- a/scripts/compatibility_probe.py
+++ b/scripts/compatibility_probe.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Run fixed compatibility probes under hard process, time, and byte bounds."""
+
+from __future__ import annotations
+
+import os
+import re
+import selectors
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Optional, Sequence
+
+
+sys.dont_write_bytecode = True
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+OFFICIAL_HELPER = SCRIPT_DIR / "official_github.py"
+SEMVER_PATTERN = r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)"
+VERSION_PATTERNS = {
+    "agy": re.compile(rf"(?:agy\s+)?({SEMVER_PATTERN})"),
+    "codex": re.compile(rf"codex-cli\s+({SEMVER_PATTERN})"),
+}
+SIGNALS = (signal.SIGHUP, signal.SIGINT, signal.SIGTERM)
+
+
+@dataclass(frozen=True)
+class Limits:
+    timeout: float
+    stdout: int
+    stderr: int
+
+
+OFFICIAL_LIMITS = Limits(timeout=20.0, stdout=8 * 1024, stderr=8 * 1024)
+VERSION_LIMITS = Limits(timeout=3.0, stdout=128, stderr=128)
+TERM_GRACE_SECONDS = 0.25
+KILL_GRACE_SECONDS = 0.75
+
+
+class ProbeError(ValueError):
+    """A compatibility probe failed without exposing child output."""
+
+
+class ProbeInterrupted(BaseException):
+    """A terminal signal interrupted an active probe."""
+
+    def __init__(self, signum: int):
+        super().__init__(signum)
+        self.signum = signum
+
+
+def scrubbed_environment(source: Optional[Mapping[str, str]] = None) -> dict[str, str]:
+    """Remove ambient network, Git transport, pager, and Python startup controls."""
+
+    environment = dict(os.environ if source is None else source)
+    exact = {
+        "ALL_PROXY",
+        "GIT_ASKPASS",
+        "GIT_CONFIG",
+        "GIT_CONFIG_COUNT",
+        "GIT_CONFIG_GLOBAL",
+        "GIT_CONFIG_NOSYSTEM",
+        "GIT_CONFIG_PARAMETERS",
+        "GIT_CONFIG_SYSTEM",
+        "GIT_PAGER",
+        "GIT_PROXY_COMMAND",
+        "GIT_SSH",
+        "GIT_SSH_COMMAND",
+        "GH_PAGER",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+        "PAGER",
+        "PYTHONBREAKPOINT",
+        "PYTHONHOME",
+        "PYTHONINSPECT",
+        "PYTHONPATH",
+        "PYTHONSTARTUP",
+        "SSH_ASKPASS",
+        "all_proxy",
+        "http_proxy",
+        "https_proxy",
+        "no_proxy",
+    }
+    prefixes = ("GIT_CONFIG_KEY_", "GIT_CONFIG_VALUE_", "DYLD_", "LD_PRELOAD")
+    for key in list(environment):
+        if key in exact or key.startswith(prefixes):
+            environment.pop(key, None)
+    environment["NO_COLOR"] = "1"
+    environment["TERM"] = "dumb"
+    return environment
+
+
+def _group_exists(pgid: int) -> bool:
+    """Observe one exact process group without exposing or signalling another group."""
+
+    try:
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _wait_group_absent(pgid: int, timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not _group_exists(pgid):
+            return True
+        time.sleep(0.01)
+    return not _group_exists(pgid)
+
+
+def terminate_group(process: subprocess.Popen[bytes], signum: int = signal.SIGTERM) -> None:
+    """Terminate the exact reserved child group, then boundedly prove its absence."""
+
+    pgid = process.pid
+
+    try:
+        os.killpg(pgid, signum)
+    except (ProcessLookupError, PermissionError):
+        pass
+    grace_deadline = time.monotonic() + TERM_GRACE_SECONDS
+    while _group_exists(pgid) and time.monotonic() < grace_deadline:
+        time.sleep(0.01)
+    if _group_exists(pgid):
+        try:
+            os.killpg(pgid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            pass
+    try:
+        process.wait(timeout=KILL_GRACE_SECONDS)
+    except subprocess.TimeoutExpired:
+        raise ProbeError("probe process group cleanup failed") from None
+    # All signals happen before reaping the reserved group leader. After reap, only
+    # observe: never signal a PGID that the kernel could subsequently reuse.
+    if not _wait_group_absent(pgid, KILL_GRACE_SECONDS):
+        raise ProbeError("probe process group cleanup failed")
+
+
+def run_bounded(
+    argv: Sequence[str],
+    limits: Limits,
+    *,
+    environment: Optional[Mapping[str, str]] = None,
+    cwd: Optional[Path] = None,
+) -> tuple[bytes, bytes]:
+    """Capture both streams incrementally and fail closed on any exceeded bound."""
+
+    process: Optional[subprocess.Popen[bytes]] = None
+    cleanup_required = False
+    previous_handlers = {signum: signal.getsignal(signum) for signum in SIGNALS}
+    entry_mask = (
+        signal.pthread_sigmask(signal.SIG_BLOCK, [])
+        if hasattr(signal, "pthread_sigmask")
+        else None
+    )
+
+    def handle_signal(signum: int, _frame: object) -> None:
+        raise ProbeInterrupted(signum)
+
+    try:
+        for signum in SIGNALS:
+            signal.signal(signum, handle_signal)
+        if hasattr(signal, "pthread_sigmask"):
+            popen_mask = signal.pthread_sigmask(signal.SIG_BLOCK, SIGNALS)
+        try:
+            process = subprocess.Popen(
+                list(argv),
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                cwd=None if cwd is None else str(cwd),
+                env=scrubbed_environment(environment),
+                start_new_session=True,
+            )
+            cleanup_required = True
+        except OSError as exc:
+            raise ProbeError("probe could not start") from exc
+        finally:
+            if hasattr(signal, "pthread_sigmask"):
+                signal.pthread_sigmask(signal.SIG_SETMASK, popen_mask)
+
+        assert process.stdout is not None and process.stderr is not None
+        stdout_descriptor = process.stdout.fileno()
+        stderr_descriptor = process.stderr.fileno()
+        streams = {
+            stdout_descriptor: (process.stdout, limits.stdout, bytearray()),
+            stderr_descriptor: (process.stderr, limits.stderr, bytearray()),
+        }
+        for descriptor in streams:
+            os.set_blocking(descriptor, False)
+        deadline = time.monotonic() + limits.timeout
+        with selectors.DefaultSelector() as selector:
+            for descriptor in streams:
+                selector.register(descriptor, selectors.EVENT_READ)
+            while selector.get_map():
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise ProbeError("probe timed out")
+                events = selector.select(min(remaining, 0.10))
+                for key, _mask in events:
+                    descriptor = key.fd
+                    stream, limit, captured = streams[descriptor]
+                    try:
+                        chunk = os.read(descriptor, min(8192, limit + 1 - len(captured)))
+                    except BlockingIOError:
+                        continue
+                    if not chunk:
+                        selector.unregister(descriptor)
+                        stream.close()
+                        continue
+                    captured.extend(chunk)
+                    if len(captured) > limit:
+                        raise ProbeError("probe output exceeded its bound")
+        if hasattr(signal, "pthread_sigmask"):
+            wait_mask = signal.pthread_sigmask(signal.SIG_BLOCK, SIGNALS)
+        try:
+            try:
+                returncode = process.wait(timeout=max(0.0, deadline - time.monotonic()))
+            except subprocess.TimeoutExpired as exc:
+                raise ProbeError("probe timed out") from exc
+            # Keep terminal signals blocked until the reaped leader can no longer
+            # authorize cleanup of its former (and now reusable) process-group ID.
+            cleanup_required = False
+        finally:
+            if hasattr(signal, "pthread_sigmask"):
+                signal.pthread_sigmask(signal.SIG_SETMASK, wait_mask)
+        if returncode != 0:
+            raise ProbeError("probe command failed")
+        return bytes(streams[stdout_descriptor][2]), bytes(streams[stderr_descriptor][2])
+    except ProbeInterrupted:
+        if process is not None and cleanup_required:
+            terminate_group(process)
+        raise
+    except BaseException:
+        if process is not None and cleanup_required:
+            terminate_group(process)
+        raise
+    finally:
+        if hasattr(signal, "pthread_sigmask") and entry_mask is not None:
+            signal.pthread_sigmask(signal.SIG_SETMASK, entry_mask)
+        for signum, handler in previous_handlers.items():
+            signal.signal(signum, handler)
+
+
+def _version_argv(tool: str) -> list[str]:
+    executable = shutil.which(tool)
+    if executable is None:
+        raise ProbeError("installed tool is unavailable")
+    return [executable, "--version"]
+
+
+def _parse_version(tool: str, raw: bytes) -> str:
+    if not raw.endswith(b"\n") or raw.count(b"\n") != 1 or b"\x00" in raw:
+        raise ProbeError("version output is malformed")
+    try:
+        line = raw[:-1].decode("ascii", "strict")
+    except UnicodeDecodeError as exc:
+        raise ProbeError("version output is malformed") from exc
+    match = VERSION_PATTERNS[tool].fullmatch(line)
+    if match is None:
+        raise ProbeError("version output lacks documented semantic content")
+    return match.group(1)
+
+
+def capture_profile(profile: str, argument: Optional[str] = None) -> bytes:
+    """Run one fixed production profile and return only validated canonical stdout."""
+
+    if profile in ("agy-version", "codex-version"):
+        if argument is not None:
+            raise ProbeError("version profile does not accept an argument")
+        tool = profile[:-8]
+        stdout, _stderr = run_bounded(_version_argv(tool), VERSION_LIMITS)
+        return (_parse_version(tool, stdout) + "\n").encode("ascii")
+
+    if profile in ("official-project", "official-agy", "official-codex"):
+        if argument is not None:
+            raise ProbeError("latest-evidence profile does not accept an argument")
+        tool = profile[len("official-") :]
+        argv = [
+            sys.executable,
+            "-I",
+            "-B",
+            str(OFFICIAL_HELPER),
+            "--latest",
+            tool,
+        ]
+    elif profile == "official-project-release":
+        if argument is None or re.fullmatch(rf"v{SEMVER_PATTERN}", argument) is None:
+            raise ProbeError("project release profile requires one stable tag")
+        argv = [
+            sys.executable,
+            "-I",
+            "-B",
+            str(OFFICIAL_HELPER),
+            "--project-release",
+            argument,
+        ]
+    else:
+        raise ProbeError("unknown probe profile")
+    stdout, _stderr = run_bounded(argv, OFFICIAL_LIMITS)
+    if not stdout.endswith(b"\n") or stdout.count(b"\n") != 1 or b"\x00" in stdout:
+        raise ProbeError("official evidence output is malformed")
+    try:
+        fields = stdout[:-1].decode("ascii", "strict").split("\t")
+    except UnicodeDecodeError as exc:
+        raise ProbeError("official evidence output is malformed") from exc
+    if len(fields) != 3 or any(not field for field in fields):
+        raise ProbeError("official evidence output is malformed")
+    return stdout
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) not in (2, 3):
+        print("compatibility probe: evidence unavailable", file=sys.stderr)
+        return 2
+    try:
+        payload = capture_profile(argv[1], argv[2] if len(argv) == 3 else None)
+    except ProbeInterrupted as exc:
+        return 128 + exc.signum
+    except (ProbeError, OSError, subprocess.SubprocessError):
+        print("compatibility probe: evidence unavailable", file=sys.stderr)
+        return 2
+    sys.stdout.buffer.write(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/official_github.py
+++ b/scripts/official_github.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Fetch bounded compatibility evidence from fixed official GitHub API paths."""
+
+from __future__ import annotations
+
+import json
+import re
+import ssl
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Iterable, Optional
+
+
+API_ORIGIN = "https://api.github.com"
+API_HOST = "api.github.com"
+MAX_RESPONSE_BYTES = 256 * 1024
+FETCH_TIMEOUT_SECONDS = 6.0
+SEMVER_PATTERN = r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)"
+SEMVER_RE = re.compile(SEMVER_PATTERN)
+REVISION_RE = re.compile(r"[0-9a-f]{40}")
+FIXED_PATH_RE = re.compile(
+    rf"(?:"
+    rf"/repos/cagdasyurekli/codex-agy-worker/"
+    rf"(?:releases/latest|commits/v{SEMVER_PATTERN})"
+    rf"|/repos/google-antigravity/antigravity-cli/"
+    rf"(?:releases/latest|git/ref/heads/main)"
+    rf"|/repos/openai/codex/(?:releases/latest|git/ref/heads/main)"
+    rf")"
+)
+
+
+@dataclass(frozen=True)
+class ToolPolicy:
+    owner: str
+    repository: str
+    tag_pattern: re.Pattern[str]
+    main_branch: Optional[str]
+
+
+POLICIES = {
+    "project": ToolPolicy(
+        owner="cagdasyurekli",
+        repository="codex-agy-worker",
+        tag_pattern=re.compile(rf"v({SEMVER_PATTERN})"),
+        main_branch=None,
+    ),
+    "agy": ToolPolicy(
+        owner="google-antigravity",
+        repository="antigravity-cli",
+        tag_pattern=re.compile(rf"v?({SEMVER_PATTERN})"),
+        main_branch="main",
+    ),
+    "codex": ToolPolicy(
+        owner="openai",
+        repository="codex",
+        tag_pattern=re.compile(rf"rust-v({SEMVER_PATTERN})"),
+        main_branch="main",
+    ),
+}
+
+
+class OfficialEvidenceError(ValueError):
+    """A sanitized fixed-source evidence failure."""
+
+    def __init__(self, category: str):
+        super().__init__(category)
+        self.category = category
+
+
+class DuplicateKeyError(OfficialEvidenceError):
+    """Duplicate JSON keys make official evidence ambiguous."""
+
+
+class RejectRedirects(urllib.request.HTTPRedirectHandler):
+    """Reject redirects before urllib can make a second request."""
+
+    def redirect_request(
+        self,
+        req: urllib.request.Request,
+        fp: Any,
+        code: int,
+        msg: str,
+        headers: Any,
+        newurl: str,
+    ) -> None:
+        del req, fp, code, msg, headers, newurl
+        raise OfficialEvidenceError("redirect rejected")
+
+
+def no_duplicate_object(pairs: Iterable[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise DuplicateKeyError("invalid JSON document")
+        result[key] = value
+    return result
+
+
+def build_fixed_opener() -> urllib.request.OpenerDirector:
+    """Build the production opener: default TLS, no proxies, no redirects."""
+
+    context = ssl.create_default_context()
+    return urllib.request.build_opener(
+        urllib.request.ProxyHandler({}),
+        RejectRedirects(),
+        urllib.request.HTTPSHandler(context=context),
+    )
+
+
+def _single_header(headers: Any, name: str, *, required: bool = True) -> Optional[str]:
+    values = headers.get_all(name) if hasattr(headers, "get_all") else None
+    if values is None:
+        value = headers.get(name) if hasattr(headers, "get") else None
+        values = [] if value is None else [value]
+    if not values and not required:
+        return None
+    if len(values) != 1 or not isinstance(values[0], str):
+        raise OfficialEvidenceError("invalid response metadata")
+    return values[0]
+
+
+def _validate_content_type(raw: str) -> None:
+    parts = [part.strip() for part in raw.split(";")]
+    if not parts or parts[0].lower() not in {
+        "application/json",
+        "application/vnd.github+json",
+    }:
+        raise OfficialEvidenceError("invalid response metadata")
+    for parameter in parts[1:]:
+        if parameter.lower() != "charset=utf-8":
+            raise OfficialEvidenceError("invalid response metadata")
+
+
+def _validate_fixed_url(url: str) -> None:
+    if not url.isascii() or "%" in url or "\\" in url:
+        raise OfficialEvidenceError("invalid fixed endpoint")
+    try:
+        parsed = urllib.parse.urlsplit(url)
+        port = parsed.port
+    except ValueError:
+        raise OfficialEvidenceError("invalid fixed endpoint") from None
+    if (
+        parsed.scheme != "https"
+        or parsed.netloc != API_HOST
+        or parsed.hostname != API_HOST
+        or parsed.username is not None
+        or parsed.password is not None
+        or port is not None
+        or parsed.query
+        or parsed.fragment
+        or FIXED_PATH_RE.fullmatch(parsed.path) is None
+    ):
+        raise OfficialEvidenceError("invalid fixed endpoint")
+
+
+def fetch_json(
+    opener: Any,
+    url: str,
+    *,
+    timeout: float = FETCH_TIMEOUT_SECONDS,
+    limit: int = MAX_RESPONSE_BYTES,
+) -> Any:
+    """Fetch one strict, incrementally bounded JSON response."""
+
+    _validate_fixed_url(url)
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "codex-agy-worker/compat",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+        method="GET",
+    )
+    try:
+        response = opener.open(request, timeout=timeout)
+    except OfficialEvidenceError:
+        raise
+    except urllib.error.HTTPError as exc:
+        if 300 <= exc.code < 400:
+            raise OfficialEvidenceError("redirect rejected") from None
+        raise OfficialEvidenceError("HTTP evidence unavailable") from None
+    except (urllib.error.URLError, TimeoutError, OSError):
+        raise OfficialEvidenceError("network evidence unavailable") from None
+    except Exception:
+        raise OfficialEvidenceError("network evidence unavailable") from None
+
+    try:
+        with response:
+            status = getattr(response, "status", None)
+            if status is None and hasattr(response, "getcode"):
+                status = response.getcode()
+            if status != 200:
+                raise OfficialEvidenceError("HTTP evidence unavailable")
+            content_type = _single_header(response.headers, "Content-Type")
+            assert content_type is not None
+            _validate_content_type(content_type)
+            if _single_header(response.headers, "Content-Encoding", required=False) not in (
+                None,
+                "identity",
+            ):
+                raise OfficialEvidenceError("invalid response metadata")
+            if _single_header(response.headers, "Transfer-Encoding", required=False) is not None:
+                raise OfficialEvidenceError("invalid response metadata")
+            length_text = _single_header(response.headers, "Content-Length")
+            assert length_text is not None
+            if re.fullmatch(r"[1-9][0-9]*", length_text) is None:
+                raise OfficialEvidenceError("invalid response metadata")
+            expected_length = int(length_text)
+            if expected_length > limit:
+                raise OfficialEvidenceError("response too large")
+
+            body = bytearray()
+            while len(body) <= limit:
+                chunk = response.read(min(8192, limit + 1 - len(body)))
+                if not chunk:
+                    break
+                body.extend(chunk)
+                if len(body) > limit:
+                    raise OfficialEvidenceError("response too large")
+    except OfficialEvidenceError:
+        raise
+    except (TimeoutError, OSError):
+        raise OfficialEvidenceError("network evidence unavailable") from None
+    except Exception:
+        raise OfficialEvidenceError("network evidence unavailable") from None
+
+    if len(body) != expected_length:
+        raise OfficialEvidenceError("invalid response metadata")
+    try:
+        return json.loads(
+            bytes(body).decode("utf-8", "strict"),
+            object_pairs_hook=no_duplicate_object,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, DuplicateKeyError):
+        raise OfficialEvidenceError("invalid JSON document") from None
+
+
+def _object(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise OfficialEvidenceError(f"invalid {label} evidence")
+    return value
+
+
+def _release(value: Any, policy: ToolPolicy) -> tuple[str, str]:
+    document = _object(value, "release")
+    tag = document.get("tag_name")
+    if (
+        not isinstance(tag, str)
+        or policy.tag_pattern.fullmatch(tag) is None
+        or document.get("draft") is not False
+        or document.get("prerelease") is not False
+    ):
+        raise OfficialEvidenceError("invalid stable release evidence")
+    match = policy.tag_pattern.fullmatch(tag)
+    assert match is not None
+    return tag, match.group(1)
+
+
+def _source_ref(value: Any, branch: str) -> str:
+    document = _object(value, "source")
+    target = _object(document.get("object"), "source")
+    revision = target.get("sha")
+    if (
+        document.get("ref") != f"refs/heads/{branch}"
+        or target.get("type") != "commit"
+        or not isinstance(revision, str)
+        or REVISION_RE.fullmatch(revision) is None
+    ):
+        raise OfficialEvidenceError("invalid source evidence")
+    return revision
+
+
+def _commit(value: Any) -> str:
+    document = _object(value, "release commit")
+    revision = document.get("sha")
+    if not isinstance(revision, str) or REVISION_RE.fullmatch(revision) is None:
+        raise OfficialEvidenceError("invalid release commit evidence")
+    return revision
+
+
+def _repository_url(policy: ToolPolicy, suffix: str) -> str:
+    return f"{API_ORIGIN}/repos/{policy.owner}/{policy.repository}/{suffix}"
+
+
+def latest_evidence(tool: str, *, opener: Optional[Any] = None) -> tuple[str, str, str]:
+    """Return a sanitized tool, stable version/tag, and source or release revision."""
+
+    policy = POLICIES.get(tool)
+    if policy is None:
+        raise OfficialEvidenceError("invalid tool policy")
+    fixed_opener = opener if opener is not None else build_fixed_opener()
+    tag, version = _release(
+        fetch_json(fixed_opener, _repository_url(policy, "releases/latest")),
+        policy,
+    )
+    if policy.main_branch is None:
+        revision = _commit(
+            fetch_json(fixed_opener, _repository_url(policy, f"commits/{tag}"))
+        )
+        return tool, tag, revision
+    revision = _source_ref(
+        fetch_json(
+            fixed_opener,
+            _repository_url(policy, f"git/ref/heads/{policy.main_branch}"),
+        ),
+        policy.main_branch,
+    )
+    return tool, version, revision
+
+
+def project_release_evidence(tag: str, *, opener: Optional[Any] = None) -> tuple[str, str, str]:
+    """Resolve one strictly validated project release tag to an official commit."""
+
+    policy = POLICIES["project"]
+    if policy.tag_pattern.fullmatch(tag) is None:
+        raise OfficialEvidenceError("invalid project release tag")
+    fixed_opener = opener if opener is not None else build_fixed_opener()
+    revision = _commit(
+        fetch_json(fixed_opener, _repository_url(policy, f"commits/{tag}"))
+    )
+    return "project", tag, revision
+
+
+def main(argv: list[str]) -> int:
+    try:
+        if len(argv) == 3 and argv[1] == "--latest" and argv[2] in POLICIES:
+            row = latest_evidence(argv[2])
+        elif len(argv) == 3 and argv[1] == "--project-release":
+            row = project_release_evidence(argv[2])
+        else:
+            raise OfficialEvidenceError("invalid invocation")
+    except OfficialEvidenceError as exc:
+        print(f"official github: evidence unavailable ({exc.category})", file=sys.stderr)
+        return 2
+    print("\t".join(row))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/skills/agy-worker/SKILL.md
+++ b/skills/agy-worker/SKILL.md
@@ -347,13 +347,17 @@ uncommitted work.
 - When `$PIPELINE/update.sh` exists, `update.sh check` is read-only and may be run
   when the user asks for an update/compatibility check. It reports tool releases plus
   verified agy version, official-upstream drift, and fixed 30-day documentation-review
-  status. A folder-only install intentionally has no checkout updater: do not fetch or
-  pull code automatically to manufacture one.
+  status. Its fixed GitHub REST evidence and installed-version probes are bounded and
+  sanitized; check/watch makes no Git network request. A folder-only install
+  intentionally has no checkout updater: do not fetch or pull code automatically to
+  manufacture one.
 - Run `update.sh apply [TAG]` only on an explicit user request. It refuses dirty or
   detached checkouts and ignored-file collisions, validates tests plus a temporary
   skill install, fast-forwards, and reinstalls this skill. If the real install fails
   after merge, report the partial update and exact recovery command; do not claim an
-  atomic rollback. Never invoke it during a worker job.
+  atomic rollback. Its explicit Git fetch still honors the caller's Git transport
+  configuration; the read-only check's transport isolation does not cover apply.
+  Never invoke it during a worker job.
 - A detected bug authorizes diagnosis, not external submission. When
   `$PIPELINE/bug-report.sh` exists and the user wants a report, create only a sanitized
   local draft with `bug-report.sh draft`, show it with `bug-report.sh preview`, and

--- a/tests/test-compatibility-probe.py
+++ b/tests/test-compatibility-probe.py
@@ -1,0 +1,476 @@
+#!/usr/bin/env python3
+"""Offline adversarial tests for bounded compatibility subprocess profiles."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import os
+import signal
+import shutil
+import stat
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+
+sys.dont_write_bytecode = True
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "compatibility_probe.py"
+SPEC = importlib.util.spec_from_file_location("compatibility_probe_tested", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+TMP = Path(tempfile.mkdtemp(prefix="agyworker-probe-tests."))
+passed = 0
+failed = 0
+
+
+def check(name: str, predicate: Callable[[], bool]) -> None:
+    global passed, failed
+    try:
+        result = bool(predicate())
+    except BaseException as exc:
+        result = False
+        detail = f" ({type(exc).__name__}: {exc})"
+    else:
+        detail = ""
+    if result:
+        passed += 1
+    else:
+        failed += 1
+        print(f"FAIL compatibility probe: {name}{detail}")
+
+
+def rejects(action: Callable[[], Any]) -> bool:
+    try:
+        action()
+    except MODULE.ProbeError:
+        return True
+    return False
+
+
+def command(code: str) -> list[str]:
+    return [sys.executable, "-I", "-B", "-c", code]
+
+
+def process_gone(pid: int) -> bool:
+    for _ in range(40):
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return True
+        time.sleep(0.025)
+    return False
+
+
+check(
+    "bounded capture returns separate exact streams",
+    lambda: MODULE.run_bounded(
+        command("import sys; sys.stdout.write('out'); sys.stderr.write('err')"),
+        MODULE.Limits(1.0, 3, 3),
+    )
+    == (b"out", b"err"),
+)
+check(
+    "exact stdout and stderr limits are accepted",
+    lambda: MODULE.run_bounded(
+        command("import sys; sys.stdout.write('1234'); sys.stderr.write('5678')"),
+        MODULE.Limits(1.0, 4, 4),
+    )
+    == (b"1234", b"5678"),
+)
+check(
+    "stdout overflow kills the probe",
+    lambda: rejects(
+        lambda: MODULE.run_bounded(
+            command("print('x' * 9, end='')"), MODULE.Limits(1.0, 8, 8)
+        )
+    ),
+)
+check(
+    "stderr overflow kills the probe",
+    lambda: rejects(
+        lambda: MODULE.run_bounded(
+            command("import sys; sys.stderr.write('x' * 9)"),
+            MODULE.Limits(1.0, 8, 8),
+        )
+    ),
+)
+check(
+    "hard wall timeout kills the probe",
+    lambda: rejects(
+        lambda: MODULE.run_bounded(
+            command("import time; time.sleep(5)"), MODULE.Limits(0.15, 8, 8)
+        )
+    ),
+)
+check(
+    "nonzero child is rejected without returning partial output",
+    lambda: rejects(
+        lambda: MODULE.run_bounded(
+            command("print('secret'); raise SystemExit(7)"), MODULE.Limits(1.0, 128, 128)
+        )
+    ),
+)
+check(
+    "missing executable is controlled",
+    lambda: rejects(
+        lambda: MODULE.run_bounded(
+            [str(TMP / "does-not-exist")], MODULE.Limits(1.0, 8, 8)
+        )
+    ),
+)
+
+
+def hostile_descendant_code(pid_marker: Path, late_marker: Path, stream: str) -> str:
+    stream_write = {
+        "none": "",
+        "stdout": "os.write(1, b'x' * 4096)",
+        "stderr": "os.write(2, b'x' * 4096)",
+    }[stream]
+    child_code = "\n".join(
+        (
+            "import os, signal, time",
+            "signal.signal(signal.SIGHUP, signal.SIG_IGN)",
+            "signal.signal(signal.SIGINT, signal.SIG_IGN)",
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN)",
+            f"with open({str(pid_marker)!r}, 'w') as marker:",
+            "    marker.write(str(os.getpid()))",
+            stream_write,
+            "time.sleep(0.7)",
+            f"with open({str(late_marker)!r}, 'w') as marker:",
+            "    marker.write('late side effect')",
+            "time.sleep(9)",
+        )
+    )
+    return (
+        "import subprocess,sys; "
+        f"subprocess.Popen([sys.executable,'-I','-B','-c',{child_code!r}]); "
+        "raise SystemExit(0)"
+    )
+
+
+def hostile_descendant_failure(label: str, stream: str) -> bool:
+    pid_marker = TMP / f"{label}.pid"
+    late_marker = TMP / f"{label}.late"
+    limits = MODULE.Limits(0.35 if stream == "none" else 2.0, 128, 128)
+    started = time.monotonic()
+    rejected = rejects(
+        lambda: MODULE.run_bounded(
+            command(hostile_descendant_code(pid_marker, late_marker, stream)), limits
+        )
+    )
+    elapsed = time.monotonic() - started
+    if not pid_marker.exists():
+        return False
+    descendant = int(pid_marker.read_text(encoding="ascii"))
+    gone = process_gone(descendant)
+    time.sleep(0.8)
+    return rejected and elapsed < 1.8 and gone and not late_marker.exists()
+
+
+check(
+    "timeout kills a TERM-ignoring descendant after its leader exits",
+    lambda: hostile_descendant_failure("hostile-timeout", "none"),
+)
+check(
+    "stdout overflow kills a TERM-ignoring descendant after its leader exits",
+    lambda: hostile_descendant_failure("hostile-stdout", "stdout"),
+)
+check(
+    "stderr overflow kills a TERM-ignoring descendant after its leader exits",
+    lambda: hostile_descendant_failure("hostile-stderr", "stderr"),
+)
+
+
+def signal_cleanup(signum: int) -> bool:
+    marker = TMP / f"signal-{signum}.pid"
+    late_marker = TMP / f"signal-{signum}.late"
+    runner = os.fork()
+    if runner == 0:
+        try:
+            MODULE.run_bounded(
+                command(hostile_descendant_code(marker, late_marker, "none")),
+                MODULE.Limits(8.0, 128, 128),
+            )
+        except MODULE.ProbeInterrupted as exc:
+            os._exit(0 if exc.signum == signum else 4)
+        except BaseException:
+            os._exit(5)
+        os._exit(6)
+    deadline = time.monotonic() + 2.0
+    while not marker.exists() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    if not marker.exists():
+        os.kill(runner, signal.SIGKILL)
+        os.waitpid(runner, 0)
+        return False
+    child = int(marker.read_text(encoding="ascii"))
+    os.kill(runner, signum)
+    _pid, status = os.waitpid(runner, 0)
+    gone = process_gone(child)
+    time.sleep(0.8)
+    return (
+        os.waitstatus_to_exitcode(status) == 0
+        and gone
+        and not late_marker.exists()
+    )
+
+
+check("HUP cleans a leader-exited TERM-ignoring group", lambda: signal_cleanup(signal.SIGHUP))
+check("INT cleans a leader-exited TERM-ignoring group", lambda: signal_cleanup(signal.SIGINT))
+check("TERM cleans a leader-exited TERM-ignoring group", lambda: signal_cleanup(signal.SIGTERM))
+
+
+def completed_reap_signal(mask_signals: bool) -> tuple[bool, bool]:
+    real_popen = MODULE.subprocess.Popen
+    real_terminate = MODULE.terminate_group
+    real_mask = MODULE.signal.pthread_sigmask
+    initial_mask = real_mask(signal.SIG_BLOCK, [])
+    cleanup_after_reap: list[bool] = []
+
+    class SignallingWaitProcess:
+        def __init__(self, *args: Any, **kwargs: Any):
+            self.child = real_popen(*args, **kwargs)
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(self.child, name)
+
+        def wait(self, *args: Any, **kwargs: Any) -> int:
+            result = self.child.wait(*args, **kwargs)
+            os.kill(os.getpid(), signal.SIGTERM)
+            return result
+
+    def record_cleanup(process: Any) -> None:
+        cleanup_after_reap.append(process.child.returncode is not None)
+
+    MODULE.subprocess.Popen = SignallingWaitProcess
+    MODULE.terminate_group = record_cleanup
+    if not mask_signals:
+        MODULE.signal.pthread_sigmask = lambda *_args: set()
+    interrupted = False
+    try:
+        MODULE.run_bounded(command("pass"), MODULE.Limits(1.0, 8, 8))
+    except MODULE.ProbeInterrupted as exc:
+        interrupted = exc.signum == signal.SIGTERM
+    finally:
+        MODULE.subprocess.Popen = real_popen
+        MODULE.terminate_group = real_terminate
+        MODULE.signal.pthread_sigmask = real_mask
+        real_mask(signal.SIG_SETMASK, initial_mask)
+    return interrupted, bool(cleanup_after_reap)
+
+
+check(
+    "signal after completed reap propagates without process-group cleanup",
+    lambda: completed_reap_signal(True) == (True, False),
+)
+check(
+    "removing atomic wait masking reintroduces cleanup after reap",
+    lambda: completed_reap_signal(False) == (True, True),
+)
+
+
+def environment_policy() -> bool:
+    source = {
+        "PATH": "/bin",
+        "HOME": "/private/example",
+        "HTTP_PROXY": "secret",
+        "https_proxy": "secret",
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "url.bad.insteadOf",
+        "GIT_CONFIG_VALUE_0": "https://github.com/",
+        "GIT_ASKPASS": "secret",
+        "GIT_SSH_COMMAND": "secret",
+        "PYTHONPATH": "secret",
+        "PYTHONSTARTUP": "secret",
+        "DYLD_INSERT_LIBRARIES": "secret",
+        "LD_PRELOAD": "secret",
+        "PAGER": "secret",
+    }
+    result = MODULE.scrubbed_environment(source)
+    return (
+        result["PATH"] == "/bin"
+        and result["HOME"] == "/private/example"
+        and result["TERM"] == "dumb"
+        and result["NO_COLOR"] == "1"
+        and not any("secret" == value for value in result.values())
+        and not any(key.startswith("GIT_CONFIG_") for key in result)
+    )
+
+
+check("ambient transport and startup controls are stripped", environment_policy)
+
+
+check(
+    "agy version parser accepts documented bare output",
+    lambda: MODULE._parse_version("agy", b"1.1.11\n") == "1.1.11",
+)
+check(
+    "agy version parser accepts documented prefix",
+    lambda: MODULE._parse_version("agy", b"agy 1.1.11\n") == "1.1.11",
+)
+check(
+    "codex version parser accepts exact documented output",
+    lambda: MODULE._parse_version("codex", b"codex-cli 0.147.0\n") == "0.147.0",
+)
+for index, raw in enumerate(
+    (
+        b"",
+        b"1.1.11",
+        b"version 1.1.11\n",
+        b"1.1.11\nextra\n",
+        b"1.1.11\x00\n",
+        b"01.1.11\n",
+        b"1.1.11-rc.1\n",
+        b"\xff\n",
+    ),
+    1,
+):
+    check(
+        f"malformed agy version form {index} is rejected",
+        lambda raw=raw: rejects(lambda: MODULE._parse_version("agy", raw)),
+    )
+for index, raw in enumerate(
+    (b"0.147.0\n", b"codex 0.147.0\n", b"codex-cli 0.147.0", b"codex-cli 0.147.0\nextra\n"),
+    1,
+):
+    check(
+        f"malformed codex version form {index} is rejected",
+        lambda raw=raw: rejects(lambda: MODULE._parse_version("codex", raw)),
+    )
+
+
+def write_tool(name: str, output: str, marker: Path) -> None:
+    path = TMP / name
+    path.write_text(
+        "#!/bin/sh\n"
+        f"printf '%s\\n' \"$*\" > {str(marker)!r}\n"
+        f"printf '%b' {output!r}\n",
+        encoding="utf-8",
+    )
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def version_profile(tool: str, output: str, expected: bytes) -> bool:
+    marker = TMP / f"{tool}.argv"
+    write_tool(tool, output, marker)
+    previous = os.environ.get("PATH")
+    os.environ["PATH"] = f"{TMP}:/usr/bin:/bin"
+    try:
+        result = MODULE.capture_profile(f"{tool}-version")
+    finally:
+        if previous is None:
+            os.environ.pop("PATH", None)
+        else:
+            os.environ["PATH"] = previous
+    return result == expected and marker.read_text(encoding="utf-8") == "--version\n"
+
+
+check(
+    "agy profile invokes only exact --version and normalizes output",
+    lambda: version_profile("agy", "agy 1.1.11\n", b"1.1.11\n"),
+)
+check(
+    "codex profile invokes only exact --version and normalizes output",
+    lambda: version_profile("codex", "codex-cli 0.147.0\n", b"0.147.0\n"),
+)
+check(
+    "version profile rejects an extra caller argument",
+    lambda: rejects(lambda: MODULE.capture_profile("agy-version", "extra")),
+)
+
+
+def official_profile(profile: str, argument: Any, expected_tail: list[str], payload: bytes) -> bool:
+    captured: list[Any] = []
+    original = MODULE.run_bounded
+
+    def fake(argv: Any, limits: Any, **_kwargs: Any) -> tuple[bytes, bytes]:
+        captured.extend([list(argv), limits])
+        return payload, b"private ignored stderr"
+
+    MODULE.run_bounded = fake
+    try:
+        result = MODULE.capture_profile(profile, argument)
+    finally:
+        MODULE.run_bounded = original
+    argv, limits = captured
+    return (
+        result == payload
+        and argv[:3] == [sys.executable, "-I", "-B"]
+        and argv[-len(expected_tail) :] == expected_tail
+        and limits == MODULE.OFFICIAL_LIMITS
+    )
+
+
+check(
+    "agy official profile binds the fixed helper and exact tool",
+    lambda: official_profile(
+        "official-agy", None, ["--latest", "agy"], b"agy\t1.1.11\t" + b"a" * 40 + b"\n"
+    ),
+)
+check(
+    "project release profile accepts one stable tag",
+    lambda: official_profile(
+        "official-project-release",
+        "v1.2.3",
+        ["--project-release", "v1.2.3"],
+        b"project\tv1.2.3\t" + b"b" * 40 + b"\n",
+    ),
+)
+check(
+    "unstable project release profile is rejected before child start",
+    lambda: rejects(
+        lambda: MODULE.capture_profile("official-project-release", "v1.2.3-rc.1")
+    ),
+)
+check(
+    "unknown production profile is rejected",
+    lambda: rejects(lambda: MODULE.capture_profile("run-arbitrary", "/bin/sh")),
+)
+check(
+    "official profile rejects multiline helper output",
+    lambda: rejects(
+        lambda: official_profile(
+            "official-codex",
+            None,
+            ["--latest", "codex"],
+            b"codex\t0.147.0\t" + b"c" * 40 + b"\nextra\n",
+        )
+    ),
+)
+
+
+def sanitized_main() -> bool:
+    original = MODULE.capture_profile
+    MODULE.capture_profile = lambda *_args: (_ for _ in ()).throw(
+        MODULE.ProbeError("credential-bearing private child bytes")
+    )
+    stderr = io.StringIO()
+    try:
+        with contextlib.redirect_stderr(stderr):
+            status = MODULE.main([str(MODULE_PATH), "agy-version"])
+    finally:
+        MODULE.capture_profile = original
+    return (
+        status == 2
+        and stderr.getvalue() == "compatibility probe: evidence unavailable\n"
+        and "credential" not in stderr.getvalue()
+    )
+
+
+check("CLI failures expose one sanitized category only", sanitized_main)
+check(
+    "CLI rejects extra invocation fields",
+    lambda: MODULE.main([str(MODULE_PATH), "agy-version", "x", "y"]) == 2,
+)
+
+shutil.rmtree(TMP)
+print(f"COMPATIBILITY_PROBE_TEST_RESULT passed={passed} failed={failed}")
+raise SystemExit(1 if failed else 0)

--- a/tests/test-official-github.py
+++ b/tests/test-official-github.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+"""Offline adversarial tests for the fixed GitHub compatibility evidence client."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import urllib.error
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+
+sys.dont_write_bytecode = True
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "official_github.py"
+SPEC = importlib.util.spec_from_file_location("official_github_tested", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+class Headers:
+    def __init__(self, values: Optional[dict[str, Any]] = None):
+        self.values = values or {}
+
+    def get_all(self, name: str) -> Optional[list[str]]:
+        value = self.values.get(name)
+        if value is None:
+            return None
+        return value if isinstance(value, list) else [value]
+
+    def get(self, name: str) -> Optional[str]:
+        value = self.values.get(name)
+        if isinstance(value, list):
+            return value[0] if value else None
+        return value
+
+
+class Response:
+    def __init__(
+        self,
+        body: bytes,
+        *,
+        status: int = 200,
+        headers: Optional[dict[str, Any]] = None,
+    ):
+        self.body = body
+        self.position = 0
+        self.status = status
+        base = {
+            "Content-Type": "application/json; charset=utf-8",
+            "Content-Length": str(len(body)),
+        }
+        if headers:
+            base.update(headers)
+        self.headers = Headers(base)
+
+    def read(self, size: int = -1) -> bytes:
+        if size < 0:
+            size = len(self.body) - self.position
+        chunk = self.body[self.position : self.position + size]
+        self.position += len(chunk)
+        return chunk
+
+    def getcode(self) -> int:
+        return self.status
+
+    def __enter__(self) -> "Response":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+
+class Opener:
+    def __init__(self, *results: Any):
+        self.results = list(results)
+        self.calls: list[tuple[str, float, dict[str, str]]] = []
+
+    def open(self, request: Any, timeout: float) -> Response:
+        self.calls.append((request.full_url, timeout, dict(request.header_items())))
+        if not self.results:
+            raise AssertionError("unexpected request")
+        result = self.results.pop(0)
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+
+def encoded(value: Any) -> bytes:
+    return json.dumps(value, separators=(",", ":")).encode("utf-8")
+
+
+def response(value: Any, **kwargs: Any) -> Response:
+    return Response(encoded(value), **kwargs)
+
+
+def release(tag: str, *, draft: Any = False, prerelease: Any = False) -> dict[str, Any]:
+    return {
+        "tag_name": tag,
+        "draft": draft,
+        "prerelease": prerelease,
+        "body": "ignored public release prose",
+    }
+
+
+def source(revision: str = "a" * 40, *, ref: str = "refs/heads/main", kind: str = "commit") -> dict[str, Any]:
+    return {"ref": ref, "object": {"sha": revision, "type": kind, "url": "ignored"}}
+
+
+def commit(revision: str = "b" * 40) -> dict[str, Any]:
+    return {"sha": revision, "commit": {"message": "ignored"}}
+
+
+passed = 0
+failed = 0
+
+
+def check(name: str, predicate: Callable[[], bool]) -> None:
+    global passed, failed
+    try:
+        result = bool(predicate())
+    except Exception as exc:  # test harness reports controlled failures compactly
+        result = False
+        detail = f" ({type(exc).__name__}: {exc})"
+    else:
+        detail = ""
+    if result:
+        passed += 1
+    else:
+        failed += 1
+        print(f"FAIL official github: {name}{detail}")
+
+
+def rejects(category: str, action: Callable[[], Any]) -> bool:
+    try:
+        action()
+    except MODULE.OfficialEvidenceError as exc:
+        return exc.category == category
+    return False
+
+
+def collect(tool: str, release_value: Any, second: Any) -> tuple[tuple[str, str, str], Opener]:
+    opener = Opener(response(release_value), response(second))
+    return MODULE.latest_evidence(tool, opener=opener), opener
+
+
+check(
+    "agy stable release and source are canonical",
+    lambda: collect("agy", release("1.1.11"), source())[0]
+    == ("agy", "1.1.11", "a" * 40),
+)
+check(
+    "agy accepts its documented optional v tag prefix",
+    lambda: collect("agy", release("v1.1.11"), source())[0]
+    == ("agy", "1.1.11", "a" * 40),
+)
+check(
+    "codex stable tag and source are canonical",
+    lambda: collect("codex", release("rust-v0.147.0"), source("c" * 40))[0]
+    == ("codex", "0.147.0", "c" * 40),
+)
+check(
+    "project latest release resolves to exact commit",
+    lambda: collect("project", release("v0.1.0"), commit())[0]
+    == ("project", "v0.1.0", "b" * 40),
+)
+check(
+    "explicit project release resolves to exact commit",
+    lambda: MODULE.project_release_evidence(
+        "v1.2.3", opener=Opener(response(commit("d" * 40)))
+    )
+    == ("project", "v1.2.3", "d" * 40),
+)
+check(
+    "inert extra API keys cannot change selected evidence",
+    lambda: collect(
+        "agy",
+        {**release("1.1.11"), "credential": "not-rendered"},
+        {**source(), "extra": {"sha": "f" * 40}},
+    )[0]
+    == ("agy", "1.1.11", "a" * 40),
+)
+
+
+def request_policy() -> bool:
+    result, opener = collect("agy", release("1.1.11"), source())
+    first_url, timeout, headers = opener.calls[0]
+    return (
+        result[0] == "agy"
+        and first_url
+        == "https://api.github.com/repos/google-antigravity/antigravity-cli/releases/latest"
+        and timeout == MODULE.FETCH_TIMEOUT_SECONDS
+        and headers.get("Accept") == "application/vnd.github+json"
+        and headers.get("X-github-api-version") == "2022-11-28"
+        and len(opener.calls) == 2
+    )
+
+
+check("request path, headers, timeout, and count are fixed", request_policy)
+check(
+    "vendor JSON content type is accepted",
+    lambda: MODULE.fetch_json(
+        Opener(
+            response(
+                {"ok": True},
+                headers={"Content-Type": "application/vnd.github+json; charset=utf-8"},
+            )
+        ),
+        "https://api.github.com/repos/openai/codex/releases/latest",
+    )
+    == {"ok": True},
+)
+check(
+    "identity content encoding is accepted",
+    lambda: MODULE.fetch_json(
+        Opener(response({"ok": True}, headers={"Content-Encoding": "identity"})),
+        "https://api.github.com/repos/openai/codex/releases/latest",
+    )
+    == {"ok": True},
+)
+
+
+def opener_policy() -> bool:
+    opener = MODULE.build_fixed_opener()
+    proxy_handlers = [
+        handler for handler in opener.handlers if isinstance(handler, MODULE.urllib.request.ProxyHandler)
+    ]
+    return (
+        not proxy_handlers
+        and any(isinstance(handler, MODULE.RejectRedirects) for handler in opener.handlers)
+    )
+
+
+check("production opener disables proxies and installs redirect rejection", opener_policy)
+check(
+    "redirect handler refuses a second request",
+    lambda: rejects(
+        "redirect rejected",
+        lambda: MODULE.RejectRedirects().redirect_request(None, None, 302, "", {}, "https://x"),
+    ),
+)
+
+
+fixed_url_rejections = [
+    "http://api.github.com/repos/openai/codex/releases/latest",
+    "https://github.com/repos/openai/codex/releases/latest",
+    "https://user@api.github.com/repos/openai/codex/releases/latest",
+    "https://api.github.com:443/repos/openai/codex/releases/latest",
+    "https://api.github.com/repos/openai/codex/releases/latest?token=x",
+    "https://api.github.com/repos/openai/codex/releases/latest#x",
+    "https://api.github.com/other/openai/codex/releases/latest",
+    "https://api.github.com/repos/attacker/codex/releases/latest",
+    "https://api.github.com/repos/openai/codex/%72eleases/latest",
+    "https://api.github.com/repos/openai\\codex/releases/latest",
+]
+for index, url in enumerate(fixed_url_rejections, 1):
+    check(
+        f"fixed endpoint mutation {index} is rejected",
+        lambda url=url: rejects(
+            "invalid fixed endpoint", lambda: MODULE.fetch_json(Opener(), url)
+        ),
+    )
+
+
+def fetch_reject(
+    category: str,
+    *,
+    body: bytes = b"{}",
+    status: int = 200,
+    headers: Optional[dict[str, Any]] = None,
+    result: Optional[BaseException] = None,
+    limit: int = MODULE.MAX_RESPONSE_BYTES,
+) -> bool:
+    item: Any = result if result is not None else Response(body, status=status, headers=headers)
+    return rejects(
+        category,
+        lambda: MODULE.fetch_json(
+            Opener(item),
+            "https://api.github.com/repos/openai/codex/releases/latest",
+            limit=limit,
+        ),
+    )
+
+
+check("non-200 response is unavailable", lambda: fetch_reject("HTTP evidence unavailable", status=500))
+check(
+    "HTTP redirect is rejected",
+    lambda: fetch_reject(
+        "redirect rejected",
+        result=urllib.error.HTTPError("https://api.github.com", 302, "", {}, None),
+    ),
+)
+check(
+    "network error is unavailable",
+    lambda: fetch_reject(
+        "network evidence unavailable", result=urllib.error.URLError("private detail")
+    ),
+)
+check("timeout is unavailable", lambda: fetch_reject("network evidence unavailable", result=TimeoutError()))
+check(
+    "missing content type is rejected",
+    lambda: fetch_reject("invalid response metadata", headers={"Content-Type": []}),
+)
+check(
+    "duplicate content type is rejected",
+    lambda: fetch_reject(
+        "invalid response metadata",
+        headers={"Content-Type": ["application/json", "application/json"]},
+    ),
+)
+check(
+    "non-JSON content type is rejected",
+    lambda: fetch_reject("invalid response metadata", headers={"Content-Type": "text/plain"}),
+)
+check(
+    "unexpected charset is rejected",
+    lambda: fetch_reject(
+        "invalid response metadata", headers={"Content-Type": "application/json; charset=latin1"}
+    ),
+)
+check(
+    "compressed response is rejected",
+    lambda: fetch_reject("invalid response metadata", headers={"Content-Encoding": "gzip"}),
+)
+check(
+    "transfer encoding is rejected",
+    lambda: fetch_reject("invalid response metadata", headers={"Transfer-Encoding": "chunked"}),
+)
+check(
+    "missing content length is rejected",
+    lambda: fetch_reject("invalid response metadata", headers={"Content-Length": []}),
+)
+check(
+    "duplicate content length is rejected",
+    lambda: fetch_reject(
+        "invalid response metadata", headers={"Content-Length": ["2", "2"]}
+    ),
+)
+check(
+    "nonnumeric content length is rejected",
+    lambda: fetch_reject("invalid response metadata", headers={"Content-Length": "two"}),
+)
+check(
+    "zero content length is rejected",
+    lambda: fetch_reject("invalid response metadata", headers={"Content-Length": "0"}),
+)
+check(
+    "declared oversize is rejected before reading",
+    lambda: fetch_reject(
+        "response too large", headers={"Content-Length": "3"}, body=b"{}", limit=2
+    ),
+)
+check(
+    "actual oversize is rejected incrementally",
+    lambda: fetch_reject(
+        "response too large", headers={"Content-Length": "2"}, body=b"{}x", limit=2
+    ),
+)
+check(
+    "short body is rejected",
+    lambda: fetch_reject(
+        "invalid response metadata", headers={"Content-Length": "3"}, body=b"{}"
+    ),
+)
+check("invalid UTF-8 is rejected", lambda: fetch_reject("invalid JSON document", body=b'"\xff"'))
+check("malformed JSON is rejected", lambda: fetch_reject("invalid JSON document", body=b"{"))
+check(
+    "duplicate JSON keys are rejected",
+    lambda: fetch_reject("invalid JSON document", body=b'{"x":1,"x":2}'),
+)
+
+
+release_rejections = [
+    (release("1.1.11", draft=True), "draft"),
+    (release("1.1.11", prerelease=True), "prerelease"),
+    (release("1.1.11-rc.1"), "prerelease tag"),
+    (release("01.1.11"), "leading zero"),
+    ({"tag_name": "1.1.11", "draft": False}, "missing prerelease"),
+    ({"tag_name": 111, "draft": False, "prerelease": False}, "nonstring tag"),
+]
+for value, label in release_rejections:
+    check(
+        f"{label} release evidence is rejected",
+        lambda value=value: rejects(
+            "invalid stable release evidence",
+            lambda: MODULE._release(value, MODULE.POLICIES["agy"]),
+        ),
+    )
+
+
+source_rejections = [
+    (source(ref="refs/heads/dev"), "wrong ref"),
+    (source(kind="tag"), "wrong type"),
+    (source("A" * 40), "uppercase revision"),
+    (source("a" * 39), "short revision"),
+    ({"ref": "refs/heads/main", "object": "bad"}, "nonobject target"),
+]
+for value, label in source_rejections:
+    check(
+        f"{label} source evidence is rejected",
+        lambda value=value: rejects(
+            "invalid source evidence", lambda: MODULE._source_ref(value, "main")
+        ),
+    )
+
+check(
+    "malformed release commit is rejected",
+    lambda: rejects("invalid release commit evidence", lambda: MODULE._commit({"sha": "secret"})),
+)
+check(
+    "unknown tool cannot select an endpoint",
+    lambda: rejects("invalid tool policy", lambda: MODULE.latest_evidence("unknown", opener=Opener())),
+)
+check(
+    "unstable explicit project tag is rejected before request",
+    lambda: rejects(
+        "invalid project release tag",
+        lambda: MODULE.project_release_evidence("v1.2.3-rc.1", opener=Opener()),
+    ),
+)
+check(
+    "invalid CLI invocation is controlled",
+    lambda: MODULE.main([str(MODULE_PATH), "--latest", "unknown"]) == 2,
+)
+
+print(f"OFFICIAL_GITHUB_TEST_RESULT passed={passed} failed={failed}")
+raise SystemExit(1 if failed else 0)

--- a/tests/test-update.sh
+++ b/tests/test-update.sh
@@ -105,6 +105,8 @@ cp -R "$ROOT/skills/agy-worker" "$SOURCE/skills/agy-worker"
 cp -R "$ROOT/compat/." "$SOURCE/compat/"
 cp "$ROOT/scripts/compatibility.py" "$SOURCE/scripts/"
 cp "$ROOT/scripts/official_distribution.py" "$SOURCE/scripts/"
+cp "$ROOT/scripts/official_github.py" "$SOURCE/scripts/"
+cp "$ROOT/scripts/compatibility_probe.py" "$SOURCE/scripts/"
 
 mkdir -p "$UPSTREAM_SOURCE"
 git -C "$UPSTREAM_SOURCE" init -q -b main
@@ -178,7 +180,53 @@ STUB
 cat > "$TMP/bin/python3" <<'STUB'
 #!/usr/bin/env bash
 set -u
+arguments=("$@")
+while [[ "${1:-}" == "-I" || "${1:-}" == "-B" ]]; do shift; done
 case "${1:-}" in
+  */scripts/compatibility_probe.py)
+    probe_script="$1"
+    profile="${2:-}"
+    argument="${3:-}"
+    case "$profile" in
+      agy-version|codex-version)
+        exec "$REAL_PYTHON_REAL" -I -B "$probe_script" "$profile"
+        ;;
+      official-project)
+        case "${FAKE_PROJECT_OFFICIAL_MODE:-unchanged}" in
+          unavailable) exit 2 ;;
+          signal-hup) exit 129 ;;
+          signal-int) exit 130 ;;
+          signal-term) exit 143 ;;
+        esac
+        tag="${FAKE_PROJECT_TAG:-v1.1.0}"
+        revision="$(git --git-dir="$FAKE_PROJECT_REMOTE" rev-parse "refs/tags/$tag^{commit}" 2>/dev/null)" || exit 2
+        printf 'project\t%s\t%s\n' "$tag" "$revision"
+        ;;
+      official-project-release)
+        [[ "$argument" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || exit 2
+        revision="$(git --git-dir="$FAKE_PROJECT_REMOTE" rev-parse "refs/tags/$argument^{commit}" 2>/dev/null)" || exit 2
+        printf 'project\t%s\t%s\n' "$argument" "$revision"
+        ;;
+      official-agy)
+        case "${FAKE_AGY_OFFICIAL_MODE:-unchanged}" in
+          unavailable) exit 2 ;;
+          malformed) printf '%s\n' 'credential-bearing malformed official bytes'; exit 0 ;;
+          drift) printf 'agy\t%s\t%s\n' "${FAKE_AGY_OFFICIAL_VERSION:-1.1.11}" "${FAKE_AGY_OFFICIAL_HEAD:-$FAKE_AGY_HEAD}" ;;
+          *) printf 'agy\t%s\t%s\n' "${FAKE_AGY_OFFICIAL_VERSION:-1.1.10}" "${FAKE_AGY_OFFICIAL_HEAD:-$FAKE_AGY_HEAD}" ;;
+        esac
+        ;;
+      official-codex)
+        case "${FAKE_CODEX_OFFICIAL_MODE:-unchanged}" in
+          unavailable) exit 2 ;;
+          malformed) printf '%s\n' 'credential-bearing malformed official bytes'; exit 0 ;;
+          drift) printf 'codex\t%s\t%s\n' "${FAKE_CODEX_OFFICIAL_VERSION:-0.147.0}" "${FAKE_CODEX_OFFICIAL_HEAD:-$FAKE_CODEX_HEAD}" ;;
+          *) printf 'codex\t%s\t%s\n' "${FAKE_CODEX_OFFICIAL_VERSION:-0.146.0}" "${FAKE_CODEX_OFFICIAL_HEAD:-$FAKE_CODEX_HEAD}" ;;
+        esac
+        ;;
+      *) exit 2 ;;
+    esac
+    exit 0
+    ;;
   */scripts/official_distribution.py)
     if [[ $# -ne 1 ]] || ! "$REAL_PYTHON_REAL" -B -c '
 import importlib.util
@@ -215,10 +263,11 @@ raise SystemExit(0 if module.MANIFEST_URL == expected else 1)
     esac
     ;;
 esac
-exec "$REAL_PYTHON_REAL" "$@"
+exec "$REAL_PYTHON_REAL" "${arguments[@]}"
 STUB
 chmod +x "$SOURCE/"*.sh "$SOURCE/tests/"*.sh "$TMP/bin/agy" "$TMP/bin/codex" \
-    "$TMP/bin/python3" "$SOURCE/scripts/compatibility.py" "$SOURCE/scripts/official_distribution.py"
+    "$TMP/bin/python3" "$SOURCE/scripts/compatibility.py" "$SOURCE/scripts/official_distribution.py" \
+    "$SOURCE/scripts/official_github.py" "$SOURCE/scripts/compatibility_probe.py"
 
 git -C "$SOURCE" init -q -b main
 git -C "$SOURCE" config user.email test@example.com
@@ -240,6 +289,9 @@ git init -q --bare "$REMOTE"
 git -C "$SOURCE" remote add publish "$REMOTE"
 git -C "$SOURCE" push -q publish main --tags
 git --git-dir="$REMOTE" symbolic-ref HEAD refs/heads/main
+export FAKE_PROJECT_REMOTE="$REMOTE"
+export FAKE_AGY_HEAD="$UPSTREAM_HEAD"
+export FAKE_CODEX_HEAD="$CODEX_UPSTREAM_HEAD"
 git init -q --bare "$NO_TAG_REMOTE"
 git -C "$SOURCE" push -q "$NO_TAG_REMOTE" main
 git --git-dir="$NO_TAG_REMOTE" symbolic-ref HEAD refs/heads/main
@@ -316,6 +368,59 @@ if ! grep -Fq 'example.invalid' "$TMP/fixed-policy.out" "$TMP/fixed-policy.err";
 else
     bad "ignored source overrides are never disclosed"
 fi
+
+REAL_GIT="$(command -v git)"
+export REAL_GIT
+NO_REMOTE_GIT_BIN="$TMP/no-remote-git-bin"
+mkdir -p "$NO_REMOTE_GIT_BIN"
+cat > "$NO_REMOTE_GIT_BIN/git" <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "ls-remote" ]]; then
+    : > "$GIT_LS_REMOTE_MARKER"
+    exit 91
+fi
+exec "$REAL_GIT" "$@"
+STUB
+chmod +x "$NO_REMOTE_GIT_BIN/git"
+cat > "$TMP/hostile-global.gitconfig" <<'EOF'
+[url "https://credential.invalid/"]
+    insteadOf = https://github.com/
+[http]
+    proxy = https://credential.invalid/proxy
+[credential]
+    helper = !printf credential-secret
+EOF
+GIT_LS_REMOTE_MARKER="$TMP/ls-remote.marker" \
+GIT_CONFIG_GLOBAL="$TMP/hostile-global.gitconfig" \
+HTTP_PROXY=https://credential.invalid/proxy \
+HTTPS_PROXY=https://credential.invalid/proxy \
+GIT_ASKPASS="$TMP/credential-askpass" \
+PATH="$NO_REMOTE_GIT_BIN:$TMP/bin:$PATH" \
+    "$CLIENT/update.sh" check --watch \
+    > "$TMP/ambient-transport.out" 2> "$TMP/ambient-transport.err"
+rc=$?
+expect_exit "ambient Git rewrite/proxy/credential controls cannot redirect watch evidence" 0 "$rc"
+if [[ ! -e "$TMP/ls-remote.marker" ]] \
+        && ! grep -Eq 'credential\.invalid|credential-secret' \
+            "$TMP/ambient-transport.out" "$TMP/ambient-transport.err"; then
+    ok "watch performs no Git network query and discloses no ambient transport bytes"
+else
+    bad "watch performs no Git network query and discloses no ambient transport bytes"
+fi
+
+for signal_case in hup int term; do
+    case "$signal_case" in
+        hup) expected_signal_rc=129 ;;
+        int) expected_signal_rc=130 ;;
+        term) expected_signal_rc=143 ;;
+    esac
+    PATH="$TMP/bin:$PATH" FAKE_PROJECT_OFFICIAL_MODE="signal-$signal_case" \
+        "$CLIENT/update.sh" check > "$TMP/project-signal-$signal_case.out" \
+        2> "$TMP/project-signal-$signal_case.err"
+    rc=$?
+    expect_exit "project evidence $signal_case signal propagates through update check" \
+        "$expected_signal_rc" "$rc"
+done
 
 set_client_matrix_mode() {
     local mode="$1"
@@ -526,7 +631,7 @@ git -C "$CLIENT" checkout -q -- compat/agy-last-reviewed.txt
 
 git -C "$CODEX_UPSTREAM_SOURCE" tag rust-v0.147.0
 git -C "$CODEX_UPSTREAM_SOURCE" push -q publish rust-v0.147.0
-PATH="$TMP/bin:$PATH" \
+PATH="$TMP/bin:$PATH" FAKE_CODEX_OFFICIAL_MODE=drift \
     "$CLIENT/update.sh" check > "$TMP/codex-stable-drift.out" 2> "$TMP/codex-stable-drift.err"
 rc=$?
 expect_exit "Codex stable release drift requires review" 3 "$rc"
@@ -535,14 +640,14 @@ if grep -Fq 'official 0.147.0; verified 0.146.0' "$TMP/codex-stable-drift.out"; 
 else
     bad "Codex stable release drift is reported separately"
 fi
-PATH="$TMP/bin:$PATH" \
+PATH="$TMP/bin:$PATH" FAKE_CODEX_OFFICIAL_MODE=drift \
     "$CLIENT/update.sh" check --watch > "$TMP/watch-drift.out" 2> "$TMP/watch-drift.err"
 rc=$?
 expect_exit "watch mode preserves drift-review exit semantics" 3 "$rc"
 
 git -C "$UPSTREAM_SOURCE" tag v1.1.11
 git -C "$UPSTREAM_SOURCE" push -q publish v1.1.11
-PATH="$TMP/bin:$PATH" \
+PATH="$TMP/bin:$PATH" FAKE_AGY_OFFICIAL_MODE=drift \
     "$CLIENT/update.sh" check > "$TMP/agy-stable-drift.out" 2> "$TMP/agy-stable-drift.err"
 rc=$?
 expect_exit "agy stable release drift requires review without baseline advance" 3 "$rc"
@@ -551,7 +656,8 @@ printf 'Codex upstream moved\n' >> "$CODEX_UPSTREAM_SOURCE/README.md"
 git -C "$CODEX_UPSTREAM_SOURCE" add README.md
 git -C "$CODEX_UPSTREAM_SOURCE" commit -qm 'Codex upstream drift fixture'
 git -C "$CODEX_UPSTREAM_SOURCE" push -q publish main
-PATH="$TMP/bin:$PATH" \
+CODEX_DRIFT_HEAD="$(git -C "$CODEX_UPSTREAM_SOURCE" rev-parse HEAD)"
+PATH="$TMP/bin:$PATH" FAKE_CODEX_OFFICIAL_HEAD="$CODEX_DRIFT_HEAD" \
     "$CLIENT/update.sh" check > "$TMP/codex-source-drift.out" 2> "$TMP/codex-source-drift.err"
 rc=$?
 expect_exit "Codex source revision drift requires review" 3 "$rc"
@@ -575,33 +681,30 @@ else
 fi
 git -C "$CLIENT" checkout -q -- compat/codex-upstream-head.txt
 
-MISSING_UPSTREAM="$TMP/missing-upstream.git"
-git -C "$CLIENT" config --unset-all "url.$UPSTREAM_REMOTE.insteadOf"
-git -C "$CLIENT" config "url.$MISSING_UPSTREAM.insteadOf" "$OFFICIAL_UPSTREAM_URL"
-PATH="$TMP/bin:$PATH" FAKE_CODEX_VERSION=9.9.9 \
+PATH="$TMP/bin:$PATH" FAKE_AGY_OFFICIAL_MODE=unavailable FAKE_CODEX_VERSION=9.9.9 \
     "$CLIENT/update.sh" check > "$TMP/unavailable-source.out" 2> "$TMP/unavailable-source.err"
 rc=$?
 expect_exit "unavailable official evidence outranks drift" 2 "$rc"
-PATH="$TMP/bin:$PATH" \
+PATH="$TMP/bin:$PATH" FAKE_AGY_OFFICIAL_MODE=unavailable \
     "$CLIENT/update.sh" check --watch > "$TMP/watch-unavailable.out" 2> "$TMP/watch-unavailable.err"
 rc=$?
 expect_exit "watch mode preserves evidence-unavailable exit semantics" 2 "$rc"
-git -C "$CLIENT" config --unset-all "url.$MISSING_UPSTREAM.insteadOf"
-git -C "$CLIENT" config "url.$UPSTREAM_REMOTE.insteadOf" "$OFFICIAL_UPSTREAM_URL"
 
 printf 'upstream moved\n' >> "$UPSTREAM_SOURCE/README.md"
 git -C "$UPSTREAM_SOURCE" add README.md
 git -C "$UPSTREAM_SOURCE" commit -qm 'upstream drift fixture'
 git -C "$UPSTREAM_SOURCE" push -q publish main
-PATH="$TMP/bin:$PATH" \
+AGY_DRIFT_HEAD="$(git -C "$UPSTREAM_SOURCE" rev-parse HEAD)"
+PATH="$TMP/bin:$PATH" FAKE_AGY_OFFICIAL_HEAD="$AGY_DRIFT_HEAD" \
     "$CLIENT/update.sh" check > "$TMP/upstream-drift.out" 2> "$TMP/upstream-drift.err"
 rc=$?
 expect_exit "official upstream HEAD drift requires review" 3 "$rc"
 
-PATH="$TMP/bin:$PATH" CODEX_SKILLS_DIR="$SKILLS" "$NO_TAG_CLIENT/update.sh" apply \
+PATH="$TMP/bin:$PATH" FAKE_PROJECT_OFFICIAL_MODE=unavailable CODEX_SKILLS_DIR="$SKILLS" \
+    "$NO_TAG_CLIENT/update.sh" apply \
     > "$TMP/no-tag.out" 2> "$TMP/no-tag.err"
 rc=$?
-expect_exit "implicit apply reports that no stable release exists" 2 "$rc"
+expect_exit "implicit apply fails closed when official release evidence is unavailable" 2 "$rc"
 
 printf 'dirty\n' > "$DIRTY_CLIENT/dirty.txt"
 PATH="$TMP/bin:$PATH" CODEX_SKILLS_DIR="$SKILLS" \
@@ -962,6 +1065,35 @@ if cmp -s "$TMP/ignored-pyc-before" "$TMP/ignored-pyc-after"; then
     ok "official distribution policy tests create no ignored bytecode"
 else
     bad "official distribution policy tests create no ignored bytecode"
+fi
+
+snapshot_ignored_pyc "$TMP/github-probe-pyc-before"
+OFFICIAL_GITHUB_TEST_OUTPUT="$($REAL_PYTHON_REAL -B "$ROOT/tests/test-official-github.py" 2>&1)"
+official_github_rc=$?
+printf '%s\n' "$OFFICIAL_GITHUB_TEST_OUTPUT"
+OFFICIAL_GITHUB_RESULT="$(printf '%s\n' "$OFFICIAL_GITHUB_TEST_OUTPUT" | tail -1)"
+if [[ "$official_github_rc" == 0 \
+        && "$OFFICIAL_GITHUB_RESULT" == "OFFICIAL_GITHUB_TEST_RESULT passed=56 failed=0" ]]; then
+    pass=$((pass+56))
+else
+    bad "fixed official GitHub transport tests (expected 56 controlled passes)"
+fi
+
+COMPATIBILITY_PROBE_TEST_OUTPUT="$($REAL_PYTHON_REAL -B "$ROOT/tests/test-compatibility-probe.py" 2>&1)"
+compatibility_probe_rc=$?
+printf '%s\n' "$COMPATIBILITY_PROBE_TEST_OUTPUT"
+COMPATIBILITY_PROBE_RESULT="$(printf '%s\n' "$COMPATIBILITY_PROBE_TEST_OUTPUT" | tail -1)"
+if [[ "$compatibility_probe_rc" == 0 \
+        && "$COMPATIBILITY_PROBE_RESULT" == "COMPATIBILITY_PROBE_TEST_RESULT passed=41 failed=0" ]]; then
+    pass=$((pass+41))
+else
+    bad "bounded compatibility probe tests (expected 41 controlled passes)"
+fi
+snapshot_ignored_pyc "$TMP/github-probe-pyc-after"
+if cmp -s "$TMP/github-probe-pyc-before" "$TMP/github-probe-pyc-after"; then
+    ok "official GitHub and probe tests create no ignored bytecode"
+else
+    bad "official GitHub and probe tests create no ignored bytecode"
 fi
 
 WORKFLOW="$ROOT/.github/workflows/compatibility-watch.yml"

--- a/update.sh
+++ b/update.sh
@@ -9,8 +9,6 @@ EXPECTED_HTTPS="https://github.com/cagdasyurekli/codex-agy-worker.git"
 EXPECTED_HTTPS_NO_SUFFIX="https://github.com/cagdasyurekli/codex-agy-worker"
 EXPECTED_SSH="git@github.com:cagdasyurekli/codex-agy-worker.git"
 EXPECTED_SSH_URL="ssh://git@github.com/cagdasyurekli/codex-agy-worker.git"
-OFFICIAL_AGY_UPSTREAM="https://github.com/google-antigravity/antigravity-cli.git"
-OFFICIAL_CODEX_UPSTREAM="https://github.com/openai/codex.git"
 COMPATIBILITY_REVIEW_DAYS=30
 
 usage() {
@@ -57,44 +55,43 @@ if [[ "$command_name" == "apply" && "$origin_available" == 0 ]]; then
 fi
 
 latest_release() {
-    local refs
-    refs="$(git ls-remote --tags --refs "$remote" 'refs/tags/v*' 2>/dev/null)" || {
+    local evidence="" probe_rc=0 tool tag revision extra
+    evidence="$(python3 -I -B "$SCRIPT_DIR/scripts/compatibility_probe.py" \
+        official-project 2>/dev/null)" || probe_rc=$?
+    case "$probe_rc" in
+        0) ;;
+        129|130|143) exit "$probe_rc" ;;
+        *)
         echo "update: could not query release tags from official origin" >&2
         return 2
-    }
-    printf '%s\n' "$refs" | python3 -c '
-import re, sys
-versions = []
-for line in sys.stdin:
-    fields = line.split()
-    if len(fields) != 2:
-        continue
-    tag = fields[1][len("refs/tags/"):]
-    match = re.fullmatch(r"v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)", tag)
-    if match:
-        versions.append((tuple(map(int, match.groups())), tag))
-if versions:
-    print(max(versions)[1])
-'
+            ;;
+    esac
+    IFS=$'\t' read -r tool tag revision extra <<< "$evidence"
+    if [[ "$tool" != "project" || -n "$extra" \
+            || ! "$tag" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ \
+            || ! "$revision" =~ ^[0-9a-f]{40}$ ]]; then
+        echo "update: could not query release tags from official origin" >&2
+        return 2
+    fi
+    printf '%s\n' "$tag"
 }
 
 remote_release_commit() {
-    local tag="$1" refs
-    refs="$(git ls-remote --tags "$remote" "refs/tags/$tag" "refs/tags/$tag^{}" 2>/dev/null)" || {
-        echo "update: could not resolve release tag $tag" >&2; return 2;
-    }
-    printf '%s\n' "$refs" | python3 -c '
-import sys
-rows = [line.split() for line in sys.stdin if line.split()]
-peeled = [oid for oid, ref in rows if ref.endswith("^{}")]
-direct = [oid for oid, ref in rows if not ref.endswith("^{}")]
-if peeled:
-    print(peeled[0])
-elif direct:
-    print(direct[0])
-else:
-    raise SystemExit(1)
-' || { echo "update: release tag not found: $tag" >&2; return 2; }
+    local tag="$1" evidence="" probe_rc=0 tool observed_tag revision extra
+    evidence="$(python3 -I -B "$SCRIPT_DIR/scripts/compatibility_probe.py" \
+        official-project-release "$tag" 2>/dev/null)" || probe_rc=$?
+    case "$probe_rc" in
+        0) ;;
+        129|130|143) exit "$probe_rc" ;;
+        *) echo "update: could not resolve release tag $tag" >&2; return 2 ;;
+    esac
+    IFS=$'\t' read -r tool observed_tag revision extra <<< "$evidence"
+    if [[ "$tool" != "project" || "$observed_tag" != "$tag" || -n "$extra" \
+            || ! "$revision" =~ ^[0-9a-f]{40}$ ]]; then
+        echo "update: release tag not found: $tag" >&2
+        return 2
+    fi
+    printf '%s\n' "$revision"
 }
 
 merge_status() {
@@ -166,18 +163,16 @@ agy_model_matrix_check() {
 }
 
 tool_compatibility_check() {
-    local tool="$1" mode="$2" upstream verified_file reviewed_file revision_file
+    local tool="$1" mode="$2" verified_file reviewed_file revision_file
     local verified_version="" review_date="" reviewed_head="" installed_output="" installed_version=""
-    local latest_stable="" remote_head="" rc=0 step_rc=0
+    local latest_stable="" remote_head="" official_output="" official_tool="" extra="" rc=0 step_rc=0
     case "$tool" in
         agy)
-            upstream="$OFFICIAL_AGY_UPSTREAM"
             verified_file="$SCRIPT_DIR/compat/agy-verified-version.txt"
             reviewed_file="$SCRIPT_DIR/compat/agy-last-reviewed.txt"
             revision_file="$SCRIPT_DIR/compat/agy-upstream-head.txt"
             ;;
         codex)
-            upstream="$OFFICIAL_CODEX_UPSTREAM"
             verified_file="$SCRIPT_DIR/compat/codex-verified-version.txt"
             reviewed_file="$SCRIPT_DIR/compat/codex-last-reviewed.txt"
             revision_file="$SCRIPT_DIR/compat/codex-upstream-head.txt"
@@ -211,15 +206,14 @@ tool_compatibility_check() {
             rc="$(merge_status "$rc" 3)"
         else
             step_rc=0
-            installed_output="$("$tool" --version 2>/dev/null)" || step_rc=$?
+            installed_output="$(python3 -I -B "$SCRIPT_DIR/scripts/compatibility_probe.py" \
+                "${tool}-version" 2>/dev/null)" || step_rc=$?
+            case "$step_rc" in 129|130|143) exit "$step_rc" ;; esac
             if (( step_rc != 0 )); then
                 echo "  installed: evidence-unavailable (--version failed)"
                 rc="$(merge_status "$rc" 2)"
             else
-                installed_version="$(printf '%s\n' "$installed_output" | python3 "$SCRIPT_DIR/scripts/compatibility.py" version-output --tool "$tool" 2>/dev/null)" || {
-                    echo "  installed: evidence-unavailable (version output lacks documented semantic content)"
-                    rc="$(merge_status "$rc" 2)"
-                }
+                installed_version="$installed_output"
                 if [[ -n "$installed_version" && -n "$verified_version" ]]; then
                     if [[ "$installed_version" == "$verified_version" ]]; then
                         echo "  installed: unchanged ($installed_version)"
@@ -245,9 +239,20 @@ tool_compatibility_check() {
     fi
 
     step_rc=0
-    latest_stable="$(git ls-remote --tags --refs "$upstream" 2>/dev/null \
-        | python3 "$SCRIPT_DIR/scripts/compatibility.py" latest-release --tool "$tool" 2>/dev/null)" || step_rc=$?
-    if (( step_rc != 0 )) || [[ -z "$latest_stable" ]]; then
+    official_output="$(python3 -I -B "$SCRIPT_DIR/scripts/compatibility_probe.py" \
+        "official-$tool" 2>/dev/null)" || step_rc=$?
+    case "$step_rc" in 129|130|143) exit "$step_rc" ;; esac
+    if (( step_rc == 0 )); then
+        IFS=$'\t' read -r official_tool latest_stable remote_head extra <<< "$official_output"
+        if [[ "$official_tool" != "$tool" || -n "$extra" \
+                || ! "$latest_stable" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ \
+                || ! "$remote_head" =~ ^[0-9a-f]{40}$ ]]; then
+            step_rc=2
+            latest_stable=""
+            remote_head=""
+        fi
+    fi
+    if (( step_rc != 0 )); then
         echo "  stable release: evidence-unavailable"
         rc="$(merge_status "$rc" 2)"
     elif [[ -n "$verified_version" && "$latest_stable" == "$verified_version" ]]; then
@@ -257,10 +262,7 @@ tool_compatibility_check() {
         rc="$(merge_status "$rc" 3)"
     fi
 
-    step_rc=0
-    remote_head="$(git ls-remote "$upstream" HEAD 2>/dev/null \
-        | python3 "$SCRIPT_DIR/scripts/compatibility.py" source-head 2>/dev/null)" || step_rc=$?
-    if (( step_rc != 0 )) || [[ -z "$remote_head" ]]; then
+    if (( step_rc != 0 )); then
         echo "  source revision: evidence-unavailable"
         rc="$(merge_status "$rc" 2)"
     elif [[ -n "$reviewed_head" && "$remote_head" == "$reviewed_head" ]]; then
@@ -307,6 +309,7 @@ check_updates() {
     fi
     if [[ "$mode" == "local" ]]; then
         latest="$(latest_release)" || release_rc=$?
+        case "$release_rc" in 129|130|143) exit "$release_rc" ;; esac
         if (( release_rc != 0 )); then
             echo "tool update: evidence-unavailable (official release query failed)"
             aggregate="$(merge_status "$aggregate" 2)"
@@ -317,6 +320,7 @@ check_updates() {
                 echo "tool update: no stable release tags are published yet"
             else
                 latest_commit="$(remote_release_commit "$latest")" || release_rc=$?
+                case "$release_rc" in 129|130|143) exit "$release_rc" ;; esac
                 if (( release_rc != 0 )); then
                     echo "tool update: evidence-unavailable (official release tag is inconclusive)"
                     aggregate="$(merge_status "$aggregate" 2)"


### PR DESCRIPTION
## What changed

Harden the evidence transport and subprocess boundary used by read-only compatibility check/watch.

- Remove `git ls-remote` from read-only project, agy, and Codex release/source observations.
- Add a fixed GitHub REST evidence client restricted to exact allowlisted `api.github.com` repository paths.
- Disable ambient proxies, reject redirects before a second request, use default TLS validation, and reject unexpected origin/path/query/fragment/userinfo/port forms.
- Require strict bounded response metadata and JSON: exact success status, accepted JSON content types, identity/no content encoding, no transfer encoding, one valid content length, incremental byte bounds, UTF-8, no duplicate keys, and exact stable-tag/source-revision shapes.
- Add a fixed-profile supervisor for official GitHub evidence and installed `agy --version` / `codex --version` probes.
- Incrementally cap stdout and stderr, enforce hard wall-clock limits, scrub ambient Git/network/pager/Python-startup controls, expose only validated canonical fields, and never surface raw child output.
- Start each probe in a fresh process group and fail closed on timeout, output overflow, start failure, malformed output, or cleanup failure.
- Close process-group and signal races by blocking HUP/INT/TERM around process creation and reap transitions, signalling only the reserved live group, then proving the group absent without signalling a potentially reused PGID.
- Preserve HUP/INT/TERM status and sanitized output while terminating and reaping leader-exited or TERM-ignoring descendants.
- Keep the existing aggregate result precedence unchanged: `2` evidence-unavailable/inconclusive takes precedence over `3` drift-review, which takes precedence over `0` unchanged.
- Update fixed-source documentation, repository flow, roadmap status, lessons learned, public skill maintenance guidance, offline tests, and concise repository instructions.

## Trust boundary and scope

- Affected paths: read-only `update.sh check`, compatibility-watch evidence helpers, installed-version probes, transport/process adversarial tests, source documentation, repository map, roadmap, lessons learned, public skill guidance, and repository instructions.
- Trust boundary affected: provider-independent observation of official project/agy/Codex evidence. Read-only check/watch now makes no Git network query, so ambient Git URL rewrites, credentials, proxy configuration, SSH helpers, and Git config injection are not evidence inputs.
- The production REST helper uses only fixed GitHub API origins and paths and returns validated version/tag/revision fields through the bounded supervisor.
- The weekly/manual watcher remains observational, read-only, macOS-only, and unable to apply, pull, commit, open an issue/PR, or advance metadata.
- agy `1.1.10` remains the active fail-closed reviewed baseline. This slice does not advance version, source revision, review date, distribution manifest, or model/effort matrix records.
- No provider call, model dispatch, authentication probe, routing/recommendation behavior, gate behavior, release action, or new network origin is added.

## Explicit limitation

This hardening covers read-only check/watch observation only. Explicit `update.sh apply` still performs a separately authorized `git fetch` after resolving the expected release commit through the fixed API. That mutating fetch continues to honor ambient Git transport configuration, including URL rewrites, credential helpers, and Git proxy settings; this pull request does not claim to isolate or harden that apply-time transport.

## Verification

Independent verification accepted the committed tree.

- [x] `./tests/test-qa-gate.sh` — 41/41
- [x] `./tests/test-evidence-receipt.sh` — 88/88
- [x] `./tests/test-agy-worker.sh` — 209/209
- [x] `./tests/test-update.sh` — 278/278
- [x] `./tests/test-reporting.sh` — 21/21
- [x] `./tests/test-packaging.sh` — 135/135
- [x] `./tests/test-doctor.sh` — 180/180
- [x] `./tests/test-proof-demo.sh` — 21/21
- [x] Fixed GitHub REST helper adversarial tests — 56/56
- [x] Bounded compatibility-probe supervisor tests — 41/41
- [x] Proxy/redirect/URL-rewrite/credential/Git-config mutation controls
- [x] Response status/header/length/encoding/JSON/schema/oversize rejection controls
- [x] Timeout, stdout/stderr overflow, malformed version, process-group reuse, leader-exited descendant, and HUP/INT/TERM controls
- [x] Read-only `2 > 3 > 0` aggregation and no-write checks
- [x] Bash 3.2 syntax checks
- [x] Python stdlib compile checks with external bytecode isolation
- [x] `git diff --check`
- [x] Human diff review completed
- [x] Independent verifier verdict: ACCEPT
- [x] `agents-md-auditor` pre/post review completed

## Safety and release

- [x] Read-only check/watch does not update compatibility metadata or repository state.
- [x] Evidence-unavailable remains inconclusive rather than green.
- [x] No worker self-report became evidence and `qa-gate.sh` remains the sole gate authority.
- [x] No permission, authentication, privacy, model-selection, recommendation, or path-policy boundary was weakened.
- [x] No runtime dependency beyond Bash 3.2, Python stdlib, and git was added.
- [x] No merge, release, tag, issue submission, provider call, external distribution/search setting change, or baseline advancement is implied by this pull request.
