### PR TITLE
Validate agy model inventories exactly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Keep these counts current when their suites change:
 - Evidence Receipt v1: 88 offline gate-protocol/publication/privacy cases.
 - `agy-worker.sh` / `install.sh` / model selection and recommendation: 209 offline
   fake-agy/routing cases.
-- `update.sh`: 278 offline transport/process/local-remote/matrix/manifest/watch-policy cases.
+- `update.sh`: 310 offline transport/process/inventory/local-remote/matrix/manifest/watch-policy cases.
 - `bug-report.sh`: 21 offline privacy/fake-`gh` cases.
 - Codex package/skill distribution: 135 offline
   manifest/runtime-copy/relocation/landing cases.
@@ -127,6 +127,11 @@ only a passing test has not been shown to catch anything.
   proxies, redirects, oversized/malformed responses, and unexpected archive URLs.
   Never request the archive. The checked-in tuple detects drift but cannot advance a
   baseline, prove source/behavior, or activate model/effort resolution.
+- **An inventory display label is not another model.** Interpret owner-captured
+  `agy models` evidence line by line against the exact reviewed slug allowlist.
+  `gpt-oss` is display text only when its line contains the one exact canonical
+  `gpt-oss-120b-medium` slug. Unknown tokens in the reviewed provider namespaces
+  fail closed; generic slug regex matches cannot advance metadata.
 - **Bug reports are local drafts first.** Never gather prompts, source, envelopes,
   paths, credentials, or raw logs automatically. Submission must show the exact body
   and require the matching SHA-256 confirmation token; send those validated bytes,

--- a/README.md
+++ b/README.md
@@ -592,6 +592,16 @@ watch runs the official-evidence-only mode without installing agy or Codex. It w
 only a bounded Step Summary, preserves the same `0`/`3`/`2` meanings, is not a required
 pull-request check, and cannot advance metadata or open an issue or pull request.
 
+Separately captured `agy models` output can be reconciled offline by the bounded
+semantic parser in `scripts/agy_inventory.py`. It requires exactly one occurrence of
+each of the 11 reviewed canonical slugs on 11 nonblank lines and rejects unknown,
+missing, duplicate, or ambiguous slug-shaped tokens, including unknown entries in
+the reviewed Gemini, Claude, and GPT namespaces. Ordinary display labels remain
+non-authoritative. The `gpt-oss` display alias is
+accepted only on the same line as `gpt-oss-120b-medium`; it never becomes a twelfth
+model. Parsing inventory does not bind an installed version, advance a baseline, or
+activate the matrix.
+
 The human-reviewed agy baseline is `1.1.10` at source revision
 `bfab12dac5bd090015a89cf82e65093d13b567d9`. The fixed official sources, one
 sandbox-correct 11-slug inventory, and two bounded single-selector jobs are recorded
@@ -718,6 +728,7 @@ bug-report.sh                 sanitized local draft/preview/optional submission
 compat/                       per-tool baselines, reviewed evidence, and active exact matrix
 scripts/compatibility.py      stdlib metadata/matrix validation and exact resolution
 scripts/compatibility_probe.py bounded process-group supervisor for fixed evidence/version probes
+scripts/agy_inventory.py      bounded exact-line semantic parser for private inventory evidence
 scripts/official_github.py    fixed, proxyless, redirect-free GitHub REST evidence client
 scripts/official_distribution.py  fixed, bounded agy distribution-manifest canary
 scripts/bug-report.py         privacy filter and SHA-bound gh submission
@@ -735,7 +746,8 @@ CODE_OF_CONDUCT.md            enforceable participation standards
 tests/test-qa-gate.sh         offline adversarial suite
 tests/test-evidence-receipt.sh  88-case offline receipt/publication/protocol suite
 tests/test-agy-worker.sh       offline dispatcher/installer/routing suite
-tests/test-update.sh          278-case offline transport/process/local-remote/matrix/manifest updater suite
+tests/test-update.sh          310-case offline transport/process/inventory/local-remote/matrix/manifest updater suite
+tests/test-agy-inventory.py   test-only exact-slug/display-alias adversary harness
 tests/test-official-github.py test-only fixed-endpoint transport adversary harness
 tests/test-compatibility-probe.py test-only timeout/output/signal/version adversary harness
 tests/test-official-distribution.py  test-only stdlib manifest adversary harness

