### PR TITLE
Reconcile roadmap implementation status

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,10 @@ or chases a moved directory. This is not same-user tamper resistance. See
 
 ## Roadmap
 
-[The product roadmap](docs/ROADMAP.md) lists proposed, dependency-ordered feature
-slices. Those items are plans, not current CLI behavior or implementation claims;
-each slice requires its own approval, tests, review, and pull request.
+[The product roadmap](docs/ROADMAP.md) records dependency-ordered feature slices and
+their explicit implemented or blocked status. Source, tests, and this README remain
+the authority for current CLI behavior; every new slice still requires its own
+approval, tests, review, and pull request.
 
 ---
 

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -218,7 +218,7 @@ does not establish same-user tamper resistance.
 | `.github/workflows/test.yml`, `scripts/ci-diff-check.sh`, `scripts/ci_diff_check.py` | macOS CI for committed PR/push diff hygiene, syntax, and all seventeen offline suites. Checkout supplies the event range; the helper performs no fetch and linearly scans changed immutable head blobs from one bounded `git cat-file --batch` process, independently of attributes or diff drivers. | packaging policy tests plus GitHub Actions |
 | `.github/workflows/compatibility-watch.yml` | Weekly/manual macOS observation of fixed official evidence; bounded Step Summary only, never a required PR or metadata/action path | static policy tests in `tests/test-update.sh` plus GitHub Actions observation |
 | `README.md` | User setup, examples, current capabilities and limitations | review plus relevant offline suites |
-| `docs/ROADMAP.md` | Planned dependency-ordered product slices, approval gates, and honest success measures; not current behavior | human review; implementation claims remain prohibited until their slices land |
+| `docs/ROADMAP.md` | Dependency-ordered product slices with explicit implemented or blocked status, approval gates, and honest success measures; source, tests, and README remain current-behavior authority | human review; implementation claims remain prohibited until their slices land |
 | `AGENTS.md`, `docs/lessons_learned.md`, this file | Durable contributor rules and architecture | `agents-md-auditor` after material changes |
 
 ## Trust boundaries

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -133,9 +133,9 @@ an earlier implementation because it shares a schema or helper.
 
 ### G0 — Compatibility Reconciliation & Watch
 
-**G0-F2 status:** Provider-independent transport hardening is implemented offline for
-review. Read-only project/agy/Codex release and source observations now use exact
-fixed GitHub REST paths with no ambient proxy or redirect path, and a bounded
+**G0-F2 status:** Provider-independent transport hardening is implemented, merged, and
+offline-verified. Read-only project/agy/Codex release and source observations now use
+exact fixed GitHub REST paths with no ambient proxy or redirect path, and a bounded
 process-group supervisor also contains installed version probes. Check/watch makes no
 Git network request. The explicit `apply` fetch remains a separately authorized
 ambient-Git transport path and is not claimed hardened by this slice. No agy `1.1.11`
@@ -329,8 +329,8 @@ provenance, code-signing verification, or OS attestation.
 
 ### G1 — Explicit Model & Effort Selection
 
-**Status:** Implemented as an isolated, offline-verified slice; merge and release
-remain separately approval-gated.
+**Status:** Implemented, merged, and offline-verified; release remains separately
+approval-gated.
 
 - **User job:** Select an exact advertised agy model or a verified base-model/effort
   pair directly, without disguising the choice as a tier or allowing a recommendation
@@ -423,8 +423,8 @@ remain separately approval-gated.
 
 #### P0-A — Evidence Receipt v1
 
-**Status:** Implemented as an isolated, offline-verified slice; merge and release
-remain separately approval-gated.
+**Status:** Implemented, merged, and offline-verified; release remains separately
+approval-gated.
 
 - **User job:** Preserve what the driver checked, against which immutable base and
   policy, and what the gate concluded without sharing source, prompts, raw logs, or
@@ -529,8 +529,8 @@ receipt or creating chronology ambiguity.
 
 #### P0-B — Human Report renderer
 
-**Status:** Implemented as an isolated, offline-verified slice; merge and release
-remain separately approval-gated. Receipt-only selection and recommendation-record
+**Status:** Implemented, merged, and offline-verified; release remains separately
+approval-gated. Receipt-only selection and recommendation-record
 validation is side-effect-free; canonical recommendation generation remains only an
 explicit pre-gate publication-input check.
 
