### PR TITLE
Prepare v0.2.0 release scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,10 @@ or chases a moved directory. This is not same-user tamper resistance. See
 ## Roadmap
 
 [The product roadmap](docs/ROADMAP.md) records dependency-ordered feature slices and
-their explicit implemented or blocked status. Source, tests, and this README remain
+their explicit implemented or deferred status. Version 0.2.0 contains the completed
+provider-independent roadmap through P2-A; P2-B and P2-C are deferred because their
+required live terminal-event and recurring-accumulation evidence does not exist.
+Source, tests, and this README remain
 the authority for current CLI behavior; every new slice still requires its own
 approval, tests, review, and pull request.
 

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -218,7 +218,7 @@ does not establish same-user tamper resistance.
 | `.github/workflows/test.yml`, `scripts/ci-diff-check.sh`, `scripts/ci_diff_check.py` | macOS CI for committed PR/push diff hygiene, syntax, and all seventeen offline suites. Checkout supplies the event range; the helper performs no fetch and linearly scans changed immutable head blobs from one bounded `git cat-file --batch` process, independently of attributes or diff drivers. | packaging policy tests plus GitHub Actions |
 | `.github/workflows/compatibility-watch.yml` | Weekly/manual macOS observation of fixed official evidence; bounded Step Summary only, never a required PR or metadata/action path | static policy tests in `tests/test-update.sh` plus GitHub Actions observation |
 | `README.md` | User setup, examples, current capabilities and limitations | review plus relevant offline suites |
-| `docs/ROADMAP.md` | Dependency-ordered product slices with explicit implemented or blocked status, approval gates, and honest success measures; source, tests, and README remain current-behavior authority | human review; implementation claims remain prohibited until their slices land |
+| `docs/ROADMAP.md` | Dependency-ordered product slices with explicit implemented or deferred status, v0.2.0 scope, approval gates, and honest success measures; source, tests, and README remain current-behavior authority | human review; implementation claims remain prohibited until their slices land |
 | `AGENTS.md`, `docs/lessons_learned.md`, this file | Durable contributor rules and architecture | `agents-md-auditor` after material changes |
 
 ## Trust boundaries

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -131,6 +131,16 @@ behavior into broader agy `1.1.10` promises:
 Each slice below is independently reviewable. A later slice must not be smuggled into
 an earlier implementation because it shares a schema or helper.
 
+### v0.2.0 release scope
+
+Version 0.2.0 releases the completed provider-independent roadmap through P2-A:
+G0/G1, P0-A through P0-D, P1-A through P1-E, and P2-A. P2-B and P2-C are not release
+blockers and are deferred rather than left as active implementation goals. Their
+sections retain the exact evidence and policy prerequisites required before either
+may be reconsidered. Deferral does not weaken the active agy `1.1.10` baseline,
+advance the unreconciled `1.1.11` evidence, or claim live provider or cleanup
+behavior.
+
 ### G0 — Compatibility Reconciliation & Watch
 
 **G0-F2 status:** Provider-independent transport hardening is implemented, merged, and
@@ -826,7 +836,8 @@ acceptance operation.
 
 #### P2-B — Provider-reported usage and latency
 
-**Status:** Blocked on current-version terminal-event evidence. The repository's
+**Status:** Deferred; no implementation path exists within the current evidence
+boundary. The repository's
 historical agy `1.1.9` observation and synthetic test streams do not establish the
 current contract for usage, duration, or turn fields. Unblocking requires a separately
 approved, executable/version-bound one-attempt public synthetic run; owner-private raw
@@ -859,8 +870,9 @@ evidence. Until then no usage parser or schema may be treated as current.
 
 #### P2-C — Optional local list/show/prune
 
-**Status:** Blocked on demonstrated recurring accumulation and a reviewed managed-root
-contract. The stable per-job lifecycle does not yet define a canonical inventory root
+**Status:** Deferred; no implementation path exists until recurring accumulation is
+demonstrated and a managed-root contract is reviewed. The stable per-job lifecycle
+does not yet define a canonical inventory root
 or prove that manual cleanup is recurring friction. Unblocking requires opt-in,
 sanitized evidence from explicit owner-private lifecycle roots showing repeated
 retention or cleanup burden without paths or raw state, followed by an explicit


### PR DESCRIPTION
## Summary

- define v0.2.0 as the completed provider-independent roadmap through P2-A
- defer P2-B until current-version terminal-event evidence exists
- defer P2-C until recurring accumulation and a managed-root policy are demonstrated
- preserve the agy 1.1.10 baseline and unreconciled 1.1.11 boundary

## Validation

- `tests/test-packaging.sh`: 346/346
- `tests/test-workload-profiles.py`: 89/89
- `tests/test-conformance.py`: 79/79
- Bash syntax, external-cache Python compile, `git diff --check`, and spill checks passed
- post-change AGENTS audit: unchanged hierarchy, 20,849 bytes, A/97

## Boundaries

Documentation-only. No runtime, schema, workflow, provider, live-job, cleanup, tag,
or release behavior is changed by this PR. The release is created only after
exact-head CI and merge verification.
