### PR TITLE
Document post-release state reconciliation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,13 @@ git diff --check
 Report exact summaries and any checks you could not run. Passing tests do not replace
 human diff review or justify unrelated cleanup.
 
+When a release is also claimed to be installed or collecting local measurements,
+verify those machine states separately after publication. A clean tagged checkout is
+not proof that the global Codex skill was recopied, that the LaunchAgent snapshot was
+rebound, or that an explicit measurement ledger and its daily append path exist. Read
+back installed-bundle parity, notifier status, the ledger header/report, and at least
+one real observation before making those claims.
+
 ## Pull requests
 
 Keep each pull request focused. Explain the trust boundary affected, list changed

--- a/docs/MEASUREMENT.md
+++ b/docs/MEASUREMENT.md
@@ -80,3 +80,23 @@ denominator and sample size, or latest snapshot.
 To rotate, stop appending to the old ledger and explicitly initialize a new ledger at
 a new owner-chosen path. The tool never overwrites, truncates, auto-prunes, or deletes
 a ledger. Retention of old ledgers is the owner’s separate responsibility.
+
+## Operational setup is a separate state transition
+
+Publishing or checking out a release does not install the Codex skill, initialize a
+ledger, or connect a daily observation to that ledger. Treat these as separate
+post-release states and read each one back independently:
+
+1. run `./install.sh`, then compare the installed bundle with
+   `skills/agy-worker/` while excluding only `.pipeline-root`;
+2. initialize one explicit persistent owner-private ledger and render an empty report;
+3. install and read back the optional notifier separately;
+4. configure a daily collector or reminder that invokes `append-watcher` with the
+   exact sanitized result, repository revision, and public Actions run URL; and
+5. confirm that the first real observation exists in the ledger.
+
+The hosted watcher and local notifier intentionally do not discover or write a
+measurement ledger. Seeing either one run successfully is therefore not evidence that
+30/60/90 data is accumulating. A collector must fail closed rather than fabricate an
+observation when the local result, exact repository revision, or public run URL cannot
+be reconciled.

--- a/docs/lessons_learned.md
+++ b/docs/lessons_learned.md
@@ -599,3 +599,13 @@ than become invalid when the first record expires. Store only closed aggregate
 metrics, opaque observation IDs, exact revisions, and explicitly public evidence.
 Missing and partial measurements are honest report states. Measurement remains
 after-the-fact evidence and can never activate metadata, routing, cleanup, or P2.
+
+A published tag, a checked-out repository, an installed Codex skill, a loaded
+notifier snapshot, and an accumulating measurement ledger are five different state
+planes. Updating or verifying one does not imply any of the others changed. Release
+handoff must name every intended plane, perform its explicit transition, and read it
+back: exact tag/commit, installed bundle parity, notifier source binding, ledger
+identity, and a first real observation. In particular, a daily watcher without an
+explicit append path produces alerts but no 30/60/90 dataset. Keep that separation
+visible instead of reporting a broad “installed” or “measurement ready” outcome from
+checkout or scheduler evidence alone.


### PR DESCRIPTION
## Summary
- document checkout, installed skill, notifier snapshot, and measurement ledger as separate state planes
- add an explicit post-release local readback checklist
- record the root cause that a scheduler without an append path produces no 30/60/90 dataset

## Machine setup completed
- global agy-worker skill reinstalled from v0.3.2 and byte-parity checked
- owner-private persistent ledger initialized with one real public watcher observation
- active daily local measurement collector configured after the notifier schedule

## Verification
- adoption measurement: 41/0
- packaging: 353/0
- `git diff --check`
- post-change agents-md audit: no conflict/cutoff; AGENTS unchanged