@@ -655,7 +655,7 @@ remains intentionally outside the Doctor contract.
 - **Implemented boundary:** The canonical portable runtime owns the v1 state machine,
   shared candidate-state digest, Receipt validation, progress reconciliation, and
   compare-and-delete cleanup. The root command is only a compatibility wrapper.
-  Ninety-four offline cases cover accepted and rejected lifecycle paths, canonical
+  Ninety-five offline cases cover accepted and rejected lifecycle paths, canonical
   branch authority, hook/filter-free fixed Git execution, durability, stale approval,
   ref-error separation, deletion-domain, signal, and weakened-authority mutations.
   Cleanup never follows symlinks, never deletes a commit, and retains the cleaned
@@ -684,7 +684,7 @@ remains intentionally outside the Doctor contract.
   implementations rejected, and no “certified secure” language.
 - **Implemented boundary:** The repository-only v1 kit binds eleven exact synthetic
   gate cases, manifest/source hashes, fixed verifier kinds, private disposable Git
-  repositories, and per-process time/output limits. Seventy-eight offline adversarial
+  repositories, and per-process time/output limits. Seventy-nine offline adversarial
   cases reject source drift and permissive gates while proving HUP/INT/TERM cleanup,
   FD-relative no-follow deletion, cleanup bounds, and fail-closed residual handling
   under an explicit gate/loaded-code/local-owner/same-UID/OS-admin TCB. The runner
@@ -826,6 +826,16 @@ acceptance operation.
 
 #### P2-B — Provider-reported usage and latency
 
+**Status:** Blocked on current-version terminal-event evidence. The repository's
+historical agy `1.1.9` observation and synthetic test streams do not establish the
+current contract for usage, duration, or turn fields. Unblocking requires a separately
+approved, executable/version-bound one-attempt public synthetic run; owner-private raw
+NDJSON; and a sanitized reviewed record binding event order and cardinality, exact
+field names and types, null/missing behavior, nested usage keys, duplicate/failure
+semantics, and invocation/source/version hashes. Official docs/source must be
+reconciled, and any undocumented behavior remains explicitly version-pinned empirical
+evidence. Until then no usage parser or schema may be treated as current.
+
 - **User job:** Inspect one run's reported token, turn, and duration telemetry to make
   a manual batching decision.
 - **Intended surface:** `usage-report.sh --stream FILE` for one explicitly selected
@@ -848,6 +858,15 @@ acceptance operation.
   stable source and a separately approved contract.
 
 #### P2-C — Optional local list/show/prune
+
+**Status:** Blocked on demonstrated recurring accumulation and a reviewed managed-root
+contract. The stable per-job lifecycle does not yet define a canonical inventory root
+or prove that manual cleanup is recurring friction. Unblocking requires opt-in,
+sanitized evidence from explicit owner-private lifecycle roots showing repeated
+retention or cleanup burden without paths or raw state, followed by an explicit
+contract for the managed-root inventory, list/show scope, exact prune deletion domain,
+and approval binding. Existing current-state, rejected-Receipt, and candidate-digest
+checks remain mandatory; age alone never authorizes deletion.
 
 - **User job:** Find and deliberately remove old locally managed job records after the
   lifecycle format is stable.


### PR DESCRIPTION
## Summary

- reconcile the roadmap with implementation slices that are already merged and offline-verified
- keep source, tests, and README as the authority for current CLI behavior
- record P2-B usage telemetry and P2-C retention/pruning as explicitly blocked on their missing evidence and contract prerequisites

## Status boundaries

This documentation-only change does not implement a roadmap item or change runtime behavior. P2-B remains blocked until current-version, terminal-event evidence is collected in a separately approved bounded run and reconciled with official documentation/source. P2-C remains blocked until recurring retention burden and a reviewed managed-root/deletion contract are demonstrated. Age alone cannot authorize deletion.

The checked-in agy compatibility baseline remains `1.1.10`; agy `1.1.11` is still unreconciled and is not activated or claimed compatible by this change.

## Scope and non-claims

- exactly three documentation files change: `README.md`, `docs/REPO_MAP.md`, and `docs/ROADMAP.md`
- no source, test, workflow, schema, runtime, or `AGENTS.md` bytes change
- no provider or live-call evidence is added
- no routing, recommendation, gate, authorization, cleanup, release, tag, or deployment behavior changes
- no roadmap status is treated as proof of current behavior; the implementation and tests remain authoritative

## Verification

The frozen three-file documentation snapshot was independently reviewed with no P0-P3 findings. Required GitHub CI must still pass on the exact PR head before merge.
