### PR TITLE
Add safe local job lifecycle

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,7 @@
 - [ ] `./tests/test-qa-gate.sh`
 - [ ] `./tests/test-evidence-receipt.sh`
 - [ ] `./tests/test-evidence-report.sh`
+- [ ] `/usr/bin/python3 -I -S -B tests/test-job-lifecycle.py`
 - [ ] `./tests/test-agy-worker.sh`
 - [ ] `./tests/test-update.sh`
 - [ ] `/usr/bin/python3 -I -S -B tests/test-version-attestation-runner.py`

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Evidence Report suite
         run: ./tests/test-evidence-report.sh
 
+      - name: local job lifecycle suite
+        run: /usr/bin/python3 -I -S -B tests/test-job-lifecycle.py
+
       - name: dispatcher suite
         run: ./tests/test-agy-worker.sh
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ Keep these counts current when their suites change:
 - `qa-gate.sh`: 41 offline cases.
 - Evidence Receipt v1: 88 offline gate-protocol/publication/privacy cases.
 - Evidence Report v1: 60 offline pure-rendering/privacy/binding/mutation cases.
+- Safe local lifecycle: 94 offline state/receipt/Git-policy/cleanup/signal cases.
 - `agy-worker.sh` / `install.sh` / model selection and recommendation: 209 offline
   fake-agy/routing cases.
 - `update.sh`: 310 offline transport/process/inventory/local-remote/matrix/manifest/watch-policy cases.
@@ -45,9 +46,9 @@ Keep these counts current when their suites change:
 - Canonical models-inventory attestation runner: 78 offline
   fixed-profile/version-binding/parser/process cases.
 - `bug-report.sh`: 21 offline privacy/fake-`gh` cases.
-- Codex package/skill distribution and CI policy: 187 offline
+- Codex package/skill distribution and CI policy: 212 offline
   manifest/runtime-copy/relocation/landing/range cases.
-- `doctor.sh`: 180 offline fake-tool/read-only cases.
+- `doctor.sh`: 184 offline fake-tool/read-only cases.
 - `proof-demo.sh`: 21 offline synthetic-boundary cases.
 
 Real runs prove one bounded edit, the complete `codex exec` pipeline, the combined
@@ -67,6 +68,7 @@ coverage is offline, partial, or absent as described in `README.md`.
 ./tests/test-qa-gate.sh        # offline, no agy, no network — must stay that way
 ./tests/test-evidence-receipt.sh # offline receipt/protocol/publication coverage
 ./tests/test-evidence-report.sh # offline pure receipt renderer/privacy coverage
+/usr/bin/python3 -I -S -B tests/test-job-lifecycle.py # offline disposable Git lifecycle
 ./tests/test-agy-worker.sh      # offline fake-agy dispatcher/installer coverage
 ./tests/test-update.sh          # offline local Git remotes; no public fetch
 /usr/bin/python3 -I -S -B tests/test-version-attestation-runner.py # offline canonical runner path
@@ -125,6 +127,19 @@ only a passing test has not been shown to catch anything.
   cannot change rejected/routed outcomes or turn `gate-passed` into acceptance.
   Receipt-only selection and recommendation validation stays side-effect-free; only
   explicit pre-gate publication input may run canonical recommendation coherence.
+- **Lifecycle cleanup spends fresh explicit authority.** State stays in an external
+  owner-private file and binds the exact repo/worktree/ref/base/job/Receipt/candidate.
+  Only rejected exits 10-14 may clean. Reconcile each completed Git step durably,
+  stop when reconciliation changes the state SHA, and require fresh job/state/candidate
+  approvals before the next destructive step. Remove the exact registered worktree,
+  then compare-delete only the unchanged ref; never force-delete a branch, follow a
+  symlink target, clean routed/passed work, or infer approval from old state.
+  Accept only an exact canonical branch name, and run every lifecycle-owned Git
+  command through the fixed sanitized Git policy. Checkout initialization disables
+  hooks and ambient config/helpers and rejects configured fsmonitor, pager, include,
+  or content-filter authority plus every effective base-tree/info filter attribute.
+  Treat only documented `show-ref --verify --quiet` exit 1 as ref absence; fatal Git
+  evidence must leave cleanup in progress for manual recovery.
 - **`update.sh check` may need network, but must remain read-only.** Compatibility
   evidence for agy and Codex is reported as unchanged, drift-review, or
   evidence-unavailable; inconclusive evidence is never green. Metadata changes only

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@ Run the offline suites and static checks before requesting review:
 ./tests/test-qa-gate.sh
 ./tests/test-evidence-receipt.sh
 ./tests/test-evidence-report.sh
+/usr/bin/python3 -I -S -B tests/test-job-lifecycle.py
 ./tests/test-agy-worker.sh
 ./tests/test-update.sh
 /usr/bin/python3 -I -S -B tests/test-version-attestation-runner.py

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -62,6 +62,28 @@ and human-review statements. It excludes source, diffs, prompts, worker prose, r
 commands or output, logs, credentials, and absolute repository paths. The report is
 still unsigned and cannot authenticate a rewritten receipt.
 
+`job.sh` stores one explicitly named mode-`0600` lifecycle state file in an
+owner-private external directory. It contains canonical absolute repository,
+worktree, Git-common-directory, and receipt paths; filesystem identities; the exact
+branch, immutable base, and job ID; state-history, receipt, and candidate SHA-256
+bindings; gate exit/verdict; and cleanup progress. `status` emits only bounded state,
+match, and hash facts. `preserve-instructions` prints local Git commands and paths
+only when explicitly requested; it executes none. The lifecycle performs no network,
+provider, dispatch, commit, or publication action. Rejected-only cleanup removes the
+exact registered disposable worktree and unchanged branch ref after fresh explicit
+hash approvals, but deliberately retains the cleaned private state tombstone. Partial
+or ambiguous states are retained for manual recovery rather than automatically
+deleted.
+
+Lifecycle-owned Git execution ignores system/global and caller Git configuration,
+uses a private empty hooks directory, and disables prompts, pagers, fsmonitor,
+external diff, protocols, and recursive submodules. Before worktree creation it
+rejects local included hook/helper/filter configuration and any effective base-tree
+or repository-info content-filter attribute. It therefore does not grant repository
+hooks or filters execution authority during lifecycle initialization. Fatal or
+ambiguous ref evidence is never treated as absence and retains the truthful recovery
+state.
+
 The project does not delete these artifacts automatically. The person running the
 tool controls retention and should review and remove unneeded artifacts according to
 their own policy. Do not commit or paste raw logs into public reports.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ text, and it hashes the Git diff plus every nontracked path—including ignored 
 before and after verification so a passing verifier cannot silently rewrite the
 candidate.
 
-The twelve offline suites need no agy process, network access, API key, or GitHub login.
+The thirteen offline suites need no agy process, network access, API key, or GitHub login.
 
 ## See the evidence boundary in under a minute
 
@@ -463,6 +463,82 @@ Gate controls:
 - Exit 15 is escalation, never acceptance. Read `open_questions` and decide whether
   one corrective dispatch is justified.
 
+### Manage one isolated local job
+
+`job.sh` records one explicit branch-backed worktree in a private external state
+file, delegates verification to `verify-job.sh`, and keeps every external action
+outside the lifecycle. It never dispatches agy, commits, pushes, opens a PR, merges,
+releases, or changes a model. Its Python entry is process-owning so signal authority
+survives output flush; invoke `job.sh` as a command/subprocess and do not embed its
+`main()` in a host process. Capture a full immutable base and create the state
+directory and worktree outside the repository:
+
+Lifecycle-owned Git commands use fixed `/usr/bin/git` with system/global and caller
+Git environment removed, a fresh private empty hooks directory, and prompts, pagers,
+fsmonitor, external diff, protocols, and recursive submodules disabled. `init` also
+rejects local included config that could authorize hooks, fsmonitor, pagers, or
+content filters, and rejects every effective `filter` attribute in the immutable base
+tree or repository info attributes. Branch names must equal Git's canonical
+`check-ref-format --branch` output byte-for-byte; reflog/revision shorthand is not a
+branch authority. These controls prevent lifecycle initialization from executing
+repository-provided checkout hooks or content filters; rejected preflight creates no
+state, ref, or worktree.
+
+```bash
+BASE="$(git rev-parse HEAD)"
+umask 077
+STATE_DIR="$(mktemp -d -t agyworker-job-state.XXXXXX)"
+WORKTREE_DIR="$(mktemp -d -t agyworker-job-worktree.XXXXXX)"
+rmdir "$WORKTREE_DIR"
+
+./job.sh init \
+  --state "$STATE_DIR/job.json" \
+  --repo "$(pwd -P)" \
+  --worktree "$WORKTREE_DIR" \
+  --branch codex/my-isolated-job \
+  --base "$BASE" \
+  --job-id my-isolated-job
+
+./job.sh status --state "$STATE_DIR/job.json"
+```
+
+Run the separately approved worker against the printed worktree through the normal
+dispatcher. Then bind the resulting envelope to the same gate and receipt protocol:
+
+```bash
+./job.sh verify \
+  --state "$STATE_DIR/job.json" \
+  --receipt "$STATE_DIR/receipt.json" \
+  --envelope envelope.json \
+  --only 'tests/**' --expect-edits \
+  --verify "git -C '$WORKTREE_DIR' diff --check"
+```
+
+For `verified-gate-passed`, `preserve-instructions` prints review/commit/integration
+commands but runs none of them. Cleanup is deliberately narrower: only Receipt exits
+`10`–`14` with verdict `rejected` qualify. First run `status` again and manually copy
+its current `job_id`, `state_sha256`, and `receipt_candidate_state_sha256` into one
+fresh command:
+
+```bash
+./job.sh cleanup \
+  --state "$STATE_DIR/job.json" \
+  --approve-job EXACT_JOB_ID \
+  --approve-state-sha CURRENT_STATE_SHA256 \
+  --approve-candidate-sha RECEIPT_CANDIDATE_STATE_SHA256
+```
+
+Cleanup revalidates the receipt, worktree registration, branch/ref/base, current
+candidate digest, deletion domain, and all three approvals. It persists progress
+before each destructive step, removes only the exact registered worktree, and deletes
+only the exact unchanged branch ref with compare-and-delete. A reconciled interrupted
+state returns without spending an old state approval; inspect the new status and issue
+a fresh command. Gate-passed, routed, committed, moved, tampered, stale, foreign,
+special-node, nested-repository, or digest-mismatched states are retained for manual
+recovery. Candidate-bound symlinks are removed as link nodes only and are never
+followed. The private mode-`0600` cleaned tombstone is retained; deleting it is a
+separate manual retention decision.
+
 ### Preserve a local Evidence Receipt v1
 
 `verify-job.sh` runs the same canonical gate and, only for gate outcomes `0` and
@@ -742,6 +818,7 @@ output, not its own recollection.
 
 ```
 agy-worker.sh                 dispatch a job, return a schema-valid envelope
+job.sh                        manage one explicit branch-backed local job lifecycle
 qa-gate.sh                    verify an envelope against the repo — the evidence
 verify-job.sh                 run the gate and durably publish Evidence Receipt v1
 evidence-report.sh            render a validated receipt as bounded text or Markdown
@@ -778,6 +855,7 @@ CODE_OF_CONDUCT.md            enforceable participation standards
 tests/test-qa-gate.sh         offline adversarial suite
 tests/test-evidence-receipt.sh  88-case offline receipt/publication/protocol suite
 tests/test-evidence-report.sh  60-case offline pure renderer/privacy/mutation suite
+tests/test-job-lifecycle.py   94-case offline state/Git-policy/receipt/cleanup/signal suite
 tests/test-agy-worker.sh       offline dispatcher/installer/routing suite
 tests/test-update.sh          310-case offline transport/process/inventory/local-remote/matrix/manifest updater suite
 tests/test-agy-inventory.py   test-only exact-slug/display-alias adversary harness
@@ -788,8 +866,8 @@ tests/test-version-attestation-harness.py  55-case offline version-attestation m
 tests/test-models-attestation-runner.py  78-case offline fixed-profile inventory attestation suite
 tests/test-official-distribution.py  test-only stdlib manifest adversary harness
 tests/test-reporting.sh       offline privacy/fake-gh reporting suite
-tests/test-packaging.sh       187-case offline Codex package/CI-policy/relocation/landing suite
-tests/test-doctor.sh          180-case offline fake-tool/read-only doctor suite
+tests/test-packaging.sh       212-case offline Codex package/CI-policy/relocation/landing suite
+tests/test-doctor.sh          184-case offline fake-tool/read-only doctor suite
 tests/test-proof-demo.sh      21-case offline starter-proof adversarial suite
 .github/workflows/compatibility-watch.yml  observational weekly/manual fixed-source watch
 ```

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -42,6 +42,26 @@ Git-visible state independently, rejects undeclared, phantom, wrong-kind, outsid
 policy, and verifier-created changes, and routes non-completed outcomes without
 accepting them.
 
