### PR TITLE
Prepare v0.2.1 release

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-agy-worker",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Delegate bounded coding work to Antigravity CLI, then independently verify repository evidence before acceptance.",
   "author": {
     "name": "cagdasyurekli",

--- a/tests/test-packaging.sh
+++ b/tests/test-packaging.sh
@@ -705,7 +705,7 @@ import sys
 root = Path(sys.argv[1])
 manifest = json.loads((root / ".codex-plugin/plugin.json").read_text())
 assert manifest["name"] == "codex-agy-worker"
-assert manifest["version"] == "0.2.0"
+assert manifest["version"] == "0.2.1"
 assert manifest["skills"] == "./skills/"
 assert manifest["license"] == "MIT"
 assert manifest["interface"]["privacyPolicyURL"].startswith("https://")


### PR DESCRIPTION
## Summary

- bump the Codex plugin manifest from 0.2.0 to 0.2.1
- bind the packaging contract to the same patch version

## Release scope

- publish the accepted hardening and evidence work merged after v0.2.0
- no new automatic routing, retry, provider, metadata, cleanup, or Git authority
- agy 1.1.10 remains the active compatibility metadata baseline; P2-B and P2-C remain deferred

## Verification

- full offline release gate: 24/24 suites, 2,746 passed, 0 failed
- packaging: 353/353
- committed-range diff gate, Bash syntax, external-cache Python compilation, `git diff --check`, RTK 154/154, and no-spill checks passed