--- a/compat/sources.md
+++ b/compat/sources.md
@@ -76,3 +76,10 @@ process-boundary hardening needed to evaluate it does not itself advance version
 source, review date, manifest, or matrix records; `1.1.10` continues to fail closed
 on observed drift until the separate inventory/provider evidence is authorized and
 accepted.
+
+Owner-captured inventory bytes are interpreted offline by `scripts/agy_inventory.py`,
+which requires one exact reviewed canonical slug per line and complete one-time
+coverage of all 11 slugs. Unknown tokens in reviewed provider namespaces fail closed.
+Display text is non-authoritative: the `gpt-oss` alias is
+valid only beside `gpt-oss-120b-medium` on that same line. This semantic parse is one
+evidence input, not a version/executable binding or permission to advance metadata.

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -108,7 +108,7 @@ accept a candidate, replace human diff review, or certify correctness or securit
 | `verify-job.sh`, `skills/agy-worker/runtime/verify-job.sh`, `skills/agy-worker/runtime/scripts/evidence_receipt.py`, `skills/agy-worker/runtime/schemas/evidence-receipt.schema.json` | Root compatibility entry plus exact input hashing, strict selection/advisory binding, startup-isolated parent-exclusive gate evidence, interruption cleanup, unsigned receipt validation, and private durable no-overwrite publication | `tests/test-evidence-receipt.sh` (88 cases) |
 | `proof-demo.sh`, `demo/fixtures/` | Repository-only offline starter proof using two canonical synthetic envelopes and isolated temporary repositories | `tests/test-proof-demo.sh` (21 cases) |
 | `skills/agy-worker/runtime/agents/*.md` | Prompt-injected bounded personas; prompt text is guidance, not enforcement | dispatcher suite plus bounded real exercises |
-| `update.sh`, `scripts/compatibility.py`, `scripts/compatibility_probe.py`, `scripts/official_github.py`, `scripts/official_distribution.py`, `compat/` | Explicit project releases; exact fixed-REST agy/Codex observation; bounded process-group/version probes; sanitized reconciliation records; bounded distribution-manifest canary; strict per-tool metadata and active-only-when-bound model/effort matrix. Explicit apply-time Git fetch remains ambient-configuration-aware. | `tests/test-update.sh` (278 cases, including fixed transport, supervisor, and manifest adversary harnesses) |
+| `update.sh`, `scripts/compatibility.py`, `scripts/compatibility_probe.py`, `scripts/agy_inventory.py`, `scripts/official_github.py`, `scripts/official_distribution.py`, `compat/` | Explicit project releases; exact fixed-REST agy/Codex observation; bounded process-group/version probes; exact-line allowlisted agy inventory interpretation with reserved provider namespaces; sanitized reconciliation records; bounded distribution-manifest canary; strict per-tool metadata and active-only-when-bound model/effort matrix. Explicit apply-time Git fetch remains ambient-configuration-aware. | `tests/test-update.sh` (310 cases, including fixed transport, supervisor, inventory, and manifest adversary harnesses) |
 | `bug-report.sh`, `scripts/bug-report.py`, `.github/ISSUE_TEMPLATE/` | Local privacy filtering, exact review binding, optional issue submission | `tests/test-reporting.sh` (21 cases) |
 | `.codex-plugin/plugin.json` | Codex skills-only package identity retained for local validation; not a public listing | `tests/test-packaging.sh` (135 cases) plus platform validators |
 | `PRIVACY.md`, `TERMS.md`, `SUPPORT.md` | Public data disclosure, project policy, and support route | `tests/test-packaging.sh` (135 cases) plus review |
@@ -153,6 +153,10 @@ accept a candidate, replace human diff review, or certify correctness or securit
   owns the exact API repository/path policy and response validation;
   `scripts/compatibility_probe.py` owns process, time, byte, environment, and signal
   bounds. These guarantees do not extend to the explicit `update.sh apply` Git fetch.