+The optional local lifecycle wraps that same authority without adding autonomy:
+
+```text
+job.sh init (explicit repo/worktree/branch/full base/job ID -> private state v1)
+  -> separately approved agy-worker.sh dispatch in the bound worktree
+  -> job.sh verify -> exact verify-job.sh / qa-gate.sh receipt path
+  -> job.sh status (read-only facts and current approval hashes)
+  -> gate-passed: preserve-instructions only, never execution
+  -> rejected exit 10-14 only: fresh triple-approved cleanup
+       -> durable cleanup-in-progress
+       -> exact registered worktree removal
+       -> exact unchanged branch ref compare-and-delete
+       -> private cleaned tombstone
+```
+
+The lifecycle cannot dispatch, accept, commit, publish, or clean routed/passed work.
+Reconciliation never spends an approval for stale state bytes on a later destructive
+step. Its deletion scan does not follow symlinks and rejects nested repositories,
+initialized submodules, special nodes, device/mount changes, and unbound digest drift.
+
 The repository-only starter proof has a deliberately smaller flow:
 
 ```text
@@ -102,12 +122,13 @@ accept a candidate, replace human diff review, or certify correctness or securit
 | `agy-worker.sh`, `skills/agy-worker/runtime/agy-worker.sh` | Root compatibility entry plus strict selector-source parsing, canonical dispatch, frozen model/mode selection, bounded retries, private selection/prompt/log staging, envelope extraction | `tests/test-agy-worker.sh` (209 cases) |
 | `model-selection.sh`, `skills/agy-worker/runtime/model-selection.sh`, `skills/agy-worker/runtime/scripts/model_selection.py`, portable matrix/schema/SHA | Root compatibility entry plus canonical exact model/effort resolution, bounded installed-version preflight, and driver selection provenance | dispatcher, doctor, and packaging suites |
 | `model-recommendation.sh`, `skills/agy-worker/runtime/model-recommendation.sh`, `skills/agy-worker/runtime/scripts/model-recommendation.py` | Root compatibility entry plus side-effect-free pre/post recommendations; direct selections are labelled but unranked and never applied | `tests/test-agy-worker.sh` (209 cases) |
-| `doctor.sh`, `skills/agy-worker/runtime/doctor.sh`, `skills/agy-worker/runtime/scripts/doctor-metadata.py`, `skills/agy-worker/runtime/compat/` | Root compatibility entry plus deterministic offline prerequisite checks and byte-synchronized portable agy metadata | `tests/test-doctor.sh` (180 cases) plus packaging synchronization checks |
+| `doctor.sh`, `skills/agy-worker/runtime/doctor.sh`, `skills/agy-worker/runtime/scripts/doctor-metadata.py`, `skills/agy-worker/runtime/compat/` | Root compatibility entry plus deterministic offline prerequisite checks and byte-synchronized portable agy metadata | `tests/test-doctor.sh` (184 cases) plus packaging synchronization checks |
 | `install.sh`, `skills/agy-worker/`, `skills/agy-worker/scripts/resolve-pipeline.sh` | Install and resolve complete-plugin, explicit-checkout, or folder-only skill layouts without fetching code | dispatcher and packaging suites |
 | `skills/agy-worker/runtime/schemas/`, `skills/agy-worker/runtime/scripts/validate-envelope.py` | Dependency-free envelope contract validation | dispatcher and gate suites |
 | `qa-gate.sh`, `skills/agy-worker/runtime/qa-gate.sh` | Root compatibility entry plus canonical immutable-base Git audit, path policy, escalation, driver verification, and internal pre-opened structured evidence handoff | `tests/test-qa-gate.sh` (41 cases) plus receipt suite no-FD compatibility checks |
 | `verify-job.sh`, `skills/agy-worker/runtime/verify-job.sh`, `skills/agy-worker/runtime/scripts/evidence_receipt.py`, `skills/agy-worker/runtime/schemas/evidence-receipt.schema.json` | Root compatibility entry plus exact input hashing, strict selection/advisory binding, startup-isolated parent-exclusive gate evidence, interruption cleanup, unsigned receipt validation, and private durable no-overwrite publication | `tests/test-evidence-receipt.sh` (88 cases) |
 | `evidence-report.sh`, `skills/agy-worker/runtime/evidence-report.sh`, `skills/agy-worker/runtime/scripts/evidence_report.py`, `skills/agy-worker/runtime/scripts/recommendation_record.py` | Root compatibility entry plus pure Receipt v1 validation, deterministic bounded text/Markdown rendering, separately trusted binding checks, privacy filtering, and optional mode-0600 no-overwrite publication; stdout-only `main(argv)` returns, while file-output `main(argv)` is process-owning through `os._exit(0)` and must run as a command/subprocess; never dispatches, routes, gates, or changes a verdict | `tests/test-evidence-report.sh` (60 cases), receipt back-compat, and packaging checks |
+| `job.sh`, `skills/agy-worker/runtime/job.sh`, `skills/agy-worker/runtime/scripts/job_lifecycle.py`, `skills/agy-worker/runtime/scripts/candidate_state.py`, `skills/agy-worker/runtime/schemas/job-state.schema.json` | Root compatibility entry plus process-owning lifecycle CLI, external private v1 state, canonical branch-backed worktree init/status, fixed sanitized Git execution with no checkout hook/filter authority, exact Receipt delegation/binding, read-only preserve instructions, interrupted-progress reconciliation, rc1-only ref-absence evidence, and triple-approved rejected-only compare-and-delete cleanup; the shared candidate helper is also the gate's sole digest implementation | `tests/test-job-lifecycle.py` (94 cases), gate parity, doctor, and packaging suites |
 | `proof-demo.sh`, `demo/fixtures/` | Repository-only offline starter proof using two canonical synthetic envelopes and isolated temporary repositories | `tests/test-proof-demo.sh` (21 cases) |
 | `skills/agy-worker/runtime/agents/*.md` | Prompt-injected bounded personas; prompt text is guidance, not enforcement | dispatcher suite plus bounded real exercises |
 | `update.sh`, `scripts/compatibility.py`, `scripts/compatibility_probe.py`, `scripts/agy_inventory.py`, `scripts/official_github.py`, `scripts/official_distribution.py`, `compat/` | Explicit project releases; exact fixed-REST agy/Codex observation; bounded process-group/version probes; exact-line allowlisted agy inventory interpretation with reserved provider namespaces; sanitized reconciliation records; bounded distribution-manifest canary; strict per-tool metadata and active-only-when-bound model/effort matrix. Explicit apply-time Git fetch remains ambient-configuration-aware. | `tests/test-update.sh` (310 cases, including fixed transport, supervisor, inventory, and manifest adversary harnesses) |
@@ -115,12 +136,12 @@ accept a candidate, replace human diff review, or certify correctness or securit
 | `scripts/version_attestation_harness.py` | Persistent provider-independent mutation harness for owner-private no-overwrite publication, one bounded synthetic controller supervisor, exact process-group cleanup, lifecycle-signal linearization, fixed copy-based weakened controls, and exact byte/SHA binding to the canonical runner before import. It never invokes agy or reads compatibility evidence. | `tests/test-version-attestation-harness.py` (55 cases) |
 | `scripts/models_attestation_runner.py`, `scripts/agy_inventory.py` | Separate canonical fixed-profile snapshot-backed `models` inventory observation bound to an accepted version binding and the same attested executable; one exact Popen, 25-second/64-KiB bounds, exact 11-line allowlist semantics, private durable raw/source/binding publication, and synthetic-only self-test. It never advances metadata, proves a provider backend, applies a selector, or exposes model/effort flags; production execution remains separately authorized. | `tests/test-models-attestation-runner.py` (78 cases), plus updater parser controls |
 | `bug-report.sh`, `scripts/bug-report.py`, `.github/ISSUE_TEMPLATE/` | Local privacy filtering, exact review binding, optional issue submission | `tests/test-reporting.sh` (21 cases) |
-| `.codex-plugin/plugin.json` | Codex skills-only package identity retained for local validation; not a public listing | `tests/test-packaging.sh` (187 cases) plus platform validators |
-| `PRIVACY.md`, `TERMS.md`, `SUPPORT.md` | Public data disclosure, project policy, and support route | `tests/test-packaging.sh` (187 cases) plus review |
-| `docs/index.md`, `docs/_layouts/`, `docs/_config.yml`, `docs/sitemap.xml` | Static GitHub Pages landing, canonical metadata, and sitemap; enabling Pages and submitting the sitemap through Search Console remain external | `tests/test-packaging.sh` (187 cases) plus rendered review |
-| `docs/assets/brand/`, `scripts/validate-brand-assets.py` | Approved light/dark master marks, pixel-hinted micro variants, favicon PNGs, social preview, and dependency-free asset validation | `tests/test-packaging.sh` (187 cases) plus rendered review |
+| `.codex-plugin/plugin.json` | Codex skills-only package identity retained for local validation; not a public listing | `tests/test-packaging.sh` (212 cases) plus platform validators |
+| `PRIVACY.md`, `TERMS.md`, `SUPPORT.md` | Public data disclosure, project policy, and support route | `tests/test-packaging.sh` (212 cases) plus review |
+| `docs/index.md`, `docs/_layouts/`, `docs/_config.yml`, `docs/sitemap.xml` | Static GitHub Pages landing, canonical metadata, and sitemap; enabling Pages and submitting the sitemap through Search Console remain external | `tests/test-packaging.sh` (212 cases) plus rendered review |
+| `docs/assets/brand/`, `scripts/validate-brand-assets.py` | Approved light/dark master marks, pixel-hinted micro variants, favicon PNGs, social preview, and dependency-free asset validation | `tests/test-packaging.sh` (212 cases) plus rendered review |
 | `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, `.github/pull_request_template.md` | Contribution workflow, private vulnerability route, conduct enforcement, and review checklist | human review plus relevant offline suites |
-| `.github/workflows/test.yml`, `scripts/ci-diff-check.sh`, `scripts/ci_diff_check.py` | macOS CI for committed PR/push diff hygiene, syntax, and all twelve offline suites. Checkout supplies the event range; the helper performs no fetch and linearly scans changed immutable head blobs from one bounded `git cat-file --batch` process, independently of attributes or diff drivers. | packaging policy tests plus GitHub Actions |
+| `.github/workflows/test.yml`, `scripts/ci-diff-check.sh`, `scripts/ci_diff_check.py` | macOS CI for committed PR/push diff hygiene, syntax, and all thirteen offline suites. Checkout supplies the event range; the helper performs no fetch and linearly scans changed immutable head blobs from one bounded `git cat-file --batch` process, independently of attributes or diff drivers. | packaging policy tests plus GitHub Actions |
 | `.github/workflows/compatibility-watch.yml` | Weekly/manual macOS observation of fixed official evidence; bounded Step Summary only, never a required PR or metadata/action path | static policy tests in `tests/test-update.sh` plus GitHub Actions observation |
 | `README.md` | User setup, examples, current capabilities and limitations | review plus relevant offline suites |
 | `docs/ROADMAP.md` | Planned dependency-ordered product slices, approval gates, and honest success measures; not current behavior | human review; implementation claims remain prohibited until their slices land |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -613,7 +613,7 @@ explicit pre-gate publication-input check.
 
 ### P1 — integrate the evidence boundary without broadening autonomy
 
-#### P1-A — Safe local lifecycle
+#### P1-A — Safe local lifecycle (implemented)
 
 - **User job:** Create, inspect, verify, and deliberately clean an isolated job without
   manually reproducing the full worktree recipe.
@@ -646,6 +646,14 @@ explicit pre-gate publication-input check.
 - **Done/exit criteria:** Crash-safe state transitions; cleanup only for an explicitly
   approved, exact hash-bound rejected disposable state; no loss of gate-passed or
   accepted work; no external action; and independent destructive-target review.
+- **Implemented boundary:** The canonical portable runtime owns the v1 state machine,
+  shared candidate-state digest, Receipt validation, progress reconciliation, and
+  compare-and-delete cleanup. The root command is only a compatibility wrapper.
+  Ninety-four offline cases cover accepted and rejected lifecycle paths, canonical
+  branch authority, hook/filter-free fixed Git execution, durability, stale approval,
+  ref-error separation, deletion-domain, signal, and weakened-authority mutations.
+  Cleanup never follows symlinks, never deletes a commit, and retains the cleaned
+  state file.
 
 #### P1-B — Full public conformance kit
 

--- a/docs/lessons_learned.md
+++ b/docs/lessons_learned.md
@@ -365,3 +365,29 @@ Do not launch `git cat-file` once per changed blob: the maximum-path fixture tur
 that design into thousands of processes and can consume the shared CI deadline.
 Feed fixed, full object IDs to one bounded batch reader and bind every response's
 order, ID, type, declared size, delimiter, total bytes, stderr, and completion.
+
+Do not make destructive lifecycle recovery an automatic continuation of old
+approval. Bind a private canonical state file to the exact repository, worktree,
+branch ref, immutable base, job ID, Receipt bytes, and candidate digest; advance it
+with sequence and previous-state hashes. Persist cleanup-in-progress before removing
+anything, record each completed Git step durably, and require fresh current-state,
+job, and candidate approvals on every new invocation. If reconciliation observes a
+completed worktree-removal step, publish that truth and stop before deleting the ref;
+the newly written state needs new approval. Remove a branch only with exact
+compare-and-delete against the recorded base, never a force-delete shortcut.
+
+A worktree is not an execution sandbox. `git worktree add` can run repository
+checkout hooks and content filters before a worker ever starts. Use one fixed
+sanitized Git runner, disable hooks and ambient helpers, inspect local included
+config, and reject every effective content-filter attribute before checkout. Branch
+validation must bind Git's canonical stdout rather than only its exit code: checkout
+shorthand such as `@{-1}` can canonicalize to a different ref. During cleanup, a ref
+probe's fatal exit is uncertainty, not absence; only the command's documented
+missing-ref status can advance a durable cleaned tombstone.
+
+A symlink inside a candidate is not automatically foreign data. The canonical gate
+digest binds its path, mode, and target. A cleanup scan may therefore delete the link
+node when the whole current candidate still matches the rejected Receipt, but it must
+use lstat-only traversal and never follow the target. Nested repositories, initialized
+submodules, mount/device changes, special nodes, and any digest drift remain manual
+recovery boundaries.

--- a/job.sh
+++ b/job.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Compatibility entry point; the distributable skill owns the canonical lifecycle.
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+exec "$SCRIPT_DIR/skills/agy-worker/runtime/job.sh" "$@"

--- a/skills/agy-worker/SKILL.md
+++ b/skills/agy-worker/SKILL.md
@@ -98,16 +98,34 @@ Otherwise just do it yourself. A single-file edit is cheaper direct than delegat
 ### 1. Isolate
 
 Never let the worker touch the user's working tree. Use a branch-backed worktree so
-accepted changes can be committed before cleanup.
+accepted changes can be committed before cleanup. Prefer the lifecycle command: it
+binds the exact repository, worktree, branch, immutable base, and job ID in a private
+external state file and performs no dispatch or external action. Invoke `job.sh` as a
+command/subprocess; its Python `main()` is process-owning for signal-safe termination
+and is not an embedding API.
+It accepts only an exact canonical branch name. Every lifecycle-owned Git command
+uses fixed sanitized Git execution with a private empty hooks directory; `init`
+rejects configured hooks/helpers/filters and effective base-tree or info-attribute
+filters before creating state, a ref, or a worktree. Fatal ref evidence is never
+treated as absence.
 
 ```bash
 PIPELINE="$(bash "$SKILL_ROOT/scripts/resolve-pipeline.sh")" || exit $?
 TARGET=/absolute/path/to/target-repo
-WT=/tmp/agy-job-12345
-JOB_BRANCH=agy/job-12345
 BASE="$(git -C "$TARGET" rev-parse HEAD)"
-git -C "$TARGET" worktree add -b "$JOB_BRANCH" "$WT" "$BASE"
+umask 077
+STATE_DIR="$(mktemp -d -t agyworker-job-state.XXXXXX)"
+WT="$(mktemp -d -t agyworker-job-worktree.XXXXXX)"
+rmdir "$WT"
+JOB_BRANCH=agy/job-12345
+JOB_ID=job-12345
+"$PIPELINE/job.sh" init --state "$STATE_DIR/job.json" \
+    --repo "$TARGET" --worktree "$WT" --branch "$JOB_BRANCH" \
+    --base "$BASE" --job-id "$JOB_ID"
 ```
+
+The manual reference remains `git -C "$TARGET" worktree add -b "$JOB_BRANCH"
+"$WT" "$BASE"`. Do not mix manual mutations into a lifecycle-managed state.
 
 ### 2. Write acceptance criteria BEFORE dispatching
 
@@ -272,6 +290,17 @@ returns that exit. A receipt uses only `gate-passed`, `rejected`, or `routed`; i
 calls a candidate accepted. It is explicitly unsigned and not tamper-evident. Even
 exit 0 still requires human diff review.
 
+For a lifecycle-managed job, use the exact same verification inputs through its
+wrapper instead of calling `verify-job.sh` directly:
+
+```bash
+"$PIPELINE/job.sh" verify --state "$STATE_DIR/job.json" \
+    --receipt "$STATE_DIR/receipt.json" --envelope /tmp/envelope.json \
+    --only 'tests/**' --expect-edits \
+    --verify "git -C '$WT' diff --check" \
+    --verify "cd '$WT' && <the command from step 2>"
+```
+
 To read or share the bounded receipt observations without pasting private job
 artifacts, render the validated receipt locally:
 
@@ -340,9 +369,14 @@ git -C "$TARGET" worktree remove "$WT"
 ```
 
 Integrate `JOB_BRANCH` only through the user's normal review/merge flow. If the job
-was rejected and its disposable changes should be discarded, remove the worktree
-with `--force` and then delete only `JOB_BRANCH`. Never force-remove accepted,
-uncommitted work.
+was rejected with gate exit `10`–`14`, run `job.sh status`, inspect its current facts,
+and invoke `job.sh cleanup` only with the exact current job ID, state SHA, and Receipt
+candidate SHA copied into the three approval flags. It rechecks the receipt, digest,
+worktree, branch, deletion domain, and approvals; it never cleans gate-passed or
+routed work. If reconciliation advances state after an interruption, stop and obtain
+fresh approval for the new state SHA before continuing. The manual reference is to
+force-remove only a known disposable rejected worktree and then delete only its exact
+job branch. Never force-remove accepted, uncommitted work.
 
 ## Never
 

--- a/skills/agy-worker/runtime/doctor.sh
+++ b/skills/agy-worker/runtime/doctor.sh
@@ -44,6 +44,7 @@ doctor_runtime_complete() {
     done
     for required in \
         agy-worker.sh \
+        job.sh \
         qa-gate.sh \
         verify-job.sh \
         evidence-report.sh \
@@ -57,6 +58,8 @@ doctor_runtime_complete() {
         scripts/model-recommendation.py \
         scripts/model_selection.py \
         scripts/compatibility.py \
+        scripts/candidate_state.py \
+        scripts/job_lifecycle.py \
         scripts/doctor-metadata.py; do
         case "$required" in
             */*) dependency_parent="${required%/*}" ;;
@@ -79,6 +82,7 @@ doctor_runtime_complete() {
         schemas/evidence-receipt.schema.json \
         schemas/model-selection.schema.json \
         schemas/model-recommendation.schema.json \
+        schemas/job-state.schema.json \
         agents/bulk-test-writer.md \
         agents/repo-inventory.md \
         agents/diff-reviewer.md \

--- a/skills/agy-worker/runtime/job.sh
+++ b/skills/agy-worker/runtime/job.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Manage one explicit branch-backed local job; never dispatch or publish externally.
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+exec python3 -I -S -B "$SCRIPT_DIR/scripts/job_lifecycle.py" "$@"

--- a/skills/agy-worker/runtime/qa-gate.sh
+++ b/skills/agy-worker/runtime/qa-gate.sh
@@ -375,55 +375,8 @@ PY
 }
 
 snapshot_repo() {
-    gate_python - "$repo" "$base" <<'PY'
-import hashlib
-import os
-import stat
-import subprocess
-import sys
-
-repo, base = sys.argv[1:3]
-
-def git_output(*args):
-    return subprocess.run(
-        ["git", "-C", repo, *args], check=True,
-        stdout=subprocess.PIPE).stdout
-
-def git_paths(*args):
-    output = git_output(*args)
-    return sorted(part for part in output.split(b"\0") if part)
-
-digest = hashlib.sha256()
-tracked_diff = git_output(
-    "diff", "--binary", "--no-ext-diff", "--no-textconv",
-    "--submodule=short", base, "--")
-digest.update(len(tracked_diff).to_bytes(8, "big"))
-digest.update(tracked_diff)
-paths = set(git_paths("ls-files", "--others", "--exclude-standard", "-z", "--"))
-paths.update(git_paths(
-    "ls-files", "--others", "--ignored", "--exclude-standard", "-z", "--"))
-for raw_path in sorted(paths):
-    path = raw_path.decode("utf-8", "surrogateescape")
-    full_path = os.path.join(repo, path)
-    digest.update(len(raw_path).to_bytes(8, "big"))
-    digest.update(raw_path)
-    try:
-        metadata = os.lstat(full_path)
-    except FileNotFoundError:
-        digest.update(b"deleted")
-        continue
-    digest.update(str(stat.S_IFMT(metadata.st_mode)).encode("ascii"))
-    digest.update(str(stat.S_IMODE(metadata.st_mode)).encode("ascii"))
-    if stat.S_ISLNK(metadata.st_mode):
-        digest.update(os.readlink(full_path).encode("utf-8", "surrogateescape"))
-    elif stat.S_ISREG(metadata.st_mode):
-        with open(full_path, "rb") as handle:
-            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-                digest.update(chunk)
-    else:
-        digest.update(b"non-regular")
-print(digest.hexdigest())
-PY
+    gate_python "$SCRIPT_DIR/scripts/candidate_state.py" \
+        --repo "$repo" --base "$base"
 }
 
 if [[ -n "$evidence_fd" ]]; then

--- a/skills/agy-worker/runtime/schemas/job-state.schema.json
+++ b/skills/agy-worker/runtime/schemas/job-state.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "agy-worker local job state v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version", "kind", "sequence", "previous_state_sha256", "phase",
+    "job_id", "repo_path", "repo_identity", "git_common_dir",
+    "git_common_identity", "worktree_path", "worktree_parent_device",
+    "worktree_identity", "branch", "branch_ref", "base", "receipt",
+    "cleanup_step", "last_result", "failure"
+  ],
+  "properties": {
+    "schema_version": {"type": "integer", "enum": [1]},
+    "kind": {"type": "string", "enum": ["agy-worker-local-job-state"]},
+    "sequence": {"type": "integer", "minimum": 1},
+    "previous_state_sha256": {
+      "anyOf": [
+        {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        {"type": "null"}
+      ]
+    },
+    "phase": {
+      "type": "string",
+      "enum": [
+        "initializing", "ready", "init-failed", "init-interrupted",
+        "verifying", "verify-failed", "verify-interrupted",
+        "verified-gate-passed", "verified-rejected", "verified-routed",
+        "cleanup-in-progress", "cleaned"
+      ]
+    },
+    "job_id": {"type": "string"},
+    "repo_path": {"type": "string"},
+    "repo_identity": {"type": "object"},
+    "git_common_dir": {"type": "string"},
+    "git_common_identity": {"type": "object"},
+    "worktree_path": {"type": "string"},
+    "worktree_parent_device": {"type": "integer", "minimum": 0},
+    "worktree_identity": {"anyOf": [{"type": "object"}, {"type": "null"}]},
+    "branch": {"type": "string"},
+    "branch_ref": {"type": "string"},
+    "base": {"type": "string"},
+    "receipt": {"anyOf": [{"type": "object"}, {"type": "null"}]},
+    "cleanup_step": {
+      "type": "string",
+      "enum": ["none", "worktree-removed", "branch-removed"]
+    },
+    "last_result": {"anyOf": [{"type": "integer"}, {"type": "null"}]},
+    "failure": {
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": ["init-failed", "interrupted", "verify-failed", "cleanup-failed"]
+        },
+        {"type": "null"}
+      ]
+    }
+  }
+}

