### PR TITLE
Synchronize v0.3.3 package metadata

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-agy-worker",
-  "version": "0.3.1",
+  "version": "0.3.3",
   "description": "Delegate bounded coding work to Antigravity CLI, then independently verify repository evidence before acceptance.",
   "author": {
     "name": "cagdasyurekli",

--- a/tests/test-packaging.sh
+++ b/tests/test-packaging.sh
@@ -722,7 +722,7 @@ import sys
 root = Path(sys.argv[1])
 manifest = json.loads((root / ".codex-plugin/plugin.json").read_text())
 assert manifest["name"] == "codex-agy-worker"
-assert manifest["version"] == "0.3.1"
+assert manifest["version"] == "0.3.3"
 assert manifest["skills"] == "./skills/"
 assert manifest["license"] == "MIT"
 assert manifest["interface"]["privacyPolicyURL"].startswith("https://")


### PR DESCRIPTION
## Summary
- align the Codex plugin package version with the approved v0.3.3 source and release tag
- update the existing package-contract assertion

## Verification
- [x] Codex distribution suite: 354 passed / 0 failed
- [x] git diff --check

## Boundary
- metadata-only; no runtime, routing, gate, provider, or compatibility behavior changes