+- `scripts/agy_inventory.py` interprets a separately owner-captured inventory only
+  through 11 exact canonical line entries. Display aliases and generic regex matches
+  are not inventory authority; unknown reviewed-provider tokens fail closed. Parsing
+  cannot activate or advance compatibility metadata.
 - The fixed agy distribution manifest is a drift canary, not executable or source
   evidence. Its validated archive tuple is never requested, opened, hashed, or run;
   the observational snapshot detects same-version build/hash changes but cannot

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -143,6 +143,15 @@ version, revision, review date, manifest, or matrix record is advanced; `1.1.10`
 remains the active fail-closed baseline until separately authorized inventory and
 provider evidence is accepted.
 
+The provider-independent inventory parser is also implemented offline. It treats
+each line as one semantic inventory entry, requires complete one-time coverage of the
+11 exact reviewed slugs, and rejects unknown reviewed-provider tokens,
+generic-regex aliases, or prefix matches. In
+particular, `gpt-oss` is accepted only as display text on the same line as
+`gpt-oss-120b-medium`. Synthetic tests pin the corrected canonical-slug hash without
+checking provider output into the repository. This does not close the missing
+installed-version/executable evidence binding or advance any `1.1.11` record.
+
 - **User job:** Learn that Codex or agy has drifted before a normal dispatch breaks,
   while keeping every check read-only and requiring a human to reconcile behavior.
 - **Intended surface:** Extend the fixed-source compatibility contract in `update.sh`,

--- a/docs/lessons_learned.md
+++ b/docs/lessons_learned.md
@@ -57,6 +57,15 @@ usage is not semantic evidence. The weekly watcher observes the same fixed sourc
 it never updates a baseline, installs a tool, dispatches a model, or takes a GitHub
 write action. A bounded real job remains separately approved when behavior changed.
 
+Model-list display text can look like an additional slug. A generic slug regex turned
+the `gpt-oss` label beside `gpt-oss-120b-medium` into a false twelfth entry. Parse a
+bounded inventory one line at a time, recognize only whole exact reviewed slugs,
+require every expected slug exactly once, and permit a display alias only beside its
+bound canonical slug. Reserve the reviewed provider namespaces so even a one-hyphen
+unknown such as `gemini-unknown` fails closed without treating every ordinary display
+label as a model. Keep prefix/longest-match and namespace-removal mutations in paired
+offline controls; inventory parsing alone is not a version binding.
+
 An official installer channel can move before a public release/source repository.
 Observe that difference through one fixed, bounded manifest canary, but do not turn a
 distribution version or checksum into source or behavior evidence. Disable proxies,