--- a/skills/agy-worker/runtime/scripts/candidate_state.py
+++ b/skills/agy-worker/runtime/scripts/candidate_state.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Canonical Git-visible candidate-state digest shared by gate and lifecycle."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+from pathlib import Path
+import re
+import stat
+import subprocess
+import sys
+from typing import Callable
+
+sys.dont_write_bytecode = True
+
+COMMIT_RE = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})")
+
+
+class CandidateStateError(ValueError):
+    pass
+
+
+GitReader = Callable[[Path, str], bytes]
+
+
+def _git(repo: Path, *arguments: str) -> bytes:
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(repo), *arguments],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+    except OSError as exc:
+        raise CandidateStateError("git candidate-state probe failed") from exc
+    if completed.returncode != 0:
+        raise CandidateStateError("git candidate-state probe failed")
+    return completed.stdout
+
+
+def _read_git(
+    repo: Path,
+    arguments: tuple[str, ...],
+    git_reader: Callable[..., bytes] | None,
+) -> bytes:
+    return _git(repo, *arguments) if git_reader is None else git_reader(repo, *arguments)
+
+
+def _paths(
+    repo: Path,
+    *arguments: str,
+    git_reader: Callable[..., bytes] | None = None,
+) -> list[bytes]:
+    return sorted(
+        part
+        for part in _read_git(repo, arguments, git_reader).split(b"\0")
+        if part
+    )
+
+
+def validate_repository(
+    repo: Path,
+    base: str,
+    *,
+    git_reader: Callable[..., bytes] | None = None,
+) -> tuple[Path, str]:
+    if not repo.is_absolute() or Path(os.path.realpath(repo)) != repo:
+        raise CandidateStateError("repository must be one canonical absolute path")
+    try:
+        metadata = repo.lstat()
+    except OSError as exc:
+        raise CandidateStateError("repository is unavailable") from exc
+    if not stat.S_ISDIR(metadata.st_mode) or stat.S_ISLNK(metadata.st_mode):
+        raise CandidateStateError("repository must be one real directory")
+    if COMMIT_RE.fullmatch(base) is None:
+        raise CandidateStateError("base must be one full immutable commit ID")
+    root = _read_git(
+        repo, ("rev-parse", "--show-toplevel"), git_reader
+    ).rstrip(b"\n")
+    try:
+        decoded_root = Path(root.decode("utf-8", "strict"))
+    except UnicodeDecodeError as exc:
+        raise CandidateStateError("repository root is not canonical UTF-8") from exc
+    if decoded_root != repo:
+        raise CandidateStateError("repository must be the exact worktree root")
+    resolved = _read_git(
+        repo, ("rev-parse", "--verify", f"{base}^{{commit}}"), git_reader
+    ).rstrip(b"\n")
+    try:
+        resolved_text = resolved.decode("ascii", "strict")
+    except UnicodeDecodeError as exc:
+        raise CandidateStateError("base resolution is invalid") from exc
+    if resolved_text != base:
+        raise CandidateStateError("base did not resolve exactly")
+    return repo, base
+
+
+def candidate_state_digest(
+    repo: Path,
+    base: str,
+    *,
+    validate: bool = True,
+    git_reader: Callable[..., bytes] | None = None,
+) -> str:
+    if validate:
+        repo, base = validate_repository(repo, base, git_reader=git_reader)
+    digest = hashlib.sha256()
+    tracked_diff = _read_git(
+        repo,
+        (
+            "diff",
+            "--binary",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--submodule=short",
+            base,
+            "--",
+        ),
+        git_reader,
+    )
+    digest.update(len(tracked_diff).to_bytes(8, "big"))
+    digest.update(tracked_diff)
+    paths = set(
+        _paths(
+            repo,
+            "ls-files",
+            "--others",
+            "--exclude-standard",
+            "-z",
+            "--",
+            git_reader=git_reader,
+        )
+    )
+    paths.update(
+        _paths(
+            repo,
+            "ls-files",
+            "--others",
+            "--ignored",
+            "--exclude-standard",
+            "-z",
+            "--",
+            git_reader=git_reader,
+        )
+    )
+    for raw_path in sorted(paths):
+        try:
+            relative = raw_path.decode("utf-8", "surrogateescape")
+        except UnicodeDecodeError as exc:  # pragma: no cover - surrogateescape is total
+            raise CandidateStateError("candidate path is invalid") from exc
+        full_path = os.path.join(repo, relative)
+        digest.update(len(raw_path).to_bytes(8, "big"))
+        digest.update(raw_path)
+        try:
+            metadata = os.lstat(full_path)
+        except FileNotFoundError:
+            digest.update(b"deleted")
+            continue
+        digest.update(str(stat.S_IFMT(metadata.st_mode)).encode("ascii"))
+        digest.update(str(stat.S_IMODE(metadata.st_mode)).encode("ascii"))
+        if stat.S_ISLNK(metadata.st_mode):
+            digest.update(os.readlink(full_path).encode("utf-8", "surrogateescape"))
+        elif stat.S_ISREG(metadata.st_mode):
+            with open(full_path, "rb") as handle:
+                for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                    digest.update(chunk)
+        else:
+            digest.update(b"non-regular")
+    return digest.hexdigest()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="candidate_state.py", add_help=False)
+    parser.add_argument("--repo", action="append")
+    parser.add_argument("--base", action="append")
+    parsed = parser.parse_args(argv)
+    if not parsed.repo or len(parsed.repo) != 1 or not parsed.base or len(parsed.base) != 1:
+        return 64
+    try:
+        print(candidate_state_digest(Path(parsed.repo[0]), parsed.base[0]))
+    except CandidateStateError:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/agy-worker/runtime/scripts/job_lifecycle.py
+++ b/skills/agy-worker/runtime/scripts/job_lifecycle.py
@@ -1,0 +1,1436 @@
+#!/usr/bin/env python3
+"""Fail-closed process-owning CLI for one explicit branch-backed worker job.
+
+Run through job.sh. Importing or embedding main() in a host process is unsupported:
+the command retains lifecycle signal handlers through flush and atomic process exit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import secrets
+import shlex
+import shutil
+import signal
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Any, Iterator
+
+sys.dont_write_bytecode = True
+SCRIPTS = Path(__file__).resolve(strict=True).parent
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from candidate_state import (  # noqa: E402
+    CandidateStateError,
+    candidate_state_digest,
+)
+from evidence_receipt import (  # noqa: E402
+    ValidationFailure,
+    load_schema,
+    parse_json_bytes,
+    validate_receipt,
+)
+
+
+SIGNALS = (signal.SIGHUP, signal.SIGINT, signal.SIGTERM)
+JOB_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,79}")
+SHA_RE = re.compile(r"[0-9a-f]{64}")
+COMMIT_RE = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})")
+STATE_FIELDS = {
+    "schema_version", "kind", "sequence", "previous_state_sha256", "phase",
+    "job_id", "repo_path", "repo_identity", "git_common_dir",
+    "git_common_identity", "worktree_path", "worktree_parent_device",
+    "worktree_identity", "branch", "branch_ref", "base", "receipt",
+    "cleanup_step", "last_result", "failure",
+}
+PHASES = {
+    "initializing", "ready", "init-failed", "init-interrupted", "verifying",
+    "verify-failed", "verify-interrupted", "verified-gate-passed",
+    "verified-rejected", "verified-routed", "cleanup-in-progress", "cleaned",
+}
+CLEANUP_STEPS = {"none", "worktree-removed", "branch-removed"}
+RECEIPT_FIELDS = {
+    "path", "sha256", "gate_exit", "verdict", "final_candidate_state_sha256"
+}
+MAX_STATE_BYTES = 128 * 1024
+MAX_RECEIPT_BYTES = 1024 * 1024
+MAX_DELETE_NODES = 100_000
+MAX_GIT_OUTPUT = 32 * 1024 * 1024
+MAX_ATTRIBUTE_PATH_BYTES = 16 * 1024 * 1024
+GIT_TIMEOUT_SECONDS = 30.0
+GIT_EXECUTABLE = "/usr/bin/git"
+UNSAFE_GIT_CONFIG_RE = re.compile(
+    rb"^(?:filter\..*\.(?:clean|smudge|process|required)|core\.(?:fsmonitor|hooksPath|pager)"
+    rb"|diff\.external|interactive\.diffFilter|pager\..*|include(?:If)?\..*)$",
+    re.IGNORECASE,
+)
+
+
+class JobError(ValueError):
+    pass
+
+
+class GitError(OSError):
+    pass
+
+
+class JobSignal(BaseException):
+    def __init__(self, number: int) -> None:
+        self.number = number
+
+
+class GitResult:
+    def __init__(self, returncode: int, stdout: bytes) -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+
+
+class Parser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:
+        del message
+        self.print_usage(sys.stderr)
+        self.exit(64, "job: invalid arguments\n")
+
+
+class Once(argparse.Action):
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Any,
+        option_string: str | None = None,
+    ) -> None:
+        if getattr(namespace, self.dest, None) is not None:
+            parser.error(f"{option_string} must be supplied once")
+        setattr(namespace, self.dest, values)
+
+
+class OnceTrue(argparse.Action):
+    def __init__(self, option_strings: list[str], dest: str, **kwargs: Any) -> None:
+        super().__init__(option_strings, dest, nargs=0, default=None, **kwargs)
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Any,
+        option_string: str | None = None,
+    ) -> None:
+        del values
+        if getattr(namespace, self.dest, None) is not None:
+            parser.error(f"{option_string} must be supplied once")
+        setattr(namespace, self.dest, True)
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value, ensure_ascii=True, sort_keys=True, separators=(",", ":")
+    ).encode("ascii") + b"\n"
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def identity(metadata: os.stat_result) -> dict[str, int]:
+    return {
+        "dev": metadata.st_dev,
+        "ino": metadata.st_ino,
+        "mode": stat.S_IMODE(metadata.st_mode),
+        "uid": metadata.st_uid,
+    }
+
+
+def validate_identity(value: Any, label: str) -> dict[str, int]:
+    if not isinstance(value, dict) or set(value) != {"dev", "ino", "mode", "uid"}:
+        raise JobError(f"{label} identity is invalid")
+    if any(type(value[key]) is not int or value[key] < 0 for key in value):
+        raise JobError(f"{label} identity is invalid")
+    return value
+
+
+def same_identity(metadata: os.stat_result, expected: dict[str, int]) -> bool:
+    return identity(metadata) == expected
+
+
+def real_absolute(path: Path, label: str, *, must_exist: bool = True) -> Path:
+    if not path.is_absolute() or "\n" in str(path) or "\r" in str(path):
+        raise JobError(f"{label} must be one canonical absolute path")
+    canonical = Path(os.path.realpath(path))
+    if canonical != path:
+        raise JobError(f"{label} must be one canonical absolute path")
+    if must_exist and not path.exists():
+        raise JobError(f"{label} is unavailable")
+    return path
+
+
+def contains(parent: Path, child: Path) -> bool:
+    try:
+        child.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def validate_private_parent(parent: Path) -> tuple[Path, int]:
+    parent = real_absolute(parent, "state parent")
+    metadata = parent.lstat()
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or metadata.st_uid != os.getuid()
+        or stat.S_IMODE(metadata.st_mode) != 0o700
+    ):
+        raise JobError("state parent must be one real owner-private mode-0700 directory")
+    descriptor = os.open(
+        parent,
+        os.O_RDONLY
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0),
+    )
+    opened = os.fstat(descriptor)
+    if not same_identity(opened, identity(metadata)):
+        os.close(descriptor)
+        raise JobError("state parent identity changed while opened")
+    return parent, descriptor
+
+
+def _read_fd(descriptor: int, maximum: int) -> bytes:
+    chunks: list[bytes] = []
+    total = 0
+    while True:
+        chunk = os.read(descriptor, min(65536, maximum + 1 - total))
+        if not chunk:
+            break
+        chunks.append(chunk)
+        total += len(chunk)
+        if total > maximum:
+            raise JobError("local artifact is oversized")
+    return b"".join(chunks)
+
+
+def read_regular(path: Path, maximum: int, label: str, *, private: bool) -> tuple[bytes, os.stat_result]:
+    try:
+        descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    except OSError as exc:
+        raise JobError(f"{label} is unavailable") from exc
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise JobError(f"{label} must be one real file")
+        if private and (
+            metadata.st_uid != os.getuid() or stat.S_IMODE(metadata.st_mode) != 0o600
+        ):
+            raise JobError(f"{label} must be owner-private mode 0600")
+        data = _read_fd(descriptor, maximum)
+        if len(data) != metadata.st_size:
+            raise JobError(f"{label} changed while read")
+        return data, metadata
+    finally:
+        os.close(descriptor)
+
+
+def read_regular_at(
+    parent_fd: int,
+    name: str,
+    maximum: int,
+    label: str,
+    *,
+    private: bool,
+) -> tuple[bytes, os.stat_result]:
+    try:
+        descriptor = os.open(
+            name,
+            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+            dir_fd=parent_fd,
+        )
+    except OSError as exc:
+        raise JobError(f"{label} is unavailable") from exc
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise JobError(f"{label} must be one real file")
+        if private and (
+            metadata.st_uid != os.getuid() or stat.S_IMODE(metadata.st_mode) != 0o600
+        ):
+            raise JobError(f"{label} must be owner-private mode 0600")
+        data = _read_fd(descriptor, maximum)
+        if len(data) != metadata.st_size:
+            raise JobError(f"{label} changed while read")
+        return data, metadata
+    finally:
+        os.close(descriptor)
+
+
+def parse_strict(data: bytes, label: str) -> Any:
+    def pairs(items: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in items:
+            if key in result:
+                raise JobError(f"{label} has a duplicate key")
+            result[key] = value
+        return result
+
+    try:
+        return json.loads(data.decode("utf-8", "strict"), object_pairs_hook=pairs)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise JobError(f"{label} is invalid") from exc
+
+
+def canonical_branch_syntax(branch: str) -> bool:
+    forbidden = set(" ~^:?*[\\")
+    if (
+        not branch
+        or branch.startswith("-")
+        or branch == "@"
+        or branch.startswith("/")
+        or branch.endswith(("/", "."))
+        or "//" in branch
+        or ".." in branch
+        or "@{" in branch
+        or any(ord(character) < 32 or ord(character) == 127 for character in branch)
+        or any(character in forbidden for character in branch)
+    ):
+        return False
+    return all(
+        component
+        and not component.startswith(".")
+        and not component.endswith(".lock")
+        for component in branch.split("/")
+    )
+
+
+def validate_state(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != STATE_FIELDS:
+        raise JobError("state fields are invalid")
+    if value["schema_version"] != 1 or value["kind"] != "agy-worker-local-job-state":
+        raise JobError("state version is invalid")
+    if type(value["sequence"]) is not int or value["sequence"] < 1:
+        raise JobError("state sequence is invalid")
+    previous = value["previous_state_sha256"]
+    if previous is not None and (not isinstance(previous, str) or SHA_RE.fullmatch(previous) is None):
+        raise JobError("state history binding is invalid")
+    if (value["sequence"] == 1) != (previous is None):
+        raise JobError("state history binding is inconsistent")
+    if value["phase"] not in PHASES or value["cleanup_step"] not in CLEANUP_STEPS:
+        raise JobError("state phase is invalid")
+    if not isinstance(value["job_id"], str) or JOB_RE.fullmatch(value["job_id"]) is None:
+        raise JobError("state job ID is invalid")
+    if not isinstance(value["base"], str) or COMMIT_RE.fullmatch(value["base"]) is None:
+        raise JobError("state base is invalid")
+    for key in ("repo_path", "git_common_dir", "worktree_path", "branch", "branch_ref"):
+        if not isinstance(value[key], str) or not value[key] or "\x00" in value[key]:
+            raise JobError("state path or ref is invalid")
+    for key in ("repo_path", "git_common_dir", "worktree_path"):
+        candidate = value[key]
+        if (
+            not Path(candidate).is_absolute()
+            or os.path.normpath(candidate) != candidate
+            or "\n" in candidate
+            or "\r" in candidate
+        ):
+            raise JobError("state path is not canonical")
+    if not canonical_branch_syntax(value["branch"]):
+        raise JobError("state branch is invalid")
+    if value["branch_ref"] != f"refs/heads/{value['branch']}":
+        raise JobError("state branch binding is inconsistent")
+    validate_identity(value["repo_identity"], "repository")
+    validate_identity(value["git_common_identity"], "Git common directory")
+    if type(value["worktree_parent_device"]) is not int or value["worktree_parent_device"] < 0:
+        raise JobError("worktree parent device is invalid")
+    if value["worktree_identity"] is not None:
+        validate_identity(value["worktree_identity"], "worktree")
+    if value["last_result"] is not None and type(value["last_result"]) is not int:
+        raise JobError("state result is invalid")
+    if value["failure"] is not None and (
+        not isinstance(value["failure"], str)
+        or value["failure"] not in {"init-failed", "interrupted", "verify-failed", "cleanup-failed"}
+    ):
+        raise JobError("state failure is invalid")
+    receipt = value["receipt"]
+    if receipt is not None:
+        if not isinstance(receipt, dict) or set(receipt) != RECEIPT_FIELDS:
+            raise JobError("state receipt binding is invalid")
+        if not isinstance(receipt["path"], str) or not Path(receipt["path"]).is_absolute():
+            raise JobError("state receipt path is invalid")
+        for key in ("sha256", "final_candidate_state_sha256"):
+            if not isinstance(receipt[key], str) or SHA_RE.fullmatch(receipt[key]) is None:
+                raise JobError("state receipt digest is invalid")
+        if type(receipt["gate_exit"]) is not int or receipt["verdict"] not in {
+            "gate-passed", "rejected", "routed"
+        }:
+            raise JobError("state receipt outcome is invalid")
+        receipt_path = receipt["path"]
+        if os.path.normpath(receipt_path) != receipt_path or "\n" in receipt_path or "\r" in receipt_path:
+            raise JobError("state receipt path is not canonical")
+        expected_verdict = (
+            "gate-passed" if receipt["gate_exit"] == 0
+            else "routed" if receipt["gate_exit"] == 15
+            else "rejected" if receipt["gate_exit"] in {10, 11, 12, 13, 14}
+            else None
+        )
+        if receipt["verdict"] != expected_verdict:
+            raise JobError("state receipt outcome is inconsistent")
+
+    phase = value["phase"]
+    cleanup_step = value["cleanup_step"]
+    worktree_identity = value["worktree_identity"]
+    last_result = value["last_result"]
+    failure = value["failure"]
+    if phase == "initializing":
+        consistent = worktree_identity is None and receipt is None and cleanup_step == "none" and last_result is None and failure is None
+    elif phase == "ready":
+        consistent = worktree_identity is not None and receipt is None and cleanup_step == "none" and last_result is None and failure is None
+    elif phase in {"init-failed", "init-interrupted"}:
+        consistent = receipt is None and cleanup_step == "none" and isinstance(last_result, int) and failure in {"init-failed", "interrupted"}
+    elif phase == "verifying":
+        consistent = worktree_identity is not None and receipt is None and cleanup_step == "none" and last_result is None and failure is None
+    elif phase in {"verify-failed", "verify-interrupted"}:
+        consistent = worktree_identity is not None and receipt is None and cleanup_step == "none" and isinstance(last_result, int) and failure in {"verify-failed", "interrupted"}
+    elif phase in {"verified-gate-passed", "verified-rejected", "verified-routed"}:
+        expected = {
+            "verified-gate-passed": "gate-passed",
+            "verified-rejected": "rejected",
+            "verified-routed": "routed",
+        }[phase]
+        consistent = (
+            worktree_identity is not None
+            and receipt is not None
+            and receipt["verdict"] == expected
+            and cleanup_step == "none"
+            and last_result == receipt["gate_exit"]
+            and failure is None
+        )
+    elif phase == "cleanup-in-progress":
+        consistent = (
+            worktree_identity is not None
+            and receipt is not None
+            and receipt["verdict"] == "rejected"
+            and cleanup_step in {"none", "worktree-removed"}
+            and (
+                (last_result is None and failure is None)
+                or (isinstance(last_result, int) and failure in {"interrupted", "cleanup-failed"})
+            )
+        )
+    else:  # cleaned
+        consistent = (
+            worktree_identity is not None
+            and receipt is not None
+            and receipt["verdict"] == "rejected"
+            and cleanup_step == "branch-removed"
+            and last_result == 0
+            and failure is None
+        )
+    if not consistent:
+        raise JobError("state phase fields are inconsistent")
+    return value
+
+
+class StateStore:
+    def __init__(self, path: Path, *, initial: bool = False) -> None:
+        self.path = real_absolute(path, "state", must_exist=not initial)
+        self.parent, self.parent_fd = validate_private_parent(self.path.parent)
+        self.parent_identity = identity(os.fstat(self.parent_fd))
+        try:
+            fcntl.flock(self.parent_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exc:
+            os.close(self.parent_fd)
+            self.parent_fd = -1
+            raise JobError("state parent is busy") from exc
+        self.name = self.path.name
+        if not self.name or self.name in {".", ".."}:
+            raise JobError("state name is invalid")
+        self.raw: bytes | None = None
+        self.metadata: os.stat_result | None = None
+        self.sha256: str | None = None
+        self.value: dict[str, Any] | None = None
+        if not initial:
+            self.load()
+
+    def close(self) -> None:
+        if self.parent_fd >= 0:
+            os.close(self.parent_fd)
+            self.parent_fd = -1
+
+    def load(self) -> dict[str, Any]:
+        self._validate_parent_path()
+        data, metadata = read_regular_at(
+            self.parent_fd, self.name, MAX_STATE_BYTES, "state", private=True
+        )
+        value = validate_state(parse_strict(data, "state"))
+        if canonical_bytes(value) != data:
+            raise JobError("state bytes are not canonical")
+        self.raw, self.metadata, self.sha256, self.value = (
+            data, metadata, sha256_bytes(data), value
+        )
+        return value
+
+    def _validate_parent_path(self) -> None:
+        try:
+            current = self.parent.lstat()
+        except OSError as exc:
+            raise JobError("state parent path changed") from exc
+        if not same_identity(current, self.parent_identity):
+            raise JobError("state parent path changed")
+
+    @contextlib.contextmanager
+    def _blocked(self) -> Iterator[None]:
+        prior = signal.pthread_sigmask(signal.SIG_BLOCK, SIGNALS)
+        try:
+            yield
+        finally:
+            signal.pthread_sigmask(signal.SIG_SETMASK, prior)
+
+    def create(self, value: dict[str, Any]) -> str:
+        validate_state(value)
+        data = canonical_bytes(value)
+        with self._blocked():
+            self._validate_parent_path()
+            descriptor = os.open(
+                self.name,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+                0o600,
+                dir_fd=self.parent_fd,
+            )
+            try:
+                os.fchmod(descriptor, 0o600)
+                _write_all(descriptor, data)
+                os.fsync(descriptor)
+                metadata = os.fstat(descriptor)
+            finally:
+                os.close(descriptor)
+            self.raw, self.metadata, self.sha256, self.value = (
+                data, metadata, sha256_bytes(data), value
+            )
+            os.fsync(self.parent_fd)
+            self._validate_parent_path()
+        assert self.sha256 is not None
+        return self.sha256
+
+    def update(self, updates: dict[str, Any]) -> str:
+        if self.value is None or self.raw is None or self.metadata is None or self.sha256 is None:
+            raise JobError("state is not loaded")
+        self._validate_parent_path()
+        current, current_metadata = read_regular_at(
+            self.parent_fd, self.name, MAX_STATE_BYTES, "state", private=True
+        )
+        if current != self.raw or not same_identity(current_metadata, identity(self.metadata)):
+            raise JobError("state changed before transition")
+        next_value = dict(self.value)
+        next_value.update(updates)
+        next_value["sequence"] = self.value["sequence"] + 1
+        next_value["previous_state_sha256"] = self.sha256
+        validate_state(next_value)
+        data = canonical_bytes(next_value)
+        temporary = f".{self.name}.job-state.{secrets.token_hex(12)}.tmp"
+        descriptor = -1
+        with self._blocked():
+            try:
+                self._validate_parent_path()
+                descriptor = os.open(
+                    temporary,
+                    os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+                    0o600,
+                    dir_fd=self.parent_fd,
+                )
+                os.fchmod(descriptor, 0o600)
+                _write_all(descriptor, data)
+                os.fsync(descriptor)
+                temporary_metadata = os.fstat(descriptor)
+                os.close(descriptor)
+                descriptor = -1
+                now = os.stat(self.name, dir_fd=self.parent_fd, follow_symlinks=False)
+                if not same_identity(now, identity(self.metadata)):
+                    raise JobError("state changed during transition")
+                os.replace(temporary, self.name, src_dir_fd=self.parent_fd, dst_dir_fd=self.parent_fd)
+                installed = os.stat(self.name, dir_fd=self.parent_fd, follow_symlinks=False)
+                if not same_identity(installed, identity(temporary_metadata)):
+                    raise JobError("state replacement identity changed")
+                self.raw, self.metadata, self.sha256, self.value = (
+                    data, installed, sha256_bytes(data), next_value
+                )
+                os.fsync(self.parent_fd)
+                self._validate_parent_path()
+            except BaseException:
+                if descriptor >= 0:
+                    os.close(descriptor)
+                try:
+                    os.unlink(temporary, dir_fd=self.parent_fd)
+                    os.fsync(self.parent_fd)
+                except FileNotFoundError:
+                    pass
+                raise
+        assert self.sha256 is not None
+        return self.sha256
+
+
+def _write_all(descriptor: int, data: bytes) -> None:
+    view = memoryview(data)
+    while view:
+        written = os.write(descriptor, view)
+        if written <= 0:
+            raise JobError("state write failed")
+        view = view[written:]
+
+
+ACTIVE_PROCESS: subprocess.Popen[bytes] | None = None
+FIRST_SIGNAL: int | None = None
+
+
+def _interrupt(number: int, _frame: Any) -> None:
+    global FIRST_SIGNAL
+    if FIRST_SIGNAL is not None:
+        return
+    FIRST_SIGNAL = number
+    raise JobSignal(number)
+
+
+def _terminate_process(process: subprocess.Popen[bytes]) -> None:
+    # A non-None returncode means Popen has already reaped the leader. Never use
+    # its former PID as process-group authority after that point: the PGID may
+    # already have been reused by an unrelated process.
+    if process.returncode is not None:
+        return
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    time.sleep(0.25)
+    # Keep the unreaped leader as the PGID reservation and send KILL before the
+    # sole wait. There are deliberately no group probes or signals after wait.
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    try:
+        process.wait(timeout=0.75)
+    except subprocess.TimeoutExpired as exc:
+        raise JobError("child cleanup failed") from exc
+
+
+def run_process(arguments: list[str], *, cwd: Path | None = None) -> int:
+    global ACTIVE_PROCESS
+    prior = signal.pthread_sigmask(signal.SIG_BLOCK, SIGNALS)
+    try:
+        ACTIVE_PROCESS = subprocess.Popen(
+            arguments,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            cwd=str(cwd) if cwd is not None else None,
+            start_new_session=True,
+        )
+    finally:
+        signal.pthread_sigmask(signal.SIG_SETMASK, prior)
+    try:
+        return ACTIVE_PROCESS.wait()
+    except JobSignal as exc:
+        signal.pthread_sigmask(signal.SIG_BLOCK, SIGNALS)
+        _terminate_process(ACTIVE_PROCESS)
+        signal.pthread_sigmask(signal.SIG_SETMASK, prior)
+        raise exc
+    finally:
+        ACTIVE_PROCESS = None
+
+
+@contextlib.contextmanager
+def _private_empty_hooks() -> Iterator[Path]:
+    directory = Path(tempfile.mkdtemp(prefix="agy-worker-empty-hooks.", dir="/tmp"))
+    try:
+        os.chmod(directory, 0o700)
+        metadata = directory.lstat()
+        if (
+            not stat.S_ISDIR(metadata.st_mode)
+            or stat.S_ISLNK(metadata.st_mode)
+            or metadata.st_uid != os.getuid()
+            or stat.S_IMODE(metadata.st_mode) != 0o700
+            or any(directory.iterdir())
+        ):
+            raise JobError("private Git policy directory is invalid")
+        yield directory
+    finally:
+        shutil.rmtree(directory, ignore_errors=True)
+
+
+def _git_environment(private_home: Path) -> dict[str, str]:
+    return {
+        "GIT_ASKPASS": "/usr/bin/false",
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_EXTERNAL_DIFF": "",
+        "GIT_PAGER": "cat",
+        "GIT_TERMINAL_PROMPT": "0",
+        "HOME": str(private_home),
+        "LANG": "C",
+        "LC_ALL": "C",
+        "NO_COLOR": "1",
+        "PAGER": "cat",
+        "PATH": "/usr/bin:/bin",
+        "SSH_ASKPASS": "/usr/bin/false",
+        "XDG_CONFIG_HOME": str(private_home),
+    }
+
+
+def _git_arguments(repo: Path | None, hooks: Path, arguments: tuple[str, ...]) -> list[str]:
+    command = [
+        GIT_EXECUTABLE,
+        "-c", f"core.hooksPath={hooks}",
+        "-c", "core.fsmonitor=false",
+        "-c", "core.pager=cat",
+        "-c", "pager.branch=false",
+        "-c", "interactive.diffFilter=",
+        "-c", "credential.helper=",
+        "-c", "protocol.allow=never",
+        "-c", "protocol.file.allow=never",
+        "-c", "submodule.recurse=false",
+        "-c", "fetch.recurseSubmodules=false",
+        "-c", "color.ui=false",
+    ]
+    if repo is not None:
+        command += ["-C", str(repo)]
+    command.extend(arguments)
+    return command
+
+
+def git_result(
+    repo: Path | None,
+    *arguments: str,
+    input_data: bytes | None = None,
+    capture: bool = True,
+) -> GitResult:
+    global ACTIVE_PROCESS
+    if not Path(GIT_EXECUTABLE).is_file():
+        raise GitError("fixed Git executable is unavailable")
+    with _private_empty_hooks() as hooks:
+        command = _git_arguments(repo, hooks, arguments)
+        prior = signal.pthread_sigmask(signal.SIG_BLOCK, SIGNALS)
+        try:
+            ACTIVE_PROCESS = subprocess.Popen(
+                command,
+                stdin=subprocess.PIPE if input_data is not None else subprocess.DEVNULL,
+                stdout=subprocess.PIPE if capture else subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                env=_git_environment(hooks),
+                start_new_session=True,
+            )
+        except OSError as exc:
+            raise GitError("Git validation failed") from exc
+        finally:
+            signal.pthread_sigmask(signal.SIG_SETMASK, prior)
+        try:
+            try:
+                stdout, _stderr = ACTIVE_PROCESS.communicate(
+                    input=input_data, timeout=GIT_TIMEOUT_SECONDS
+                )
+            except subprocess.TimeoutExpired as exc:
+                signal.pthread_sigmask(signal.SIG_BLOCK, SIGNALS)
+                try:
+                    _terminate_process(ACTIVE_PROCESS)
+                except JobError as cleanup_exc:
+                    raise GitError("Git cleanup failed") from cleanup_exc
+                finally:
+                    signal.pthread_sigmask(signal.SIG_SETMASK, prior)
+                raise GitError("Git validation timed out") from exc
+            if capture and len(stdout) > MAX_GIT_OUTPUT:
+                raise GitError("Git validation output is oversized")
+            return GitResult(ACTIVE_PROCESS.returncode, stdout if capture else b"")
+        except JobSignal as exc:
+            signal.pthread_sigmask(signal.SIG_BLOCK, SIGNALS)
+            try:
+                _terminate_process(ACTIVE_PROCESS)
+            finally:
+                signal.pthread_sigmask(signal.SIG_SETMASK, prior)
+            raise exc
+        finally:
+            ACTIVE_PROCESS = None
+
+
+def git(repo: Path, *arguments: str, capture: bool = True) -> bytes:
+    completed = git_result(repo, *arguments, capture=capture)
+    if completed.returncode != 0:
+        raise GitError("Git validation failed")
+    return completed.stdout if capture else b""
+
+
+def run_git(repo: Path, *arguments: str) -> int:
+    return git_result(repo, *arguments, capture=False).returncode
+
+
+def ref_value(repo: Path, reference: str) -> str | None:
+    existence = git_result(repo, "show-ref", "--verify", "--quiet", reference)
+    if existence.returncode == 1:
+        return None
+    if existence.returncode != 0:
+        raise GitError("Git ref validation failed")
+    completed = git_result(repo, "show-ref", "--verify", "--hash", reference)
+    if completed.returncode != 0:
+        raise GitError("Git ref validation failed")
+    try:
+        value = completed.stdout.decode("ascii", "strict").strip()
+    except UnicodeDecodeError as exc:
+        raise GitError("Git ref validation failed") from exc
+    if COMMIT_RE.fullmatch(value) is None:
+        raise GitError("Git ref validation failed")
+    return value
+
+
+def _config_key(record: bytes) -> bytes:
+    # `git config --null --get-regexp` separates key and value with a newline.
+    return record.split(b"\n", 1)[0]
+
+
+def validate_safe_git_checkout(repo: Path, base: str) -> None:
+    configured = git_result(
+        repo,
+        "config",
+        "--local",
+        "--includes",
+        "--null",
+        "--get-regexp",
+        r"^(filter\..*\.(clean|smudge|process|required)|core\.(fsmonitor|hooksPath|pager)|diff\.external|interactive\.diffFilter|pager\..*|include(If)?\..*)$",
+    )
+    if configured.returncode not in {0, 1}:
+        raise GitError("Git configuration validation failed")
+    if configured.returncode == 0:
+        records = [record for record in configured.stdout.split(b"\0") if record]
+        if (
+            not records
+            or any(
+                UNSAFE_GIT_CONFIG_RE.fullmatch(_config_key(record)) is None
+                for record in records
+            )
+        ):
+            raise JobError("Git configuration validation failed")
+        raise JobError("external Git configuration is not checkout-safe")
+
+    tree = git(repo, "ls-tree", "-r", "-z", "--name-only", base)
+    if len(tree) > MAX_ATTRIBUTE_PATH_BYTES:
+        raise JobError("base tree path inventory is oversized")
+    paths = [path for path in tree.split(b"\0") if path]
+    if len(paths) > MAX_DELETE_NODES:
+        raise JobError("base tree path inventory is oversized")
+    if any(b"\n" in path or b"\r" in path for path in paths):
+        raise JobError("base tree path inventory is invalid")
+    if not paths:
+        return
+    attributes = git_result(
+        repo,
+        "check-attr",
+        f"--source={base}",
+        "-z",
+        "--stdin",
+        "filter",
+        input_data=b"\0".join(paths) + b"\0",
+    )
+    if attributes.returncode != 0:
+        raise GitError("Git attribute validation failed")
+    fields = attributes.stdout.split(b"\0")
+    if fields and fields[-1] == b"":
+        fields.pop()
+    if len(fields) != len(paths) * 3:
+        raise JobError("Git attribute validation failed")
+    for index, path in enumerate(paths):
+        record = fields[index * 3:index * 3 + 3]
+        if (
+            record[0] != path
+            or record[1] != b"filter"
+            or record[2] not in {b"unspecified", b"unset"}
+        ):
+            raise JobError("external Git content filters are not checkout-safe")
+
+
+def canonical_repo(path: Path) -> tuple[Path, dict[str, int], Path, dict[str, int]]:
+    path = real_absolute(path, "repository")
+    metadata = path.lstat()
+    if not stat.S_ISDIR(metadata.st_mode) or stat.S_ISLNK(metadata.st_mode):
+        raise JobError("repository must be one real directory")
+    root = Path(git(path, "rev-parse", "--show-toplevel").decode("utf-8", "strict").strip())
+    if root != path:
+        raise JobError("repository must be the exact top-level worktree")
+    common_text = git(path, "rev-parse", "--git-common-dir").decode("utf-8", "strict").strip()
+    common = Path(common_text)
+    if not common.is_absolute():
+        common = path / common
+    common = Path(os.path.realpath(common))
+    common_metadata = common.lstat()
+    if not stat.S_ISDIR(common_metadata.st_mode) or stat.S_ISLNK(common_metadata.st_mode):
+        raise JobError("Git common directory must be real")
+    return path, identity(metadata), common, identity(common_metadata)
+
+
+def validate_branch(repo: Path, branch: str) -> str:
+    if not canonical_branch_syntax(branch):
+        raise JobError("branch is invalid")
+    completed = git_result(repo, "check-ref-format", "--branch", branch)
+    if completed.returncode != 0:
+        raise JobError("branch is invalid")
+    expected = branch.encode("utf-8", "strict") + b"\n"
+    if completed.stdout != expected:
+        raise JobError("branch shorthand or canonicalization is forbidden")
+    return f"refs/heads/{branch}"
+
+
+def validate_base(repo: Path, base: str) -> None:
+    if COMMIT_RE.fullmatch(base) is None:
+        raise JobError("base must be one full immutable commit ID")
+    resolved = git(repo, "rev-parse", "--verify", f"{base}^{{commit}}").decode("ascii").strip()
+    if resolved != base:
+        raise JobError("base did not resolve exactly")
+
+
+def output_state(state: dict[str, Any], digest: str) -> None:
+    result: dict[str, Any] = {
+        "cleanup_authorized": False,
+        "job_id": state["job_id"],
+        "phase": state["phase"],
+        "state_sha256": digest,
+    }
+    if state["last_result"] is not None:
+        result["last_result"] = state["last_result"]
+    print(canonical_bytes(result).decode("ascii"), end="")
+
+
+def initial_state(args: argparse.Namespace) -> tuple[dict[str, Any], Path, Path]:
+    if JOB_RE.fullmatch(args.job_id or "") is None:
+        raise JobError("job ID is invalid")
+    repo, repo_id, common, common_id = canonical_repo(Path(args.repo))
+    validate_base(repo, args.base)
+    validate_safe_git_checkout(repo, args.base)
+    branch_ref = validate_branch(repo, args.branch)
+    if ref_value(repo, branch_ref) is not None:
+        raise JobError("branch already exists")
+    worktree = real_absolute(Path(args.worktree), "worktree", must_exist=False)
+    if worktree.exists() or worktree.is_symlink():
+        raise JobError("worktree path already exists")
+    worktree_parent = real_absolute(worktree.parent, "worktree parent")
+    if contains(repo, worktree) or contains(worktree, repo):
+        raise JobError("worktree must be outside the repository")
+    state_path = Path(args.state)
+    if contains(repo, state_path) or contains(worktree, state_path):
+        raise JobError("state must be outside repository and worktree")
+    state = {
+        "schema_version": 1,
+        "kind": "agy-worker-local-job-state",
+        "sequence": 1,
+        "previous_state_sha256": None,
+        "phase": "initializing",
+        "job_id": args.job_id,
+        "repo_path": str(repo),
+        "repo_identity": repo_id,
+        "git_common_dir": str(common),
+        "git_common_identity": common_id,
+        "worktree_path": str(worktree),
+        "worktree_parent_device": worktree_parent.lstat().st_dev,
+        "worktree_identity": None,
+        "branch": branch_ref.removeprefix("refs/heads/"),
+        "branch_ref": branch_ref,
+        "base": args.base,
+        "receipt": None,
+        "cleanup_step": "none",
+        "last_result": None,
+        "failure": None,
+    }
+    return state, repo, worktree
+
+
+def command_init(args: argparse.Namespace) -> int:
+    state, repo, worktree = initial_state(args)
+    store = StateStore(Path(args.state), initial=True)
+    try:
+        store.create(state)
+        try:
+            rc = run_git(
+                repo,
+                "worktree", "add", "-b", state["branch"], str(worktree), state["base"],
+            )
+            if rc != 0:
+                store.update({"phase": "init-failed", "failure": "init-failed", "last_result": rc})
+                output_state(store.value, store.sha256)  # type: ignore[arg-type]
+                return 1
+            facts = validate_ready_state(state)
+            store.update({"phase": "ready", "worktree_identity": facts["worktree_identity"]})
+            output_state(store.value, store.sha256)  # type: ignore[arg-type]
+            return 0
+        except JobSignal as exc:
+            store.update({"phase": "init-interrupted", "failure": "interrupted", "last_result": 128 + exc.number})
+            output_state(store.value, store.sha256)  # type: ignore[arg-type]
+            return 128 + exc.number
+        except (JobError, OSError):
+            store.update({"phase": "init-failed", "failure": "init-failed", "last_result": 1})
+            output_state(store.value, store.sha256)  # type: ignore[arg-type]
+            return 1
+    finally:
+        store.close()
+
+
+def worktree_records(repo: Path) -> list[dict[str, str]]:
+    raw = git(repo, "worktree", "list", "--porcelain", "-z")
+    records: list[dict[str, str]] = []
+    current: dict[str, str] = {}
+    for token in raw.split(b"\0"):
+        if not token:
+            if current:
+                records.append(current)
+                current = {}
+            continue
+        text = token.decode("utf-8", "strict")
+        key, separator, value = text.partition(" ")
+        current[key] = value if separator else "true"
+    if current:
+        records.append(current)
+    return records
+
+
+def validate_repo_binding(state: dict[str, Any]) -> Path:
+    repo, repo_id, common, common_id = canonical_repo(Path(state["repo_path"]))
+    if repo_id != state["repo_identity"] or str(common) != state["git_common_dir"] or common_id != state["git_common_identity"]:
+        raise JobError("repository binding changed")
+    return repo
+
+
+def validate_ready_state(state: dict[str, Any]) -> dict[str, Any]:
+    repo = validate_repo_binding(state)
+    worktree = real_absolute(Path(state["worktree_path"]), "worktree")
+    metadata = worktree.lstat()
+    if not stat.S_ISDIR(metadata.st_mode) or stat.S_ISLNK(metadata.st_mode):
+        raise JobError("worktree is not one real directory")
+    records = [record for record in worktree_records(repo) if record.get("worktree") == str(worktree)]
+    if len(records) != 1:
+        raise JobError("worktree registration changed")
+    record = records[0]
+    if record.get("HEAD") != state["base"] or record.get("branch") != state["branch_ref"]:
+        raise JobError("worktree registration changed")
+    head = git(worktree, "rev-parse", "HEAD").decode("ascii").strip()
+    symbolic = git(worktree, "symbolic-ref", "-q", "HEAD").decode("utf-8", "strict").strip()
+    branch_value = git(repo, "rev-parse", "--verify", state["branch_ref"]).decode("ascii").strip()
+    if head != state["base"] or branch_value != state["base"] or symbolic != state["branch_ref"]:
+        raise JobError("branch or worktree HEAD moved")
+    expected = state["worktree_identity"]
+    current_identity = identity(metadata)
+    if expected is not None and current_identity != expected:
+        raise JobError("worktree identity changed")
+    if worktree.parent.lstat().st_dev != state["worktree_parent_device"]:
+        raise JobError("worktree parent device changed")
+    return {"repo": repo, "worktree": worktree, "worktree_identity": current_identity}
+
+
+def _receipt_binding(path: Path, expected_exit: int, base: str) -> dict[str, Any]:
+    path = real_absolute(path, "receipt")
+    raw, _metadata = read_regular(path, MAX_RECEIPT_BYTES, "receipt", private=True)
+    scripts_root = SCRIPTS.parent
+    schema = load_schema(scripts_root / "schemas/evidence-receipt.schema.json")
+    try:
+        receipt = validate_receipt(parse_json_bytes(raw, "receipt"), schema)
+    except ValidationFailure as exc:
+        raise JobError("receipt is invalid") from exc
+    if receipt["gate_exit"] != expected_exit or receipt["resolved_base"] != base:
+        raise JobError("receipt outcome or base is unbound")
+    return {
+        "path": str(path),
+        "sha256": sha256_bytes(raw),
+        "gate_exit": receipt["gate_exit"],
+        "verdict": receipt["verdict"],
+        "final_candidate_state_sha256": receipt["final_candidate_state_sha256"],
+    }
+
+
+def command_verify(args: argparse.Namespace) -> int:
+    store = StateStore(Path(args.state))
+    try:
+        state = store.value
+        assert state is not None
+        if state["phase"] not in {"ready", "verify-failed"}:
+            raise JobError("state is not eligible for verification")
+        facts = validate_ready_state(state)
+        receipt = real_absolute(Path(args.receipt), "receipt", must_exist=False)
+        if receipt.exists() or receipt.is_symlink():
+            raise JobError("receipt path already exists")
+        store.update({"phase": "verifying", "failure": None, "last_result": None, "receipt": None})
+        runtime = SCRIPTS.parent
+        command = [
+            str(runtime / "verify-job.sh"), "--receipt", str(receipt),
+            "--envelope", args.envelope, "--repo", str(facts["worktree"]),
+            "--base", state["base"],
+        ]
+        for value in args.allow:
+            command += ["--allow", value]
+        for value in args.only:
+            command += ["--only", value]
+        if args.expect_edits:
+            command.append("--expect-edits")
+        for value in args.verify:
+            command += ["--verify", value]
+        if args.selection:
+            command += ["--selection", args.selection]
+        if args.pre_recommendation:
+            command += ["--pre-recommendation", args.pre_recommendation]
+        try:
+            rc = run_process(command)
+        except JobSignal as exc:
+            store.update({"phase": "verify-interrupted", "failure": "interrupted", "last_result": 128 + exc.number})
+            output_state(store.value, store.sha256)  # type: ignore[arg-type]
+            return 128 + exc.number
+        if rc in {0, 10, 11, 12, 13, 14, 15}:
+            binding = _receipt_binding(receipt, rc, state["base"])
+            current = candidate_state_digest(
+                facts["worktree"], state["base"], git_reader=git
+            )
+            if binding["final_candidate_state_sha256"] != current:
+                raise JobError("receipt does not bind the current candidate")
+            phase = (
+                "verified-gate-passed" if rc == 0
+                else "verified-routed" if rc == 15
+                else "verified-rejected"
+            )
+            store.update({"phase": phase, "receipt": binding, "failure": None, "last_result": rc})
+        else:
+            if receipt.exists() or receipt.is_symlink():
+                raise JobError("failed verification left an unbound receipt")
+            store.update({"phase": "verify-failed", "failure": "verify-failed", "last_result": rc})
+        output_state(store.value, store.sha256)  # type: ignore[arg-type]
+        return rc
+    except (JobError, CandidateStateError, OSError):
+        if store.value is not None and store.value["phase"] == "verifying":
+            try:
+                store.update({"phase": "verify-failed", "failure": "verify-failed", "last_result": 1})
+            except (JobError, OSError):
+                pass
+        raise
+    finally:
+        store.close()
+
+
+def validate_receipt_binding(state: dict[str, Any]) -> dict[str, Any]:
+    binding = state["receipt"]
+    if not isinstance(binding, dict):
+        raise JobError("rejected state has no receipt binding")
+    current = _receipt_binding(Path(binding["path"]), binding["gate_exit"], state["base"])
+    if current != binding:
+        raise JobError("receipt binding changed")
+    if current["gate_exit"] not in {10, 11, 12, 13, 14} or current["verdict"] != "rejected":
+        raise JobError("receipt is not cleanup-eligible")
+    return current
+
+
+def scan_deletion_domain(worktree: Path) -> None:
+    root = worktree.lstat()
+    root_device = root.st_dev
+    seen = 0
+    for directory, names, files in os.walk(worktree, topdown=True, followlinks=False):
+        directory_path = Path(directory)
+        metadata = directory_path.lstat()
+        if not stat.S_ISDIR(metadata.st_mode) or metadata.st_dev != root_device:
+            raise JobError("worktree crosses a device or mount boundary")
+        for name in [*names, *files]:
+            seen += 1
+            if seen > MAX_DELETE_NODES:
+                raise JobError("worktree deletion domain is oversized")
+            path = directory_path / name
+            item = path.lstat()
+            relative = path.relative_to(worktree)
+            if item.st_dev != root_device:
+                raise JobError("worktree crosses a device or mount boundary")
+            if name == ".git" and relative != Path(".git"):
+                raise JobError("nested repository or initialized submodule is not disposable")
+            # Candidate-state evidence binds a symlink's path, mode, and target.
+            # os.walk never follows it, so removal can delete only the link node;
+            # its target remains outside the proven deletion domain.
+            if not (
+                stat.S_ISREG(item.st_mode)
+                or stat.S_ISDIR(item.st_mode)
+                or stat.S_ISLNK(item.st_mode)
+            ):
+                raise JobError("special nodes are not cleanup-eligible")
+
+
+def _cleanup_reconcile(store: StateStore) -> None:
+    state = store.value
+    assert state is not None
+    repo = validate_repo_binding(state)
+    worktree = Path(state["worktree_path"])
+    registered = any(record.get("worktree") == str(worktree) for record in worktree_records(repo))
+    if not registered and not worktree.exists() and state["cleanup_step"] == "none":
+        store.update({"cleanup_step": "worktree-removed"})
+        state = store.value
+        assert state is not None
+    ref_exists = ref_value(repo, state["branch_ref"]) is not None
+    if not ref_exists and state["cleanup_step"] == "worktree-removed":
+        store.update({"cleanup_step": "branch-removed", "phase": "cleaned", "failure": None, "last_result": 0})
+
+
+def _cleanup_checkpoint(_name: str) -> None:
+    """Test-only callable; production has no CLI or environment override."""
+
+
+def command_cleanup(args: argparse.Namespace) -> int:
+    store = StateStore(Path(args.state))
+    try:
+        state = store.value
+        assert state is not None and store.sha256 is not None
+        if args.approve_job != state["job_id"]:
+            raise JobError("cleanup job approval does not match")
+        if args.approve_state_sha != store.sha256:
+            raise JobError("cleanup state approval does not match current bytes")
+        if not isinstance(args.approve_candidate_sha, str) or SHA_RE.fullmatch(args.approve_candidate_sha) is None:
+            raise JobError("cleanup candidate approval is invalid")
+        if state["phase"] not in {"verified-rejected", "cleanup-in-progress"}:
+            raise JobError("state is not cleanup-eligible")
+        receipt = validate_receipt_binding(state)
+        if args.approve_candidate_sha != receipt["final_candidate_state_sha256"]:
+            raise JobError("cleanup candidate approval does not match receipt")
+        if state["phase"] == "cleanup-in-progress":
+            approved_sha = store.sha256
+            _cleanup_reconcile(store)
+            state = store.value
+            assert state is not None and store.sha256 is not None
+            if state["phase"] == "cleaned":
+                output_state(state, store.sha256)
+                return 0
+            if store.sha256 != approved_sha:
+                # Reconciliation is observational only. Never spend approval for
+                # old bytes on the next destructive step; print the new binding
+                # and require a fresh invocation with its SHA.
+                output_state(state, store.sha256)
+                return 74
+        facts: dict[str, Any] | None = None
+        if state["cleanup_step"] == "none":
+            facts = validate_ready_state(state)
+            scan_deletion_domain(facts["worktree"])
+            current = candidate_state_digest(
+                facts["worktree"], state["base"], git_reader=git
+            )
+            if current != args.approve_candidate_sha:
+                raise JobError("candidate changed after verification")
+        if state["phase"] != "cleanup-in-progress":
+            store.update({"phase": "cleanup-in-progress", "failure": None, "last_result": None})
+            state = store.value
+            assert state is not None
+        if state["cleanup_step"] == "none":
+            facts = validate_ready_state(state)
+            scan_deletion_domain(facts["worktree"])
+            if candidate_state_digest(
+                facts["worktree"], state["base"], git_reader=git
+            ) != args.approve_candidate_sha:
+                raise JobError("candidate changed before cleanup")
+            _cleanup_checkpoint("before-worktree-remove")
+            rc = run_git(
+                facts["repo"], "worktree", "remove", "--force", str(facts["worktree"])
+            )
+            if rc != 0:
+                raise JobError("worktree removal failed")
+            if facts["worktree"].exists() or any(
+                record.get("worktree") == str(facts["worktree"])
+                for record in worktree_records(facts["repo"])
+            ):
+                raise JobError("worktree removal was incomplete")
+            store.update({"cleanup_step": "worktree-removed"})
+            state = store.value
+            assert state is not None
+        if state["cleanup_step"] == "worktree-removed":
+            repo = validate_repo_binding(state)
+            worktree = Path(state["worktree_path"])
+            if worktree.exists() or any(
+                record.get("worktree") == str(worktree) for record in worktree_records(repo)
+            ):
+                raise JobError("removed worktree step does not match Git reality")
+            if ref_value(repo, state["branch_ref"]) != state["base"]:
+                raise JobError("branch ref moved before compare-and-delete")
+            _cleanup_checkpoint("before-ref-delete")
+            rc = run_git(
+                repo, "update-ref", "-d", state["branch_ref"], state["base"]
+            )
+            if rc != 0:
+                raise JobError("compare-and-delete ref failed")
+            if ref_value(repo, state["branch_ref"]) is not None:
+                raise JobError("branch ref still exists")
+            store.update({"cleanup_step": "branch-removed", "phase": "cleaned", "failure": None, "last_result": 0})
+        output_state(store.value, store.sha256)  # type: ignore[arg-type]
+        return 0
+    except JobSignal as exc:
+        prior_mask = signal.pthread_sigmask(signal.SIG_BLOCK, SIGNALS)
+        try:
+            _cleanup_reconcile(store)
+            if store.value is not None and store.value["phase"] == "cleanup-in-progress":
+                store.update({"failure": "interrupted", "last_result": 128 + exc.number})
+        except (JobError, OSError):
+            pass
+        finally:
+            # The first signal is authoritative. Pending later lifecycle signals
+            # are delivered to the non-raising handler after cleanup completes.
+            signal.pthread_sigmask(signal.SIG_SETMASK, prior_mask)
+        output_state(store.value, store.sha256)  # type: ignore[arg-type]
+        return 128 + exc.number
+    except GitError:
+        # A fatal/transient ref observation after compare-delete is uncertainty,
+        # never proof of absence. Do not retry/reconcile it into `cleaned` in the
+        # same invocation; persist failure and require manual review plus a fresh
+        # approval-bound invocation.
+        if store.value is not None and store.value["phase"] == "cleanup-in-progress":
+            try:
+                store.update({"failure": "cleanup-failed", "last_result": 1})
+            except (JobError, OSError):
+                pass
+        raise
+    except (JobError, CandidateStateError, OSError):
+        if store.value is not None and store.value["phase"] == "cleanup-in-progress":
+            try:
+                _cleanup_reconcile(store)
+                if store.value is not None and store.value["phase"] == "cleanup-in-progress":
+                    store.update({"failure": "cleanup-failed", "last_result": 1})
+            except (JobError, OSError):
+                pass
+        raise
+    finally:
+        store.close()
+
+
+def status_facts(state: dict[str, Any]) -> dict[str, Any]:
+    result = {
+        "branch_matches": False,
+        "candidate_matches_receipt": False,
+        "receipt_candidate_state_sha256": None,
+        "cleanup_authorized": False,
+        "job_id": state["job_id"],
+        "phase": state["phase"],
+        "receipt_bound": False,
+        "worktree_registered": False,
+    }
+    try:
+        facts = validate_ready_state(state)
+        result["branch_matches"] = True
+        result["worktree_registered"] = True
+        if state["receipt"] is not None:
+            receipt = validate_receipt_binding(state)
+            result["receipt_bound"] = True
+            result["receipt_candidate_state_sha256"] = receipt["final_candidate_state_sha256"]
+            result["candidate_matches_receipt"] = (
+                candidate_state_digest(
+                    facts["worktree"], state["base"], git_reader=git
+                )
+                == receipt["final_candidate_state_sha256"]
+            )
+    except (JobError, CandidateStateError, OSError):
+        pass
+    return result
+
+
+def command_status(args: argparse.Namespace) -> int:
+    store = StateStore(Path(args.state))
+    try:
+        result = status_facts(store.value)  # type: ignore[arg-type]
+        result["state_sha256"] = store.sha256
+        print(canonical_bytes(result).decode("ascii"), end="")
+        return 0
+    finally:
+        store.close()
+
+
+def command_preserve(args: argparse.Namespace) -> int:
+    store = StateStore(Path(args.state))
+    try:
+        state = store.value
+        assert state is not None
+        if state["phase"] != "verified-gate-passed":
+            raise JobError("only gate-passed work receives preserve instructions")
+        validate_ready_state(state)
+        worktree = shlex.quote(state["worktree_path"])
+        repo = shlex.quote(state["repo_path"])
+        branch = shlex.quote(state["branch"])
+        print(f"git -C {worktree} status --short")
+        print(f"git -C {worktree} add -- REPLACE_WITH_REVIEWED_PATHS")
+        print(f"git -C {worktree} commit -m 'REPLACE_WITH_REVIEWED_MESSAGE'")
+        print(f"git -C {repo} worktree remove {worktree}")
+        print(f"# integrate {branch} only through your normal reviewed Git workflow")
+        return 0
+    finally:
+        store.close()
+
+
+def parser() -> argparse.ArgumentParser:
+    result = Parser(prog="job.sh")
+    commands = result.add_subparsers(dest="command", required=True, parser_class=Parser)
+    init = commands.add_parser("init")
+    for name in ("state", "repo", "worktree", "branch", "base", "job-id"):
+        init.add_argument(f"--{name}", action=Once, required=True)
+    status = commands.add_parser("status")
+    status.add_argument("--state", action=Once, required=True)
+    verify = commands.add_parser("verify")
+    verify.add_argument("--state", action=Once, required=True)
+    verify.add_argument("--receipt", action=Once, required=True)
+    verify.add_argument("--envelope", action=Once, required=True)
+    verify.add_argument("--allow", action="append", default=[])
+    verify.add_argument("--only", action="append", default=[])
+    verify.add_argument("--expect-edits", action=OnceTrue)
+    verify.add_argument("--verify", action="append", default=[])
+    verify.add_argument("--selection", action=Once)
+    verify.add_argument("--pre-recommendation", action=Once)
+    preserve = commands.add_parser("preserve-instructions")
+    preserve.add_argument("--state", action=Once, required=True)
+    cleanup = commands.add_parser("cleanup")
+    cleanup.add_argument("--state", action=Once, required=True)
+    cleanup.add_argument("--approve-job", action=Once, required=True)
+    cleanup.add_argument("--approve-state-sha", action=Once, required=True)
+    cleanup.add_argument("--approve-candidate-sha", action=Once, required=True)
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    global FIRST_SIGNAL
+    FIRST_SIGNAL = None
+    for number in SIGNALS:
+        signal.signal(number, _interrupt)
+    try:
+        args = parser().parse_args(argv)
+        if args.command == "init":
+            return command_init(args)
+        if args.command == "status":
+            return command_status(args)
+        if args.command == "verify":
+            if not args.verify or any(not item.strip() for item in args.verify):
+                raise JobError("verify needs at least one driver command")
+            return command_verify(args)
+        if args.command == "preserve-instructions":
+            return command_preserve(args)
+        if args.command == "cleanup":
+            return command_cleanup(args)
+        raise JobError("unknown command")
+    except JobSignal as exc:
+        print("job: interrupted", file=sys.stderr)
+        return 128 + exc.number
+    except JobError:
+        print("job: local lifecycle validation failed", file=sys.stderr)
+        return 64
+    except (OSError, CandidateStateError):
+        print("job: local lifecycle operation failed", file=sys.stderr)
+        return 74
+
+
+def process_main() -> None:
+    """Own signal handling through flush and atomic process termination."""
+    try:
+        result = main()
+        sys.stdout.flush()
+        sys.stderr.flush()
+    except JobSignal as exc:
+        # A first signal after command return but before termination still wins.
+        # _interrupt makes every later lifecycle signal non-raising.
+        result = 128 + exc.number
+        print("job: interrupted", file=sys.stderr)
+        sys.stdout.flush()
+        sys.stderr.flush()
+    os._exit(result)
+
+
+if __name__ == "__main__":
+    process_main()

--- a/skills/agy-worker/scripts/resolve-pipeline.sh
+++ b/skills/agy-worker/scripts/resolve-pipeline.sh
@@ -52,6 +52,7 @@ pipeline_runtime_complete() {
     done
     for required in \
         agy-worker.sh \
+        job.sh \
         qa-gate.sh \
         verify-job.sh \
         evidence-report.sh \
@@ -65,6 +66,8 @@ pipeline_runtime_complete() {
         scripts/model-recommendation.py \
         scripts/model_selection.py \
         scripts/compatibility.py \
+        scripts/candidate_state.py \
+        scripts/job_lifecycle.py \
         scripts/doctor-metadata.py; do
         case "$required" in
             */*) dependency_parent="${required%/*}" ;;
@@ -87,6 +90,7 @@ pipeline_runtime_complete() {
         schemas/evidence-receipt.schema.json \
         schemas/model-selection.schema.json \
         schemas/model-recommendation.schema.json \
+        schemas/job-state.schema.json \
         agents/bulk-test-writer.md \
         agents/repo-inventory.md \
         agents/diff-reviewer.md \

--- a/tests/test-doctor.sh
+++ b/tests/test-doctor.sh
@@ -746,11 +746,15 @@ else
 fi
 
 for dependency in \
+    'job.sh:lifecycle-entry' \
     'scripts/validate-envelope.py:python-helper' \
     'scripts/evidence_receipt.py:receipt-helper' \
+    'scripts/candidate_state.py:candidate-state-helper' \
+    'scripts/job_lifecycle.py:lifecycle-helper' \
     'scripts/model_selection.py:model-resolver' \
     'schemas/worker-result.schema.json:schema' \
     'schemas/evidence-receipt.schema.json:receipt-schema' \
+    'schemas/job-state.schema.json:lifecycle-schema' \
     'schemas/model-selection.schema.json:selection-schema' \
     'agents/repo-inventory.md:persona' \
     'compat/agy-upstream-head.txt:source-record' \

--- a/tests/test-job-lifecycle.py
+++ b/tests/test-job-lifecycle.py
@@ -1,0 +1,880 @@
+#!/usr/bin/env python3
+"""Offline adversarial tests for the branch-backed local job lifecycle."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import shutil
+import shlex
+import signal
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Any, Callable
+
+
+sys.dont_write_bytecode = True
+ROOT = Path(__file__).resolve().parents[1]
+RUNTIME = ROOT / "skills" / "agy-worker" / "runtime"
+MODULE_PATH = RUNTIME / "scripts" / "job_lifecycle.py"
+CANDIDATE_PATH = RUNTIME / "scripts" / "candidate_state.py"
+PYTHON = "/usr/bin/python3"
+
+
+def load(name: str, path: Path) -> Any:
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+MODULE = load("job_lifecycle_tested", MODULE_PATH)
+CANDIDATE = sys.modules["candidate_state"]
+TMP = Path(tempfile.mkdtemp(prefix="agyworker-job-lifecycle-tests.")).resolve()
+TMP.chmod(0o700)
+passed = 0
+failed = 0
+
+
+def check(name: str, predicate: Callable[[], bool]) -> None:
+    global passed, failed
+    try:
+        result = bool(predicate())
+    except BaseException as exc:
+        result = False
+        detail = f" ({type(exc).__name__}: {exc})"
+    else:
+        detail = ""
+    if result:
+        passed += 1
+    else:
+        failed += 1
+        print(f"FAIL job lifecycle: {name}{detail}")
+
+
+def rejects(action: Callable[[], object]) -> bool:
+    try:
+        action()
+    except (MODULE.JobError, CANDIDATE.CandidateStateError, OSError, ValueError):
+        return True
+    return False
+
+
+def git(repo: Path, *args: str, check_result: bool = True) -> bytes:
+    completed = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    if check_result and completed.returncode != 0:
+        raise AssertionError(f"git failed: {args!r}")
+    return completed.stdout
+
+
+def make_repo(label: str) -> tuple[Path, str]:
+    repo = TMP / label
+    repo.mkdir(mode=0o700)
+    git(repo, "init", "-q")
+    git(repo, "config", "user.name", "test")
+    git(repo, "config", "user.email", "test@example.com")
+    (repo / "fixture.txt").write_bytes(b"before\n")
+    git(repo, "add", "fixture.txt")
+    git(repo, "commit", "-qm", "base")
+    return repo, git(repo, "rev-parse", "HEAD").decode("ascii").strip()
+
+
+def canonical(value: object) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("ascii") + b"\n"
+
+
+def run_cli(
+    *args: str,
+    timeout: float = 20.0,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        [PYTHON, "-I", "-S", "-B", str(MODULE_PATH), *args],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+        check=False,
+        env=env,
+    )
+
+
+class Fixture:
+    def __init__(self, label: str) -> None:
+        self.root = TMP / label
+        self.root.mkdir(mode=0o700)
+        self.repo, self.base = make_repo(f"{label}-repo")
+        self.state_dir = self.root / "state"
+        self.state_dir.mkdir(mode=0o700)
+        self.state = self.state_dir / "job.json"
+        self.worktree = self.root / "worktree"
+        self.receipt = self.state_dir / "receipt.json"
+        self.envelope = self.state_dir / "envelope.json"
+        self.job_id = f"job-{label}"
+        self.branch = f"codex/{label}"
+
+    def init(self) -> subprocess.CompletedProcess[bytes]:
+        return self.init_as(self.branch)
+
+    def init_as(
+        self,
+        branch: str,
+        *,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[bytes]:
+        return run_cli(
+            "init", "--state", str(self.state), "--repo", str(self.repo),
+            "--worktree", str(self.worktree), "--branch", branch,
+            "--base", self.base, "--job-id", self.job_id,
+            env=env,
+        )
+
+    def value(self) -> dict[str, Any]:
+        return json.loads(self.state.read_bytes())
+
+    def state_sha(self) -> str:
+        return hashlib.sha256(self.state.read_bytes()).hexdigest()
+
+    def write_envelope(self, *, changed: bool = True) -> None:
+        value = {
+            "status": "completed", "summary": "synthetic",
+            "files_changed": ([{"path": "fixture.txt", "change": "modified"}] if changed else []),
+            "commands_run": [], "tests_run": [], "risks": [], "open_questions": [],
+            "confidence": 1, "requires_human": False,
+        }
+        self.envelope.write_bytes(canonical(value))
+        self.envelope.chmod(0o600)
+
+    def verify_reject(self) -> subprocess.CompletedProcess[bytes]:
+        self.write_envelope()
+        return run_cli(
+            "verify", "--state", str(self.state), "--receipt", str(self.receipt),
+            "--envelope", str(self.envelope), "--only", "tests/**", "--verify", "true",
+        )
+
+    def cleanup(self, *, state_sha: str | None = None, job: str | None = None, candidate: str | None = None) -> subprocess.CompletedProcess[bytes]:
+        value = self.value()
+        bound = value.get("receipt") or {}
+        return run_cli(
+            "cleanup", "--state", str(self.state),
+            "--approve-job", job or self.job_id,
+            "--approve-state-sha", state_sha or self.state_sha(),
+            "--approve-candidate-sha", candidate or bound.get("final_candidate_state_sha256", "0" * 64),
+        )
+
+
+def clean_fixture(fixture: Fixture) -> None:
+    git(fixture.repo, "worktree", "remove", "--force", str(fixture.worktree), check_result=False)
+    git(fixture.repo, "update-ref", "-d", f"refs/heads/{fixture.branch}", fixture.base, check_result=False)
+
+
+check("module imports with bytecode disabled", lambda: sys.dont_write_bytecode)
+check("root wrapper is executable", lambda: os.access(ROOT / "job.sh", os.X_OK))
+check("portable wrapper is executable", lambda: os.access(RUNTIME / "job.sh", os.X_OK))
+check("candidate helper is executable", lambda: os.access(CANDIDATE_PATH, os.X_OK))
+check("state schema is present", lambda: (RUNTIME / "schemas" / "job-state.schema.json").is_file())
+
+
+def candidate_reference(repo: Path, base: str) -> str:
+    digest = hashlib.sha256()
+    tracked = git(repo, "diff", "--binary", "--no-ext-diff", "--no-textconv", "--submodule=short", base, "--")
+    digest.update(len(tracked).to_bytes(8, "big")); digest.update(tracked)
+    paths = set(part for part in git(repo, "ls-files", "--others", "--exclude-standard", "-z", "--").split(b"\0") if part)
+    paths.update(part for part in git(repo, "ls-files", "--others", "--ignored", "--exclude-standard", "-z", "--").split(b"\0") if part)
+    for raw in sorted(paths):
+        path = repo / raw.decode("utf-8", "surrogateescape")
+        info = path.lstat()
+        digest.update(len(raw).to_bytes(8, "big")); digest.update(raw)
+        digest.update(str(stat.S_IFMT(info.st_mode)).encode("ascii")); digest.update(str(stat.S_IMODE(info.st_mode)).encode("ascii"))
+        if stat.S_ISLNK(info.st_mode):
+            digest.update(os.readlink(path).encode("utf-8", "surrogateescape"))
+        elif stat.S_ISREG(info.st_mode):
+            digest.update(path.read_bytes())
+        else:
+            digest.update(b"non-regular")
+    return digest.hexdigest()
+
+
+repo, base = make_repo("candidate-parity")
+(repo / ".gitignore").write_text("ignored.txt\n", encoding="utf-8")
+(repo / "ignored.txt").write_text("ignored\n", encoding="utf-8")
+(repo / "untracked.txt").write_text("untracked\n", encoding="utf-8")
+(repo / "link").symlink_to("fixture.txt")
+(repo / "fixture.txt").write_text("changed\n", encoding="utf-8")
+check("shared candidate digest exactly matches legacy gate algorithm", lambda: CANDIDATE.candidate_state_digest(repo, base) == candidate_reference(repo, base))
+before = CANDIDATE.candidate_state_digest(repo, base)
+(repo / "ignored.txt").write_text("mutated\n", encoding="utf-8")
+check("shared candidate digest binds ignored artifacts", lambda: CANDIDATE.candidate_state_digest(repo, base) != before)
+check("candidate CLI rejects repeated repo authority", lambda: CANDIDATE.main(["--repo", str(repo), "--repo", str(repo), "--base", base]) == 64)
+check("candidate CLI rejects symbolic base", lambda: CANDIDATE.main(["--repo", str(repo), "--base", "HEAD"]) == 1)
+
+
+def private_parent_pair() -> bool:
+    parent = TMP / "private-parent"
+    parent.mkdir(mode=0o700)
+    path, descriptor = MODULE.validate_private_parent(parent)
+    os.close(descriptor)
+    accepted = path == parent
+    parent.chmod(0o755)
+    return accepted and rejects(lambda: MODULE.validate_private_parent(parent))
+
+
+check("state parent accepts owner 0700 and rejects 0755", private_parent_pair)
+check("state path rejects canonical alias", lambda: rejects(lambda: MODULE.real_absolute(Path("/var/tmp"), "test")))
+
+
+branch_fixture = Fixture("branch-alias")
+original_branch = git(branch_fixture.repo, "symbolic-ref", "--short", "HEAD").decode().strip()
+git(branch_fixture.repo, "checkout", "-qb", "old")
+git(branch_fixture.repo, "checkout", "-q", original_branch)
+alias_result = branch_fixture.init_as("@{-1}")
+check(
+    "checkout shorthand is rejected before any ref worktree or state is created",
+    lambda: (
+        alias_result.returncode == 64
+        and not branch_fixture.state.exists()
+        and not branch_fixture.worktree.exists()
+        and git(
+            branch_fixture.repo,
+            "show-ref",
+            "--verify",
+            "--quiet",
+            "refs/heads/@{-1}",
+            check_result=False,
+        ) == b""
+        and git(branch_fixture.repo, "worktree", "list", "--porcelain").count(b"worktree ") == 1
+    ),
+)
+original_branch_syntax = MODULE.canonical_branch_syntax
+try:
+    MODULE.canonical_branch_syntax = lambda _branch: True
+    check(
+        "canonical check-ref stdout independently rejects checkout shorthand",
+        lambda: rejects(lambda: MODULE.validate_branch(branch_fixture.repo, "@{-1}")),
+    )
+finally:
+    MODULE.canonical_branch_syntax = original_branch_syntax
+for bad_branch in ("main@{1}", "main~1", "main^", "main:next", "main*", "main?", "main[0]", "main\\next"):
+    check(
+        f"revision or metachar branch is rejected: {bad_branch}",
+        lambda bad_branch=bad_branch: rejects(
+            lambda: MODULE.validate_branch(branch_fixture.repo, bad_branch)
+        ),
+    )
+
+
+def write_executable(path: Path, body: str) -> None:
+    path.write_text("#!/bin/sh\n" + body, encoding="utf-8")
+    path.chmod(0o700)
+
+
+hook_fixture = Fixture("hook-policy")
+hook_marker = hook_fixture.root / "hook.marker"
+late_marker = hook_fixture.root / "hook-late.marker"
+hooks = hook_fixture.repo / ".git" / "hooks"
+write_executable(
+    hooks / "post-checkout",
+    f"printf ran > {shlex.quote(str(hook_marker))}\n(sleep 1; printf late > {shlex.quote(str(late_marker))}) &\n",
+)
+write_executable(
+    hooks / "pre-checkout",
+    f"printf ran > {shlex.quote(str(hook_marker))}\n",
+)
+hook_init = hook_fixture.init()
+time.sleep(1.1)
+check(
+    "private empty hooks policy suppresses checkout hooks and descendants",
+    lambda: hook_init.returncode == 0 and not hook_marker.exists() and not late_marker.exists(),
+)
+clean_fixture(hook_fixture)
+
+
+attribute_fixture = Fixture("attribute-filter")
+(attribute_fixture.repo / ".gitattributes").write_text("fixture.txt filter=missing-driver\n", encoding="utf-8")
+git(attribute_fixture.repo, "add", ".gitattributes")
+git(attribute_fixture.repo, "commit", "-qm", "attributes")
+attribute_fixture.base = git(attribute_fixture.repo, "rev-parse", "HEAD").decode().strip()
+attribute_init = attribute_fixture.init()
+check(
+    "effective base-tree filter attributes reject before initialization",
+    lambda: attribute_init.returncode == 64 and not attribute_fixture.state.exists() and not attribute_fixture.worktree.exists(),
+)
+
+info_attribute_fixture = Fixture("info-attribute-filter")
+(info_attribute_fixture.repo / ".git" / "info" / "attributes").write_text(
+    "fixture.txt filter=info-driver\n", encoding="utf-8"
+)
+info_attribute_init = info_attribute_fixture.init()
+check(
+    "repository info attributes cannot authorize a checkout filter",
+    lambda: info_attribute_init.returncode == 64 and not info_attribute_fixture.state.exists(),
+)
+
+
+filter_fixture = Fixture("configured-filter")
+filter_marker = filter_fixture.root / "filter.marker"
+filter_program = filter_fixture.root / "filter.sh"
+write_executable(filter_program, f"printf ran > {shlex.quote(str(filter_marker))}\ncat\n")
+(filter_fixture.repo / ".gitattributes").write_text("fixture.txt filter=danger\n", encoding="utf-8")
+git(filter_fixture.repo, "add", ".gitattributes")
+git(filter_fixture.repo, "commit", "-qm", "filter attributes")
+filter_fixture.base = git(filter_fixture.repo, "rev-parse", "HEAD").decode().strip()
+git(filter_fixture.repo, "config", "filter.danger.smudge", str(filter_program))
+git(filter_fixture.repo, "config", "filter.danger.process", str(filter_program))
+filter_init = filter_fixture.init()
+check(
+    "smudge and process filters reject with zero external execution",
+    lambda: filter_init.returncode == 64 and not filter_marker.exists() and not filter_fixture.state.exists(),
+)
+
+
+config_fixture = Fixture("external-config")
+config_marker = config_fixture.root / "config.marker"
+config_program = config_fixture.root / "config.sh"
+write_executable(config_program, f"printf ran > {shlex.quote(str(config_marker))}\n")
+git(config_fixture.repo, "config", "core.fsmonitor", str(config_program))
+config_init = config_fixture.init()
+check(
+    "configured fsmonitor rejects with zero execution",
+    lambda: config_init.returncode == 64 and not config_marker.exists(),
+)
+
+
+pager_fixture = Fixture("pager-config")
+pager_marker = pager_fixture.root / "pager.marker"
+pager_program = pager_fixture.root / "pager.sh"
+write_executable(pager_program, f"printf ran > {shlex.quote(str(pager_marker))}\ncat\n")
+git(pager_fixture.repo, "config", "core.pager", str(pager_program))
+pager_init = pager_fixture.init()
+check(
+    "configured pager rejects with zero execution",
+    lambda: pager_init.returncode == 64 and not pager_marker.exists(),
+)
+
+
+alias_fixture = Fixture("git-alias")
+alias_marker = alias_fixture.root / "alias.marker"
+git(alias_fixture.repo, "config", "alias.worktree", f"!printf ran > {alias_marker}")
+alias_init = alias_fixture.init()
+check(
+    "exact built-in Git commands never execute a hostile alias",
+    lambda: alias_init.returncode == 0 and not alias_marker.exists(),
+)
+clean_fixture(alias_fixture)
+
+
+ambient_fixture = Fixture("ambient-config")
+ambient_marker = ambient_fixture.root / "ambient.marker"
+ambient_hooks = ambient_fixture.root / "ambient-hooks"
+ambient_hooks.mkdir(mode=0o700)
+write_executable(
+    ambient_hooks / "post-checkout",
+    f"printf ran > {shlex.quote(str(ambient_marker))}\n",
+)
+global_config = ambient_fixture.root / "global.gitconfig"
+global_config.write_text(f"[core]\n\thooksPath = {ambient_hooks}\n", encoding="utf-8")
+hostile_env = dict(os.environ)
+hostile_env.update(
+    {
+        "GIT_CONFIG_GLOBAL": str(global_config),
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "core.hooksPath",
+        "GIT_CONFIG_VALUE_0": str(ambient_hooks),
+        "GIT_PAGER": str(config_program),
+        "GIT_EXTERNAL_DIFF": str(config_program),
+    }
+)
+ambient_init = ambient_fixture.init_as(ambient_fixture.branch, env=hostile_env)
+check(
+    "ambient Git config environment and external helpers are stripped",
+    lambda: ambient_init.returncode == 0 and not ambient_marker.exists() and not config_marker.exists(),
+)
+clean_fixture(ambient_fixture)
+
+check(
+    "fatal ref probe is never classified as absence",
+    lambda: rejects(lambda: MODULE.ref_value(TMP / "not-a-repository", "refs/heads/missing")),
+)
+
+
+fixture = Fixture("happy")
+init = fixture.init()
+check("init creates exact branch-backed ready state", lambda: init.returncode == 0 and fixture.value()["phase"] == "ready")
+check("state is canonical owner-private mode 0600", lambda: fixture.state.read_bytes() == canonical(fixture.value()) and stat.S_IMODE(fixture.state.stat().st_mode) == 0o600)
+check("init uses explicit immutable base", lambda: git(fixture.worktree, "rev-parse", "HEAD").decode().strip() == fixture.base)
+check("init binds exact branch ref", lambda: git(fixture.worktree, "symbolic-ref", "HEAD").decode().strip() == f"refs/heads/{fixture.branch}")
+status = run_cli("status", "--state", str(fixture.state))
+status_value = json.loads(status.stdout)
+check("status is read-only and grants zero cleanup authority", lambda: status.returncode == 0 and status_value["cleanup_authorized"] is False and status_value["phase"] == "ready")
+check("preserve instructions reject unverified state", lambda: run_cli("preserve-instructions", "--state", str(fixture.state)).returncode == 64)
+
+original = fixture.value()
+mutated = dict(original); mutated["previous_state_sha256"] = None
+check("state history rejects a missing digest after sequence one", lambda: rejects(lambda: MODULE.validate_state(mutated)))
+mutated = dict(original); mutated["branch_ref"] = "refs/heads/other"
+check("state rejects branch and ref mismatch", lambda: rejects(lambda: MODULE.validate_state(mutated)))
+mutated = dict(original); mutated["phase"] = "verified-rejected"
+check("state rejects phase fields without a receipt", lambda: rejects(lambda: MODULE.validate_state(mutated)))
+mutated = dict(original); mutated["repo_path"] += "/../x"
+check("state rejects noncanonical bound paths", lambda: rejects(lambda: MODULE.validate_state(mutated)))
+
+
+fixture.worktree.joinpath("fixture.txt").write_text("worker edit\n", encoding="utf-8")
+outside_target = fixture.root / "outside-sentinel.txt"
+outside_target.write_text("preserve\n", encoding="utf-8")
+link = fixture.worktree / "bound-link"
+link.symlink_to(outside_target)
+verify = fixture.verify_reject()
+check("verify delegates to qa-gate and records rejected receipt", lambda: verify.returncode == 10 and fixture.value()["phase"] == "verified-rejected")
+rejected = fixture.value()
+check("receipt path raw hash and candidate digest are bound", lambda: rejected["receipt"]["sha256"] == hashlib.sha256(fixture.receipt.read_bytes()).hexdigest() and rejected["receipt"]["final_candidate_state_sha256"] == CANDIDATE.candidate_state_digest(fixture.worktree, fixture.base))
+rejected_status = json.loads(run_cli("status", "--state", str(fixture.state)).stdout)
+check("status exposes exact approval hashes but grants no cleanup authority", lambda: rejected_status["state_sha256"] == fixture.state_sha() and rejected_status["receipt_candidate_state_sha256"] == rejected["receipt"]["final_candidate_state_sha256"] and rejected_status["cleanup_authorized"] is False)
+check("cleanup rejects wrong job approval", lambda: fixture.cleanup(job="other-job").returncode == 64)
+check("cleanup rejects stale state approval", lambda: fixture.cleanup(state_sha="0" * 64).returncode == 64)
+check("cleanup rejects wrong candidate approval", lambda: fixture.cleanup(candidate="0" * 64).returncode == 64)
+
+receipt_bytes = fixture.receipt.read_bytes()
+fixture.receipt.write_bytes(receipt_bytes + b" ")
+check("cleanup rejects mutated receipt bytes", lambda: fixture.cleanup().returncode == 64)
+fixture.receipt.write_bytes(receipt_bytes); fixture.receipt.chmod(0o600)
+
+fixture.worktree.joinpath("fixture.txt").write_text("post-gate drift\n", encoding="utf-8")
+check("cleanup rejects candidate drift after receipt", lambda: fixture.cleanup().returncode == 64)
+fixture.worktree.joinpath("fixture.txt").write_text("worker edit\n", encoding="utf-8")
+
+nested = fixture.worktree / "nested"
+nested.mkdir(); git(nested, "init", "-q")
+check("cleanup rejects a nested repository", lambda: fixture.cleanup().returncode == 64)
+shutil.rmtree(nested)
+
+fifo = fixture.worktree / "unsafe-fifo"
+os.mkfifo(fifo)
+check("cleanup rejects special deletion nodes", lambda: fixture.cleanup().returncode == 64)
+fifo.unlink()
+
+cleanup = fixture.cleanup()
+check("digest-bound symlink cleans without traversing its outside target", lambda: cleanup.returncode == 0 and outside_target.read_bytes() == b"preserve\n")
+check("triple-approved rejected candidate cleans exact worktree and ref", lambda: not fixture.worktree.exists() and git(fixture.repo, "rev-parse", "--verify", f"refs/heads/{fixture.branch}", check_result=False) == b"")
+check("cleanup retains private canonical cleaned tombstone", lambda: fixture.value()["phase"] == "cleaned" and fixture.value()["cleanup_step"] == "branch-removed" and stat.S_IMODE(fixture.state.stat().st_mode) == 0o600)
+
+
+passed_fixture = Fixture("passed")
+assert passed_fixture.init().returncode == 0
+passed_fixture.worktree.joinpath("fixture.txt").write_text("worker edit\n", encoding="utf-8")
+passed_fixture.write_envelope()
+passed_verify = run_cli("verify", "--state", str(passed_fixture.state), "--receipt", str(passed_fixture.receipt), "--envelope", str(passed_fixture.envelope), "--only", "fixture.txt", "--expect-edits", "--verify", "true")
+check("gate-passed state is retained and never cleanup-eligible", lambda: passed_verify.returncode == 0 and passed_fixture.value()["phase"] == "verified-gate-passed" and passed_fixture.cleanup().returncode == 64)
+preserve = run_cli("preserve-instructions", "--state", str(passed_fixture.state))
+check("passed state returns instructions without executing them", lambda: preserve.returncode == 0 and b"git -C" in preserve.stdout and passed_fixture.worktree.exists())
+clean_fixture(passed_fixture)
+
+
+def state_cas_pair() -> bool:
+    parent = TMP / "state-cas"
+    parent.mkdir(mode=0o700)
+    path = parent / "state.json"
+    value = dict(original)
+    value["job_id"] = "cas-job"
+    store = MODULE.StateStore(path, initial=True)
+    try:
+        first = store.create(value)
+        raw = path.read_bytes()
+        disk = json.loads(raw)
+        disk["job_id"] = "attacker"
+        path.write_bytes(canonical(disk)); path.chmod(0o600)
+        rejected = rejects(lambda: store.update({"phase": "verifying"}))
+        return first == hashlib.sha256(raw).hexdigest() and rejected
+    finally:
+        store.close()
+
+
+check("state compare-and-swap rejects attacker byte replacement", state_cas_pair)
+
+
+def state_parent_swap_pair() -> bool:
+    parent = TMP / "state-parent-swap"
+    parent.mkdir(mode=0o700)
+    path = parent / "state.json"
+    value = dict(original); value["job_id"] = "parent-swap-job"
+    store = MODULE.StateStore(path, initial=True)
+    moved = TMP / "state-parent-original"
+    try:
+        store.create(value)
+        parent.rename(moved)
+        parent.mkdir(mode=0o700)
+        return rejects(lambda: store.update({"phase": "verifying"})) and (moved / "state.json").is_file()
+    finally:
+        store.close()
+
+
+check("state operations reject parent path inode replacement", state_parent_swap_pair)
+
+
+def state_history_and_fsync_pair() -> bool:
+    parent = TMP / "state-history"
+    parent.mkdir(mode=0o700)
+    path = parent / "state.json"
+    value = dict(original)
+    value["job_id"] = "history-job"
+    store = MODULE.StateStore(path, initial=True)
+    original_fsync = MODULE.os.fsync
+    original_replace = MODULE.os.replace
+    try:
+        first = store.create(value)
+        store.update({"phase": "verifying", "last_result": None, "failure": None})
+        second_value = store.value
+        assert second_value is not None
+        history_ok = second_value["sequence"] == value["sequence"] + 1 and second_value["previous_state_sha256"] == first
+        installed = False
+        failed_once = False
+
+        def replacing(*args: Any, **kwargs: Any) -> None:
+            nonlocal installed
+            original_replace(*args, **kwargs)
+            installed = True
+
+        def failing_parent_fsync(descriptor: int) -> None:
+            nonlocal failed_once
+            if installed and descriptor == store.parent_fd and not failed_once:
+                failed_once = True
+                raise OSError("synthetic parent fsync failure")
+            original_fsync(descriptor)
+
+        MODULE.os.replace = replacing
+        MODULE.os.fsync = failing_parent_fsync
+        rejected = rejects(lambda: store.update({"phase": "verify-failed", "last_result": 1, "failure": "verify-failed"}))
+        disk = json.loads(path.read_bytes())
+        return rejected and failed_once and history_ok and disk["phase"] == "verify-failed" and store.value == disk and store.raw == path.read_bytes()
+    finally:
+        MODULE.os.fsync = original_fsync
+        MODULE.os.replace = original_replace
+        store.close()
+
+
+check("installed state remains truthful when parent fsync reports failure", state_history_and_fsync_pair)
+
+
+resume_fixture = Fixture("resume")
+assert resume_fixture.init().returncode == 0
+resume_fixture.worktree.joinpath("fixture.txt").write_text("worker edit\n", encoding="utf-8")
+assert resume_fixture.verify_reject().returncode == 10
+resume_store = MODULE.StateStore(resume_fixture.state)
+resume_store.update({"phase": "cleanup-in-progress", "failure": None, "last_result": None})
+resume_store.close()
+git(resume_fixture.repo, "worktree", "remove", "--force", str(resume_fixture.worktree))
+reconcile = resume_fixture.cleanup()
+check("resume reconciles removed worktree without spending stale approval on ref", lambda: reconcile.returncode == 74 and resume_fixture.value()["cleanup_step"] == "worktree-removed" and git(resume_fixture.repo, "rev-parse", "--verify", f"refs/heads/{resume_fixture.branch}", check_result=False) != b"")
+resume = resume_fixture.cleanup()
+check("fresh approval resumes compare-delete after reconciled state", lambda: resume.returncode == 0 and resume_fixture.value()["phase"] == "cleaned")
+
+
+fatal_ref_fixture = Fixture("fatal-ref")
+assert fatal_ref_fixture.init().returncode == 0
+fatal_ref_fixture.worktree.joinpath("fixture.txt").write_text("worker edit\n", encoding="utf-8")
+assert fatal_ref_fixture.verify_reject().returncode == 10
+fatal_state = fatal_ref_fixture.value()
+fatal_argv = [
+    "cleanup",
+    "--state", str(fatal_ref_fixture.state),
+    "--approve-job", fatal_ref_fixture.job_id,
+    "--approve-state-sha", fatal_ref_fixture.state_sha(),
+    "--approve-candidate-sha", fatal_state["receipt"]["final_candidate_state_sha256"],
+]
+original_ref_value = MODULE.ref_value
+fatal_observation_raised = False
+
+
+def fatal_after_ref_delete(repo: Path, reference: str) -> str | None:
+    global fatal_observation_raised
+    value = original_ref_value(repo, reference)
+    if value is None and not fatal_observation_raised:
+        fatal_observation_raised = True
+        raise MODULE.GitError("synthetic fatal ref verification")
+    return value
+
+
+try:
+    MODULE.ref_value = fatal_after_ref_delete
+    fatal_result = MODULE.main(fatal_argv)
+finally:
+    MODULE.ref_value = original_ref_value
+fatal_after = fatal_ref_fixture.value()
+check(
+    "fatal post-delete ref verification stays cleanup-in-progress",
+    lambda: (
+        fatal_result == 74
+        and fatal_after["phase"] == "cleanup-in-progress"
+        and fatal_after["cleanup_step"] == "worktree-removed"
+        and original_ref_value(fatal_ref_fixture.repo, fatal_after["branch_ref"]) is None
+    ),
+)
+
+
+def subprocess_signal(signum: int) -> bool:
+    marker = TMP / f"signal-{signum}.marker"
+    child_code = (
+        "import pathlib,signal,time,sys;"
+        "signal.signal(signal.SIGTERM,signal.SIG_IGN);"
+        "time.sleep(4);pathlib.Path(sys.argv[1]).write_text('late')"
+    )
+    script = (
+        "import importlib.util,os,signal,sys,threading,time;"
+        f"p={str(MODULE_PATH)!r};"
+        "s=importlib.util.spec_from_file_location('life_signal',p);m=importlib.util.module_from_spec(s);sys.modules[s.name]=m;s.loader.exec_module(m);"
+        "[signal.signal(n,m._interrupt) for n in m.SIGNALS];"
+        f"threading.Timer(.2,lambda:os.kill(os.getpid(),{signum})).start();"
+        f"\ntry:m.run_process([{PYTHON!r},'-I','-S','-B','-c',{child_code!r},{str(marker)!r}])\nexcept m.JobSignal as e:raise SystemExit(128+e.number)"
+    )
+    result = subprocess.run([PYTHON, "-I", "-S", "-B", "-c", script], stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=5, check=False)
+    time.sleep(0.2)
+    return result.returncode == 128 + signum and not marker.exists()
+
+
+for lifecycle_signal in MODULE.SIGNALS:
+    check(f"signal {lifecycle_signal} terminates child group without late side effect", lambda lifecycle_signal=lifecycle_signal: subprocess_signal(lifecycle_signal))
+
+
+def completion_signal(signum: int) -> bool:
+    script = (
+        "import importlib.util,os,signal,sys;"
+        f"p={str(MODULE_PATH)!r};"
+        "s=importlib.util.spec_from_file_location('life_complete',p);m=importlib.util.module_from_spec(s);sys.modules[s.name]=m;s.loader.exec_module(m);"
+        "\ndef fake():\n m.FIRST_SIGNAL=None\n [signal.signal(n,m._interrupt) for n in m.SIGNALS]\n return 0\n"
+        "\nclass W:\n def __init__(self,x):self.x=x;self.sent=False\n def write(self,v):return self.x.write(v)\n def flush(self):\n  if not self.sent:self.sent=True;os.kill(os.getpid()," + str(int(signum)) + ")\n  return self.x.flush()\n"
+        "\nm.main=fake;sys.stdout=W(sys.stdout);m.process_main()"
+    )
+    result = subprocess.run([PYTHON, "-I", "-S", "-B", "-c", script], stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=3, check=False)
+    if result.returncode != 128 + signum:
+        raise AssertionError(f"rc={result.returncode} stderr={result.stderr[:1000]!r}")
+    return True
+
+
+for lifecycle_signal in MODULE.SIGNALS:
+    check(f"signal {lifecycle_signal} after command return wins before process exit", lambda lifecycle_signal=lifecycle_signal: completion_signal(lifecycle_signal))
+
+
+def distinct_second_signal() -> bool:
+    marker = TMP / "double-signal.marker"
+    child_code = "import pathlib,signal,time,sys;signal.signal(signal.SIGTERM,signal.SIG_IGN);time.sleep(4);pathlib.Path(sys.argv[1]).write_text('late')"
+    script = (
+        "import importlib.util,os,signal,sys,threading;"
+        f"p={str(MODULE_PATH)!r};s=importlib.util.spec_from_file_location('life_double',p);m=importlib.util.module_from_spec(s);sys.modules[s.name]=m;s.loader.exec_module(m);"
+        "[signal.signal(n,m._interrupt) for n in m.SIGNALS];"
+        "threading.Timer(.2,lambda:os.kill(os.getpid(),signal.SIGHUP)).start();"
+        "threading.Timer(.22,lambda:os.kill(os.getpid(),signal.SIGTERM)).start();"
+        f"\ntry:m.run_process([{PYTHON!r},'-I','-S','-B','-c',{child_code!r},{str(marker)!r}])\nexcept m.JobSignal as e:raise SystemExit(128+e.number)"
+    )
+    result = subprocess.run([PYTHON, "-I", "-S", "-B", "-c", script], stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=5, check=False)
+    time.sleep(0.2)
+    return result.returncode == 129 and not marker.exists()
+
+
+check("distinct second signal cannot replace first exit or interrupt cleanup", distinct_second_signal)
+
+
+source = MODULE_PATH.read_bytes()
+check(
+    "child stderr is suppressed and only bounded Git stdout may be captured",
+    lambda: (
+        source.count(b"stderr=subprocess.DEVNULL") >= 2
+        and b"stdout=subprocess.PIPE if capture else subprocess.DEVNULL" in source
+        and b"if capture and len(stdout) > MAX_GIT_OUTPUT:" in source
+    ),
+)
+check("compare-delete uses exact ref and expected base", lambda: b'"update-ref", "-d", state["branch_ref"], state["base"]' in source)
+check("cleanup never uses branch force delete", lambda: b"branch -D" not in source and b'"branch", "-D"' not in source)
+check("status hard-codes zero cleanup authority", lambda: source.count(b'"cleanup_authorized": False') >= 2)
+check("worker command claims are never executed by lifecycle", lambda: b"commands_run" not in source and b"tests_run" not in source)
+
+
+def branch_contract(data: bytes) -> bool:
+    start = data.index(b"def validate_branch")
+    end = data.index(b"\ndef validate_base", start)
+    body = data[start:end]
+    return (
+        b"canonical_branch_syntax(branch)" in body
+        and b'"check-ref-format", "--branch", branch' in body
+        and b'expected = branch.encode("utf-8", "strict") + b"\\n"' in body
+        and b"if completed.stdout != expected:" in body
+        and b'return f"refs/heads/{branch}"' in body
+    )
+
+
+check("branch authority binds exact canonical check-ref stdout", lambda: branch_contract(source))
+mutated = source.replace(b"    if completed.stdout != expected:\n", b"    if False:\n", 1)
+check("mutation accepting check-ref canonicalization is killed", lambda: not branch_contract(mutated))
+
+
+def git_policy_contract(data: bytes) -> bool:
+    start = data.index(b"def _git_environment")
+    end = data.index(b"\ndef canonical_repo", start)
+    body = data[start:end]
+    initial = data[data.index(b"def initial_state"):data.index(b"\ndef command_init")]
+    return (
+        b'"GIT_CONFIG_NOSYSTEM": "1"' in body
+        and b'"GIT_CONFIG_GLOBAL": "/dev/null"' in body
+        and b'"GIT_TERMINAL_PROMPT": "0"' in body
+        and b'"GIT_EXTERNAL_DIFF": ""' in body
+        and b'"-c", f"core.hooksPath={hooks}"' in body
+        and b'"-c", "core.fsmonitor=false"' in body
+        and b'"-c", "protocol.allow=never"' in body
+        and b"validate_safe_git_checkout(repo, args.base)" in initial
+        and initial.index(b"validate_safe_git_checkout(repo, args.base)")
+        < initial.index(b"if ref_value(repo, branch_ref) is not None:")
+        and data.count(b"subprocess.run(") == 0
+    )
+
+
+check("all lifecycle Git runs share fixed no-external execution policy", lambda: git_policy_contract(source))
+for old, new, label in (
+    (b'"-c", f"core.hooksPath={hooks}"', b'"-c", "core.hooksPath=.git/hooks"', "hooks override"),
+    (b'"GIT_CONFIG_GLOBAL": "/dev/null"', b'"GIT_CONFIG_GLOBAL": os.environ.get("GIT_CONFIG_GLOBAL", "/dev/null")', "global config isolation"),
+    (b"    validate_safe_git_checkout(repo, args.base)\n", b"    pass\n", "checkout preflight"),
+):
+    mutated = source.replace(old, new, 1)
+    check(f"mutation removing {label} is killed", lambda mutated=mutated: not git_policy_contract(mutated))
+
+
+def checkout_preflight_contract(data: bytes) -> bool:
+    start = data.index(b"def validate_safe_git_checkout")
+    end = data.index(b"\ndef canonical_repo", start)
+    body = data[start:end]
+    return (
+        b'"config",\n        "--local",\n        "--includes"' in body
+        and b"filter\\..*\\.(clean|smudge|process|required)" in body
+        and b'"check-attr",\n        f"--source={base}"' in body
+        and b"if configured.returncode == 0:" in body
+        and b'input_data=b"\\0".join(paths) + b"\\0"' in body
+        and b'record[2] not in {b"unspecified", b"unset"}' in body
+        and b"MAX_ATTRIBUTE_PATH_BYTES" in body
+        and b"MAX_DELETE_NODES" in body
+    )
+
+
+check("checkout preflight binds config and effective filter attributes", lambda: checkout_preflight_contract(source))
+for old, new, label in (
+    (b'            or record[2] not in {b"unspecified", b"unset"}\n', b"            or False\n", "attribute rejection"),
+    (b"    if configured.returncode == 0:\n", b"    if False:\n", "external config rejection"),
+):
+    mutated = source.replace(old, new, 1)
+    check(f"mutation removing {label} is killed", lambda mutated=mutated: not checkout_preflight_contract(mutated))
+
+def candidate_policy_contract(data: bytes) -> bool:
+    return data.count(b"git_reader=git") >= 4
+
+
+check("lifecycle candidate digest uses the fixed Git policy reader", lambda: candidate_policy_contract(source))
+mutated = source.replace(b", git_reader=git", b"", 1)
+check(
+    "mutation bypassing fixed Git reader is killed",
+    lambda: not candidate_policy_contract(mutated),
+)
+
+
+def ref_contract(data: bytes) -> bool:
+    start = data.index(b"def ref_value")
+    end = data.index(b"\ndef _config_key", start)
+    body = data[start:end]
+    cleanup = data[data.index(b"def command_cleanup"):data.index(b"\ndef status_facts")]
+    return (
+        b'"show-ref", "--verify", "--quiet", reference' in body
+        and b"if existence.returncode == 1:" in body
+        and b"if existence.returncode != 0:" in body
+        and b"returncode == 128" not in body
+        and b'if ref_value(repo, state["branch_ref"]) is not None:' in cleanup
+        and b"except GitError:" in cleanup
+        and b"Do not retry/reconcile it into `cleaned`" in cleanup
+        and b"except JobError:\n                pass" not in cleanup
+    )
+
+
+check("ref absence accepts only documented show-ref rc1", lambda: ref_contract(source))
+mutated = source.replace(
+    b"    if existence.returncode == 1:\n",
+    b"    if existence.returncode in {1, 128}:\n",
+    1,
+)
+check("mutation treating fatal rc128 as absence is killed", lambda: not ref_contract(mutated))
+mutated = source.replace(b"    except GitError:\n", b"    except OSError:\n", 1)
+check("mutation allowing same-invocation fatal ref reconciliation is killed", lambda: not ref_contract(mutated))
+
+
+def process_exit_contract(data: bytes) -> bool:
+    start = data.index(b"def process_main()")
+    end = data.index(b'\n\nif __name__ == "__main__":', start)
+    body = data[start:end]
+    return (
+        body.count(b"os._exit(result)") == 1
+        and body.count(b"sys.stdout.flush()") == 2
+        and body.count(b"sys.stderr.flush()") == 2
+        and b"except JobSignal as exc:" in body
+        and b"result = 128 + exc.number" in body
+        and b"\n    return" not in body
+        and b"signal.signal(number, handler)" not in data
+    )
+
+
+check("CLI owns handlers through flush and atomic process exit", lambda: process_exit_contract(source))
+mutated = source.replace(b"    os._exit(result)\n", b"    return\n", 1)
+check("mutation removing atomic process exit is killed", lambda: not process_exit_contract(mutated))
+
+
+def process_group_contract(data: bytes) -> bool:
+    start = data.index(b"def _terminate_process")
+    end = data.index(b"\ndef run_process", start)
+    body = data[start:end]
+    wait = body.index(b"process.wait(")
+    return (
+        body.count(b"os.killpg(") == 2
+        and body.index(b"os.killpg(process.pid, signal.SIGTERM)") < wait
+        and body.index(b"os.killpg(process.pid, signal.SIGKILL)") < wait
+        and b"os.killpg(" not in body[wait:]
+        and b"process.poll(" not in body
+    )
+
+
+check("process-group authority is used only before leader reap", lambda: process_group_contract(source))
+mutated = source.replace(b"        process.wait(timeout=0.75)\n", b"        process.wait(timeout=0.75)\n        os.killpg(process.pid, 0)\n", 1)
+check("mutation adding post-reap process-group probe is killed", lambda: not process_group_contract(mutated))
+
+
+def state_fsync_contract(data: bytes) -> bool:
+    start = data.index(b"class StateStore")
+    end = data.index(b"\ndef _write_all", start)
+    body = data[start:end]
+    create = body[body.index(b"    def create"):body.index(b"    def update")]
+    update = body[body.index(b"    def update"):]
+    return (
+        body.count(b"os.fsync(descriptor)") == 2
+        and body.count(b"os.fsync(self.parent_fd)") == 3
+        and create.index(b"os.fsync(descriptor)") < create.index(b"self.raw, self.metadata") < create.index(b"os.fsync(self.parent_fd)")
+        and update.index(b"os.fsync(descriptor)") < update.index(b"os.replace(") < update.index(b"self.raw, self.metadata") < update.index(b"os.fsync(self.parent_fd)")
+        and update.index(b"os.unlink(temporary") < update.rindex(b"os.fsync(self.parent_fd)")
+    )
+
+
+check("state publication binds file and parent durability calls", lambda: state_fsync_contract(source))
+mutated = source.replace(b"                os.fsync(descriptor)\n", b"                pass\n", 1)
+check("mutation removing staged state fsync is killed", lambda: not state_fsync_contract(mutated))
+mutated = source.replace(b"            os.fsync(self.parent_fd)\n", b"            pass\n", 1)
+check("mutation removing initial parent fsync is killed", lambda: not state_fsync_contract(mutated))
+
+clean_fixture(fixture)
+shutil.rmtree(TMP)
+print(f"job lifecycle offline tests: {passed} passed, {failed} failed")
+raise SystemExit(0 if failed == 0 else 1)

--- a/tests/test-packaging.sh
+++ b/tests/test-packaging.sh
@@ -728,6 +728,16 @@ else
     bad "root and portable packages include the pure Evidence Report renderer"
 fi
 
+if [[ -x "$ROOT/job.sh" ]] \
+        && [[ -x "$ROOT/skills/agy-worker/runtime/job.sh" ]] \
+        && [[ -x "$ROOT/skills/agy-worker/runtime/scripts/job_lifecycle.py" ]] \
+        && [[ -x "$ROOT/skills/agy-worker/runtime/scripts/candidate_state.py" ]] \
+        && [[ -f "$ROOT/skills/agy-worker/runtime/schemas/job-state.schema.json" ]]; then
+    ok "root and portable packages include the safe local job lifecycle"
+else
+    bad "root and portable packages include the safe local job lifecycle"
+fi
+
 if grep -Fq 'is process-owning: it keeps signal rollback authority' \
         "$ROOT/skills/agy-worker/runtime/scripts/evidence_report.py" \
         && grep -Fq 'The `--output` CLI path is deliberately process-owning' \
@@ -741,6 +751,7 @@ fi
 
 required_runtime_dependencies=(
     agy-worker.sh
+    job.sh
     qa-gate.sh
     verify-job.sh
     evidence-report.sh
@@ -754,11 +765,14 @@ required_runtime_dependencies=(
     scripts/model-recommendation.py
     scripts/model_selection.py
     scripts/compatibility.py
+    scripts/candidate_state.py
+    scripts/job_lifecycle.py
     scripts/doctor-metadata.py
     schemas/worker-result.schema.json
     schemas/evidence-receipt.schema.json
     schemas/model-selection.schema.json
     schemas/model-recommendation.schema.json
+    schemas/job-state.schema.json
     agents/bulk-test-writer.md
     agents/repo-inventory.md
     agents/diff-reviewer.md
@@ -854,6 +868,7 @@ for parent in scripts agents schemas compat; do
 done
 
 for specification in \
+    'job.sh:executable' \
     'qa-gate.sh:executable' \
     'verify-job.sh:executable' \
     'evidence-report.sh:executable' \
@@ -861,9 +876,12 @@ for specification in \
     'scripts/evidence_receipt.py:executable' \
     'scripts/evidence_report.py:executable' \
     'scripts/recommendation_record.py:executable' \
+    'scripts/candidate_state.py:executable' \
+    'scripts/job_lifecycle.py:executable' \
     'scripts/model_selection.py:executable' \
     'schemas/worker-result.schema.json:data' \
     'schemas/evidence-receipt.schema.json:data' \
+    'schemas/job-state.schema.json:data' \
     'agents/repo-inventory.md:data' \
     'compat/agy-verified-version.txt:data' \
     'compat/agy-model-effort-matrix.json:data'; do
@@ -1464,15 +1482,23 @@ if ! grep -Fq '/usr/bin/python3 -I -S -B tests/test-models-attestation-runner.py
         || [[ ! -f "$ROOT/scripts/models_attestation_runner.py" ]]; then
     governance_lists_all_suites=0
 fi
+if ! grep -Fq '/usr/bin/python3 -I -S -B tests/test-job-lifecycle.py' \
+        "$ROOT/CONTRIBUTING.md" \
+        || ! grep -Fq '/usr/bin/python3 -I -S -B tests/test-job-lifecycle.py' \
+            "$ROOT/.github/pull_request_template.md" \
+        || ! grep -Fq 'tests/test-job-lifecycle.py' \
+            "$ROOT/.github/workflows/test.yml"; then
+    governance_lists_all_suites=0
+fi
 
 if [[ "$governance_lists_all_suites" == "1" ]] \
         && grep -Fq 'Google/Gemini' "$ROOT/PRIVACY.md" \
         && grep -Fq 'logs/' "$ROOT/PRIVACY.md" \
         && grep -Fq 'GitHub Issues' "$ROOT/SUPPORT.md" \
         && grep -Fq 'not legal advice' "$ROOT/TERMS.md"; then
-    ok "governance docs require all twelve suites and disclose public policy boundaries"
+    ok "governance docs require all thirteen suites and disclose public policy boundaries"
 else
-    bad "governance docs require all twelve suites and disclose public policy boundaries"
+    bad "governance docs require all thirteen suites and disclose public policy boundaries"
 fi
 
 python3 "$ROOT/scripts/validate-brand-assets.py" "$ROOT/docs/assets/brand" \

--- a/tests/test-proof-demo.sh
+++ b/tests/test-proof-demo.sh
@@ -92,11 +92,14 @@ make_demo_tree() {
         "$destination/skills/agy-worker/runtime/qa-gate.sh"
     cp "$ROOT/skills/agy-worker/runtime/scripts/validate-envelope.py" \
         "$destination/skills/agy-worker/runtime/scripts/validate-envelope.py"
+    cp "$ROOT/skills/agy-worker/runtime/scripts/candidate_state.py" \
+        "$destination/skills/agy-worker/runtime/scripts/candidate_state.py"
     cp "$ROOT/skills/agy-worker/runtime/schemas/worker-result.schema.json" \
         "$destination/skills/agy-worker/runtime/schemas/worker-result.schema.json"
     chmod +x "$destination/proof-demo.sh" "$destination/qa-gate.sh" \
         "$destination/skills/agy-worker/runtime/qa-gate.sh" \
-        "$destination/skills/agy-worker/runtime/scripts/validate-envelope.py"
+        "$destination/skills/agy-worker/runtime/scripts/validate-envelope.py" \
+        "$destination/skills/agy-worker/runtime/scripts/candidate_state.py"
 }
 
 mkdir -p "$TMP/bin" "$TMP/caller-temp/agy-worker-proof.COLLISION"


### PR DESCRIPTION
## What changed

Adds an offline, process-owning `job.sh` lifecycle for one explicitly registered
branch-backed worktree. Canonical state lives outside the repository in an
owner-private mode-0600 file and advances as a hash-linked CAS history bound to the
exact job, repository, worktree, ref, immutable base, Receipt v1 bytes, and candidate
digest.

The lifecycle provides fail-closed `init`, read-only `status`, canonical
`verify-job.sh` delegation, non-executing preserve instructions, and narrowly scoped
cleanup for rejected receipts only.

## Trust boundary and scope

- Affected paths: canonical/public lifecycle wrappers, private state schema and
  lifecycle/candidate helpers, the gate's shared candidate digest integration,
  resolver/doctor/package inventory, paired offline tests, CI, and documentation.
- Cleanup authority: only Receipt v1 exits 10–14 with verdict `rejected` qualify.
  Every invocation requires fresh exact job, current-state SHA, and Receipt candidate
  SHA approvals. Reconciliation persists observed progress and stops when it changes
  state, so an earlier approval never auto-resumes a later destructive step.
- Exact deletion domain: cleanup revalidates the registered worktree, canonical
  branch/ref, immutable base, Receipt, current candidate digest, and all approvals.
  It removes only the exact registered worktree and compare-deletes only an unchanged
  ref; it never force-deletes a branch.
- Recovery and foreign-node boundary: interrupted or partially completed operations
  remain durable and require manual inspection plus fresh approval. Nested
  repositories, submodules, device/mount changes, special or foreign nodes, moved or
  committed candidates, and any digest drift fail closed. A digest-bound symlink is
  removed only as its link node and is never followed. A private cleaned tombstone is
  retained for a separate manual retention decision.
- Git execution boundary: lifecycle-owned Git uses fixed, sanitized Git execution
  with caller/system/global influence removed, a private empty hooks directory, and
  prompts, pagers, fsmonitor, external diff, protocols, recursive submodules, hooks,
  helpers, and content-filter authority disabled or rejected before initialization.
  Fatal ref evidence is uncertainty; only the documented missing-ref result may
  advance cleanup.
- Gate/report authority: `qa-gate.sh` remains the sole outcome authority and uses the
  same canonical candidate digest implementation as lifecycle cleanup. Evidence
  Report remains a validated view with no routing, gate, cleanup, or acceptance
  authority.
- User-visible claims changed: documentation now describes explicit local lifecycle
  setup, status, verification, preserve, cleanup, interruption, and manual recovery
  boundaries.
- Explicitly out of scope: automatic resume, background cleanup, real agy calls,
  provider or network evidence, private fixture publication, compatibility metadata
  or matrix changes, model selection/routing, commit/push/PR/merge actions from the
  runtime, and any tag or release.

## Verification

- [x] `./tests/test-qa-gate.sh` — 41/41
- [x] `./tests/test-evidence-receipt.sh` — 88/88
- [x] `./tests/test-evidence-report.sh` — 60/60
- [x] `/usr/bin/python3 -I -S -B tests/test-job-lifecycle.py` — 94/94
- [x] `./tests/test-agy-worker.sh` — 209/209
- [x] `./tests/test-update.sh` — 310/310
- [x] `/usr/bin/python3 -I -S -B tests/test-version-attestation-runner.py` — 157/157
- [x] `/usr/bin/python3 -I -S -B tests/test-version-attestation-harness.py` — 55/55
- [x] `/usr/bin/python3 -I -S -B tests/test-models-attestation-runner.py` — 78/78
- [x] `./tests/test-reporting.sh` — 21/21
- [x] `./tests/test-packaging.sh` — 212/212
- [x] `./tests/test-doctor.sh` — 184/184
- [x] `./tests/test-proof-demo.sh` — 21/21
- [x] Bash and Python syntax checks
- [x] `git diff --check`
- [x] Human diff review completed

Coverage is offline and uses temporary repositories, worktrees, fake receipts, and
synthetic interruption, stale-approval, compare-delete, hook/filter, foreign-node,
symlink, digest-parity, mutation, packaging, and recovery fixtures only.

## Safety and release

- [x] No worker-reported command or test was treated as evidence.
- [x] No permission, authentication, privacy, or path-policy boundary was weakened.
- [x] No commit, push, merge, release, issue submission, or external setting change is
      implied by this pull request without separate authorization.

This PR adds no live agy/provider proof, network behavior, compatibility baseline,
model metadata, tag, release, or private artifact.
