### PR TITLE
Stabilize benchmark supervisor timing test

### DIFF
--- a/tests/test-benchmark.py
+++ b/tests/test-benchmark.py
@@ -196,16 +196,31 @@ check("signal after durable link leaves no final or temp", interrupted_link_roll
 
 
 supervisor_dir = TMP / "supervisor"; supervisor_dir.mkdir(mode=0o700)
+SUCCESS_TIMEOUT = 5.0
 
 
-def bounded(code: str, *arguments: str, timeout: float = 1.0) -> tuple[int, bytes, bytes]:
+def bounded(code: str, *arguments: str, timeout: float = SUCCESS_TIMEOUT) -> tuple[int, bytes, bytes]:
     return MODULE.run_bounded(["/usr/bin/python3", "-I", "-S", "-B", "-c", code, *arguments], supervisor_dir, timeout)
 
 
 check("bounded supervisor preserves a clean zero exit", lambda: bounded("raise SystemExit(0)")[0] == 0)
 check("bounded supervisor preserves a nonzero exit", lambda: bounded("raise SystemExit(14)")[0] == 14)
 check("bounded supervisor rejects stdout overflow", lambda: rejects(lambda: bounded("import os;os.write(1,b'x'*131073)")))
-check("bounded supervisor rejects a wall timeout", lambda: rejects(lambda: bounded("import time;time.sleep(2)", timeout=0.1)))
+
+
+def timeout_authority_pair() -> bool:
+    child = "import time;time.sleep(2)"
+    secure_rejects = rejects(lambda: bounded(child, timeout=0.1))
+    real = MODULE.run_bounded
+    MODULE.run_bounded = lambda argv, cwd, timeout: real(argv, cwd, SUCCESS_TIMEOUT)
+    try:
+        weakening_exposed = not rejects(lambda: bounded(child, timeout=0.1))
+    finally:
+        MODULE.run_bounded = real
+    return secure_rejects and weakening_exposed
+
+
+check("bounded supervisor rejects a wall timeout and kills timeout weakening", timeout_authority_pair)
 check("bounded supervisor sanitizes launch failure", lambda: rejects(lambda: MODULE.run_bounded([str(supervisor_dir / "missing")], supervisor_dir, 0.1)))
 
 


### PR DESCRIPTION
## Summary

- stabilize the test-only success-path timing boundary for the offline benchmark supervisor
- retain a `0.1s` negative timeout case and add a weakening mutant that must be detected
- keep all production benchmark code and the production `RUN_TIMEOUT = 30` contract unchanged

## Root cause and fix

The exact merge-SHA post-main test run `31350661498` (job `93340669410`) failed in the offline benchmark suite with `benchmark gate timed out`: 103 cases passed and one clean-zero-exit timing assertion failed. The same bytes had passed the pull-request run, so the one-second test harness success timeout was too close to observed CI startup/scheduling variance.

This patch changes only `tests/test-benchmark.py`. Ordinary success and nonzero-exit probes receive a five-second test-only ceiling. Timeout enforcement remains proven with a real `0.1s` rejection, and a temporary weakening mutant that substitutes the success ceiling must fail the negative assertion. The production supervisor timeout remains 30 seconds and no production runtime behavior changes.

## Trust and scope boundaries

- test-only timing stabilization; no gate, receipt, report, benchmark runtime, routing, model, provider, network, or publication behavior changes
- the negative timeout and mutant pair preserve evidence that the supervisor still rejects and kills bounded timeouts
- no retry of the failed post-main run was performed

## Verification

The frozen one-file patch was independently reviewed and accepted by Euclid with no P0-P3 findings before publication. This PR must pass one fresh exact-head required CI run; the earlier failed run is retained as historical evidence.