--- a/scripts/agy_inventory.py
+++ b/scripts/agy_inventory.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Parse bounded, owner-captured ``agy models`` inventory evidence.
+
+This module is deliberately offline.  It recognizes only the reviewed canonical
+slugs below; display text is never promoted into model-selection metadata.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from typing import Iterable, Tuple
+
+
+MAX_INVENTORY_BYTES = 64 * 1024
+EXPECTED_SLUGS: Tuple[str, ...] = (
+    "gemini-3.6-flash-low",
+    "gemini-3.6-flash-medium",
+    "gemini-3.6-flash-high",
+    "gemini-3.5-flash-low",
+    "gemini-3.5-flash-medium",
+    "gemini-3.5-flash-high",
+    "gemini-3.1-pro-low",
+    "gemini-3.1-pro-high",
+    "claude-sonnet-4-6",
+    "claude-opus-4-6-thinking",
+    "gpt-oss-120b-medium",
+)
+DISPLAY_ALIASES = {"gpt-oss": "gpt-oss-120b-medium"}
+RESERVED_MODEL_NAMESPACES = ("gemini", "claude", "gpt")
+TOKEN_RE = re.compile(
+    r"(?<![A-Za-z0-9._-])([a-z0-9][a-z0-9._-]*[a-z0-9])"
+    r"(?![A-Za-z0-9._-])"
+)
+
+
+class InventoryEvidenceError(ValueError):
+    """The inventory cannot be interpreted without ambiguity."""
+
+
+@dataclass(frozen=True)
+class InventoryEvidence:
+    """Sanitized semantic fields derived from one complete inventory."""
+
+    slugs: Tuple[str, ...]
+    normalized_sha256: str
+    line_count: int
+
+
+def _error() -> InventoryEvidenceError:
+    return InventoryEvidenceError("invalid agy inventory evidence")
+
+
+def _tokens(line: str) -> Tuple[str, ...]:
+    return tuple(match.group(1) for match in TOKEN_RE.finditer(line))
+
+
+def _canonical_for_line(line: str) -> str:
+    tokens = _tokens(line)
+    slug_candidates = tuple(
+        token
+        for token in tokens
+        if token not in DISPLAY_ALIASES
+        and (
+            token.count("-") >= 2
+            or token.partition("-")[0] in RESERVED_MODEL_NAMESPACES
+        )
+    )
+    canonical = tuple(token for token in slug_candidates if token in EXPECTED_SLUGS)
+    unknown = tuple(token for token in slug_candidates if token not in EXPECTED_SLUGS)
+    if unknown or len(canonical) != 1:
+        raise _error()
+
+    selected = canonical[0]
+    if slug_candidates.count(selected) != 1:
+        raise _error()
+
+    for alias, target in DISPLAY_ALIASES.items():
+        alias_count = tokens.count(alias)
+        if alias_count and (alias_count != 1 or selected != target):
+            raise _error()
+    return selected
+
+
+def _normalized_bytes(slugs: Iterable[str]) -> bytes:
+    return "".join(f"{slug}\n" for slug in sorted(slugs)).encode("ascii")
+
+
+def parse_inventory_bytes(raw: bytes) -> InventoryEvidence:
+    """Return sanitized semantics for one complete bounded inventory document."""
+    if not isinstance(raw, bytes) or not raw or len(raw) > MAX_INVENTORY_BYTES:
+        raise _error()
+    try:
+        text = raw.decode("utf-8", errors="strict")
+    except UnicodeDecodeError:
+        raise _error() from None
+    if not text.endswith("\n") or "\r" in text:
+        raise _error()
+    if any(
+        (ord(character) < 0x20 and character not in ("\t", "\n"))
+        or ord(character) == 0x7F
+        for character in text
+    ):
+        raise _error()
+
+    lines = text[:-1].split("\n")
+    if len(lines) != len(EXPECTED_SLUGS) or any(not line.strip() for line in lines):
+        raise _error()
+
+    observed = tuple(_canonical_for_line(line) for line in lines)
+    if len(set(observed)) != len(observed) or set(observed) != set(EXPECTED_SLUGS):
+        raise _error()
+
+    normalized = _normalized_bytes(observed)
+    return InventoryEvidence(
+        slugs=tuple(sorted(observed)),
+        normalized_sha256=hashlib.sha256(normalized).hexdigest(),
+        line_count=len(lines),
+    )

