### PR TITLE
Prepare v0.3.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ or chases a moved directory. This is not same-user tamper resistance. See
 ## Roadmap
 
 [The product roadmap](docs/ROADMAP.md) records dependency-ordered feature slices and
-their explicit implemented or deferred status. Version 0.3.1 is the release represented
+their explicit implemented or deferred status. Version 0.3.2 is the release represented
 by this source and adds daily compatibility observation, private 30/60/90 measurement,
 the optional local notifier, version-drift-safe default/literal routing, and the
 bounded updater hotfix to the completed provider-independent roadmap through P2-A.

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -227,7 +227,7 @@ does not establish same-user tamper resistance.
 | `.github/workflows/test.yml`, `scripts/ci-diff-check.sh`, `scripts/ci_diff_check.py` | macOS CI for committed PR/push diff hygiene, syntax, and all twenty-six offline suites. Checkout supplies the event range; the helper performs no fetch and linearly scans changed immutable head blobs from one bounded `git cat-file --batch` process, independently of attributes or diff drivers. | packaging policy tests plus GitHub Actions |
 | `.github/workflows/compatibility-watch.yml` | Daily/manual macOS observation of fixed official evidence; bounded Step Summary only, never a required PR or metadata/action path | static policy tests in `tests/test-update.sh` plus GitHub Actions observation |
 | `README.md` | User setup, examples, current capabilities and limitations | review plus relevant offline suites |
-| `docs/ROADMAP.md` | Dependency-ordered product slices with explicit implemented or deferred status, historical v0.2.0 scope, current v0.3.1 release context, approval gates, and honest success measures; source, tests, and README remain current-behavior authority | human review; implementation claims remain prohibited until their slices land |
+| `docs/ROADMAP.md` | Dependency-ordered product slices with explicit implemented or deferred status, historical v0.2.0 scope, current v0.3.2 release context, approval gates, and honest success measures; source, tests, and README remain current-behavior authority | human review; implementation claims remain prohibited until their slices land |
 | `AGENTS.md`, `docs/lessons_learned.md`, this file | Durable contributor rules and architecture | `agents-md-auditor` after material changes |
 
 ## Trust boundaries

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -147,7 +147,7 @@ behavior.
 **Current status:** Daily hosted observation, the optional local notifier, privacy-
 limited 30/60/90 measurement tooling, Codex `0.147.0` reconciliation, bounded GitHub
 transport hardening, and the agy `1.1.12` reconciliation are implemented and offline-
-verified in the current post-v0.3.1 candidate change set. Read-only project/agy/Codex observations use
+verified in the current v0.3.2 release. Read-only project/agy/Codex observations use
 exact fixed GitHub REST paths with no ambient proxy or redirect path, and a bounded
 process-group supervisor also contains installed version probes. Check/watch makes no
 Git network request. The explicit `apply` fetch remains a separately authorized


### PR DESCRIPTION
## Summary
- mark the merged agy 1.1.12 reconciliation and stable Codex release observation as v0.3.2
- update only README, roadmap, and repository-map current-release wording

## Verification
- [x] release scope is documentation-only: 3 files, 3 insertions / 3 deletions
- [x] packaging: 353/0
- [x] `git diff --check`
- [x] `rtk hook check`
- [x] post-change `agents-md-auditor`: no conflicts or cutoff

## Release boundary
- tag and GitHub Release remain separate actions after exact-head CI and merge
- no product, compatibility, routing, notifier, provider, or matrix bytes change