--- a/tests/test-agy-inventory.py
+++ b/tests/test-agy-inventory.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Offline adversarial tests for semantic ``agy models`` inventory parsing."""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+from typing import Callable
+
+sys.dont_write_bytecode = True
+
+ROOT = Path(__file__).resolve().parent.parent
+MODULE_PATH = ROOT / "scripts" / "agy_inventory.py"
+SPEC = importlib.util.spec_from_file_location("agy_inventory", MODULE_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise SystemExit("cannot load agy inventory module")
+inventory = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = inventory
+SPEC.loader.exec_module(inventory)
+
+EXPECTED_HASH = "8d46bcac6b8f27995635d91dc6f5a0e549d351e707efe11a82d8b6593fe12daf"
+
+
+def fixture_lines() -> list[str]:
+    lines = [f"available model\t{slug}" for slug in inventory.EXPECTED_SLUGS]
+    index = inventory.EXPECTED_SLUGS.index("gpt-oss-120b-medium")
+    lines[index] = "gpt-oss display\tgpt-oss-120b-medium"
+    return lines
+
+
+def encode(lines: list[str]) -> bytes:
+    return ("\n".join(lines) + "\n").encode("utf-8")
+
+
+def replace_line(lines: list[str], needle: str, replacement: str) -> list[str]:
+    result = list(lines)
+    index = next(i for i, line in enumerate(result) if needle in line)
+    result[index] = replacement
+    return result
+
+
+def expect_error(raw: bytes) -> None:
+    try:
+        inventory.parse_inventory_bytes(raw)
+    except inventory.InventoryEvidenceError as exc:
+        assert str(exc) == "invalid agy inventory evidence"
+        return
+    raise AssertionError("expected controlled inventory rejection")
+
+
+TESTS: list[tuple[str, Callable[[], None]]] = []
+
+
+def test(name: str) -> Callable[[Callable[[], None]], Callable[[], None]]:
+    def register(callback: Callable[[], None]) -> Callable[[], None]:
+        TESTS.append((name, callback))
+        return callback
+
+    return register
+
+
+@test("reviewed canonical inventory and colocated display alias are accepted")
+def _() -> None:
+    result = inventory.parse_inventory_bytes(encode(fixture_lines()))
+    assert result.slugs == tuple(sorted(inventory.EXPECTED_SLUGS))
+    assert result.line_count == 11
+
+
+@test("corrected canonical normalized hash is pinned")
+def _() -> None:
+    result = inventory.parse_inventory_bytes(encode(fixture_lines()))
+    assert result.normalized_sha256 == EXPECTED_HASH
+
+
+@test("inventory ordering does not change canonical hash")
+def _() -> None:
+    result = inventory.parse_inventory_bytes(encode(list(reversed(fixture_lines()))))
+    assert result.normalized_sha256 == EXPECTED_HASH
+
+
+@test("standalone display alias line is rejected")
+def _() -> None:
+    expect_error(encode(fixture_lines() + ["gpt-oss"]))
+
+
+@test("display alias without its canonical slug is rejected")
+def _() -> None:
+    lines = replace_line(fixture_lines(), "gpt-oss-120b-medium", "gpt-oss display")
+    expect_error(encode(lines))
+
+
+@test("display alias beside a different canonical slug is rejected")
+def _() -> None:
+    lines = replace_line(
+        fixture_lines(),
+        "gemini-3.6-flash-low",
+        "gpt-oss display\tgemini-3.6-flash-low",
+    )
+    expect_error(encode(lines))
+
+
+@test("repeated display alias is rejected")
+def _() -> None:
+    lines = replace_line(
+        fixture_lines(),
+        "gpt-oss-120b-medium",
+        "gpt-oss gpt-oss\tgpt-oss-120b-medium",
+    )
+    expect_error(encode(lines))
+
+
+@test("missing canonical line is rejected")
+def _() -> None:
+    expect_error(encode(fixture_lines()[:-1]))
+
+
+@test("duplicate canonical line is rejected")
+def _() -> None:
+    lines = fixture_lines()
+    lines[-1] = lines[0]
+    expect_error(encode(lines))
+
+
+@test("extra line is rejected")
+def _() -> None:
+    expect_error(encode(fixture_lines() + ["safe display only"]))
+
+
+@test("two canonical slugs on one line are rejected")
+def _() -> None:
+    lines = replace_line(
+        fixture_lines(),
+        "gemini-3.6-flash-low",
+        "gemini-3.6-flash-low gemini-3.6-flash-medium",
+    )
+    expect_error(encode(lines))
+
+
+@test("same canonical slug twice on one line is rejected")
+def _() -> None:
+    lines = replace_line(
+        fixture_lines(),
+        "gemini-3.6-flash-low",
+        "gemini-3.6-flash-low gemini-3.6-flash-low",
+    )
+    expect_error(encode(lines))
+
+
+@test("unknown slug-shaped token beside a canonical slug is rejected")
+def _() -> None:
+    lines = replace_line(
+        fixture_lines(),
+        "gemini-3.6-flash-low",
+        "gemini-9.9-unknown gemini-3.6-flash-low",
+    )
+    expect_error(encode(lines))
+
+
+@test("ordinary one-hyphen display label is accepted")
+def _() -> None:
+    lines = replace_line(
+        fixture_lines(),
+        "gemini-3.6-flash-low",
+        "vendor-label display\tgemini-3.6-flash-low",
+    )
+    result = inventory.parse_inventory_bytes(encode(lines))
+    assert result.normalized_sha256 == EXPECTED_HASH
+
+
+@test("nearby non-provider namespace is not overclassified")
+def _() -> None:
+    lines = replace_line(
+        fixture_lines(),
+        "gemini-3.6-flash-low",
+        "geminix-unknown display\tgemini-3.6-flash-low",
+    )
+    result = inventory.parse_inventory_bytes(encode(lines))
+    assert result.normalized_sha256 == EXPECTED_HASH
+
+
+@test("unknown one-hyphen Gemini model token is rejected")
+def _() -> None:
+    lines = replace_line(
+        fixture_lines(),
+        "gemini-3.6-flash-low",
+        "gemini-unknown gemini-3.6-flash-low",
+    )
+    expect_error(encode(lines))
+
+
+@test("unknown one-hyphen Claude model token is rejected")
+def _() -> None:
+    lines = replace_line(
+        fixture_lines(),
+        "claude-sonnet-4-6",
+        "claude-unknown claude-sonnet-4-6",
+    )
+    expect_error(encode(lines))
+
+
+@test("unknown one-hyphen GPT model token is rejected")
+def _() -> None:
+    lines = replace_line(
+        fixture_lines(),
+        "gpt-oss-120b-medium",
+        "gpt-unknown gpt-oss display\tgpt-oss-120b-medium",
+    )
+    expect_error(encode(lines))
+
+
+@test("reserved-namespace mutation reintroduces one-hyphen ambiguity")
+def _() -> None:
+    lines = replace_line(
+        fixture_lines(),
+        "gemini-3.6-flash-low",
+        "gemini-unknown gemini-3.6-flash-low",
+    )
+    expect_error(encode(lines))
+    original = inventory.RESERVED_MODEL_NAMESPACES
+    try:
+        inventory.RESERVED_MODEL_NAMESPACES = ()
+        result = inventory.parse_inventory_bytes(encode(lines))
+    finally:
+        inventory.RESERVED_MODEL_NAMESPACES = original
+    assert result.normalized_sha256 == EXPECTED_HASH
+
+
+@test("unknown slug-shaped extra line is rejected")
+def _() -> None:
+    lines = fixture_lines()
+    lines[-1] = "vendor-next-model-high"
+    expect_error(encode(lines))
+
+
+@test("canonical prefix extended into a longer token is rejected")
+def _() -> None:
+    lines = replace_line(
+        fixture_lines(),
+        "gemini-3.6-flash-low",
+        "gemini-3.6-flash-low-preview",
+    )
+    expect_error(encode(lines))
+
+
+@test("exact token matching catches the naive longest-prefix mutation")
+def _() -> None:
+    mutated = "gemini-3.6-flash-low-preview"
+    lines = replace_line(fixture_lines(), "gemini-3.6-flash-low", mutated)
+    expect_error(encode(lines))
+    alternatives = "|".join(
+        re.escape(slug)
+        for slug in sorted(inventory.EXPECTED_SLUGS, key=len, reverse=True)
+    )
+    prefix_only = re.compile(
+        rf"(?<![A-Za-z0-9._-])({alternatives})"
+    )
+    original = inventory.TOKEN_RE
+    try:
+        inventory.TOKEN_RE = prefix_only
+        result = inventory.parse_inventory_bytes(encode(lines))
+    finally:
+        inventory.TOKEN_RE = original
+    assert result.normalized_sha256 == EXPECTED_HASH
+
+
+@test("malformed UTF-8 is rejected")
+def _() -> None:
+    expect_error(encode(fixture_lines())[:-1] + b"\xff\n")
+
+
+@test("NUL control byte is rejected")
+def _() -> None:
+    expect_error(encode(fixture_lines()).replace(b"available", b"available\x00", 1))
+
+
+@test("DEL control byte is rejected")
+def _() -> None:
+    expect_error(encode(fixture_lines()).replace(b"available", b"available\x7f", 1))
+
+
+@test("CRLF evidence is rejected")
+def _() -> None:
+    expect_error(encode(fixture_lines()).replace(b"\n", b"\r\n"))
+
+
+@test("missing final newline is rejected")
+def _() -> None:
+    expect_error(encode(fixture_lines())[:-1])
+
+
+@test("blank line is rejected")
+def _() -> None:
+    lines = fixture_lines()
+    lines[0] = ""
+    expect_error(encode(lines))
+
+
+@test("empty evidence is rejected")
+def _() -> None:
+    expect_error(b"")
+
+
+@test("evidence exactly at byte limit is accepted")
+def _() -> None:
+    raw = encode(fixture_lines())
+    padding = inventory.MAX_INVENTORY_BYTES - len(raw)
+    lines = fixture_lines()
+    lines[0] = (" " * padding) + lines[0]
+    assert len(encode(lines)) == inventory.MAX_INVENTORY_BYTES
+    inventory.parse_inventory_bytes(encode(lines))
+
+
+@test("evidence over byte limit is rejected")
+def _() -> None:
+    raw = encode(fixture_lines())
+    padding = inventory.MAX_INVENTORY_BYTES + 1 - len(raw)
+    lines = fixture_lines()
+    lines[0] = (" " * padding) + lines[0]
+    expect_error(encode(lines))
+
+
+@test("non-bytes input fails closed")
+def _() -> None:
+    expect_error("not bytes")  # type: ignore[arg-type]
+
+
+passed = 0
+failed = 0
+for name, callback in TESTS:
+    try:
+        callback()
+    except Exception as exc:
+        failed += 1
+        print(f"FAIL {name}: {exc}")
+    else:
+        passed += 1
+        print(f"ok   {name}")
+
+print(f"AGY_INVENTORY_TEST_RESULT passed={passed} failed={failed}")
+raise SystemExit(1 if failed else 0)

--- a/tests/test-update.sh
+++ b/tests/test-update.sh
@@ -107,6 +107,7 @@ cp "$ROOT/scripts/compatibility.py" "$SOURCE/scripts/"
 cp "$ROOT/scripts/official_distribution.py" "$SOURCE/scripts/"
 cp "$ROOT/scripts/official_github.py" "$SOURCE/scripts/"
 cp "$ROOT/scripts/compatibility_probe.py" "$SOURCE/scripts/"
+cp "$ROOT/scripts/agy_inventory.py" "$SOURCE/scripts/"
 
 mkdir -p "$UPSTREAM_SOURCE"
 git -C "$UPSTREAM_SOURCE" init -q -b main
@@ -267,7 +268,8 @@ exec "$REAL_PYTHON_REAL" "${arguments[@]}"
 STUB
 chmod +x "$SOURCE/"*.sh "$SOURCE/tests/"*.sh "$TMP/bin/agy" "$TMP/bin/codex" \
     "$TMP/bin/python3" "$SOURCE/scripts/compatibility.py" "$SOURCE/scripts/official_distribution.py" \
-    "$SOURCE/scripts/official_github.py" "$SOURCE/scripts/compatibility_probe.py"
+    "$SOURCE/scripts/official_github.py" "$SOURCE/scripts/compatibility_probe.py" \
+    "$SOURCE/scripts/agy_inventory.py"
 
 git -C "$SOURCE" init -q -b main
 git -C "$SOURCE" config user.email test@example.com
@@ -1089,11 +1091,22 @@ if [[ "$compatibility_probe_rc" == 0 \
 else
     bad "bounded compatibility probe tests (expected 41 controlled passes)"
 fi
+
+AGY_INVENTORY_TEST_OUTPUT="$($REAL_PYTHON_REAL -B "$ROOT/tests/test-agy-inventory.py" 2>&1)"
+agy_inventory_rc=$?
+printf '%s\n' "$AGY_INVENTORY_TEST_OUTPUT"
+AGY_INVENTORY_RESULT="$(printf '%s\n' "$AGY_INVENTORY_TEST_OUTPUT" | tail -1)"
+if [[ "$agy_inventory_rc" == 0 \
+        && "$AGY_INVENTORY_RESULT" == "AGY_INVENTORY_TEST_RESULT passed=32 failed=0" ]]; then
+    pass=$((pass+32))
+else
+    bad "agy inventory semantic parser tests (expected 32 controlled passes)"
+fi
 snapshot_ignored_pyc "$TMP/github-probe-pyc-after"
 if cmp -s "$TMP/github-probe-pyc-before" "$TMP/github-probe-pyc-after"; then
-    ok "official GitHub and probe tests create no ignored bytecode"
+    ok "official GitHub, probe, and inventory tests create no ignored bytecode"
 else
-    bad "official GitHub and probe tests create no ignored bytecode"
+    bad "official GitHub, probe, and inventory tests create no ignored bytecode"
 fi
 
 WORKFLOW="$ROOT/.github/workflows/compatibility-watch.yml"


### PR DESCRIPTION
## What changed

Add a bounded, provider-independent semantic parser for separately owner-captured `agy models` inventory evidence.

- Add `scripts/agy_inventory.py` as the sole semantic authority for interpreting a complete captured inventory document.
- Accept only strict UTF-8 input within 64 KiB, with a final LF, no CR, no prohibited control characters, and exactly 11 nonblank lines.
- Require exactly one reviewed canonical slug on each line and complete one-time coverage of all 11 reviewed slugs.
- Reject missing, duplicate, extra, ambiguous, extended-prefix, multi-slug, malformed, or unknown slug-shaped entries.
- Reserve the Gemini, Claude, and GPT namespaces so unknown one-hyphen provider tokens fail closed instead of being dismissed as display text.
- Treat ordinary display labels as non-authoritative. The `gpt-oss` display alias is valid only once, on the same line as the exact canonical `gpt-oss-120b-medium` slug; it never becomes a twelfth model.
- Return only sanitized semantics: the sorted canonical slug tuple, deterministic normalized SHA-256, and line count.
- Add 32 focused offline accept/reject and mutation tests covering alias placement, namespace removal, exact-token/longest-prefix behavior, encoding/control/size/line-shape failures, duplicate/missing/unknown models, and deterministic normalization.
- Integrate the focused parser suite into the offline updater harness and update source ownership, repository flow, roadmap status, lessons learned, README, and concise repository guidance.

## Trust boundary and scope

- The parser interprets only separately captured bytes. It does not capture inventory, invoke `agy`, access a provider or network, inspect authentication, or read private configuration.
- The exact reviewed slug allowlist is authority; generic regex matches, display aliases, model-name guesses, and provider namespace lookalikes are not.
- The parser is one bounded evidence input only. It does not bind an installed executable or version, prove provider/backend identity, quality, cost, or behavior, or authorize metadata changes.
- `qa-gate.sh` remains the sole candidate acceptance authority. Model recommendations remain advisory-only, and direct model/effort selection behavior is unchanged.
- No raw inventory or provider evidence is committed or included in this pull request.

## Compatibility status

- All canonical compatibility metadata remains byte-identical to `main`.
- agy `1.1.10` remains the active, fail-closed reviewed baseline.
- agy `1.1.11` remains unreconciled: this slice does not change its version, source revision, review date, distribution manifest, model/effort matrix, matrix hash, or activation state.
- Advancing to `1.1.11` still requires separately authorized official-source reconciliation plus accepted inventory and bounded provider evidence.

## Verification

Independent verification accepted the committed tree.

- [x] Inventory parser focused suite — 32/32
- [x] `./tests/test-qa-gate.sh` — 41/41
- [x] `./tests/test-evidence-receipt.sh` — 88/88
- [x] `./tests/test-agy-worker.sh` — 209/209
- [x] `./tests/test-update.sh` — 310/310
- [x] `./tests/test-reporting.sh` — 21/21
- [x] `./tests/test-packaging.sh` — 135/135
- [x] `./tests/test-doctor.sh` — 180/180
- [x] `./tests/test-proof-demo.sh` — 21/21
- [x] Exact allowlist, full-set, one-line/one-slug, namespace, alias, normalization, and mutation coverage
- [x] Canonical compatibility metadata byte-identity checks
- [x] Bash 3.2 syntax checks
- [x] Python stdlib compile checks with external bytecode isolation
- [x] `git diff --check`
- [x] Human diff review completed
- [x] Independent verifier verdict: ACCEPT
- [x] `agents-md-auditor` pre/post review completed

## Safety and release

- [x] No provider call, network request, inventory capture, raw evidence publication, or external action occurred.
- [x] No compatibility baseline, matrix, manifest, routing, selection, recommendation, gate, or dispatch behavior changed.
- [x] Unknown reviewed-provider tokens fail closed and cannot silently advance metadata.
- [x] No runtime dependency beyond Python stdlib was added.
- [x] No merge, release, tag, issue submission, external distribution/search setting change, or `1.1.11` activation is implied by this pull request.
