### PR TITLE
Stabilize close-then-exec conformance timeout

### DIFF
--- a/tests/test-conformance.py
+++ b/tests/test-conformance.py
@@ -546,7 +546,12 @@ exec >/dev/null 2>&1
 exec {str(GATE)!r} "$@"
 """,
 )
-close_then_exec_result = run(close_then_exec_gate)
+# Eleven sequential v1 gates at ten seconds, plus wrapper delay and CI headroom.
+CLOSE_THEN_EXEC_OUTER_TIMEOUT_SECONDS = 120.0
+close_then_exec_result = run(
+    close_then_exec_gate,
+    timeout=CLOSE_THEN_EXEC_OUTER_TIMEOUT_SECONDS,
+)
 check(
     "pipe EOF waits for unreaped leader before preserving exact gate exits",
     lambda: close_then_exec_result.returncode == 0 and close_then_exec_result.stdout == EXPECTED,


### PR DESCRIPTION
## Summary

- keep the ordinary conformance helper watchdog at 25 seconds
- give only the eleven-gate close-then-exec fixture a named 120-second outer deadline
- preserve the product's ten-second gate limits and cleanup behavior

## Verification

- isolated `tests/test-conformance.py`: 81/81 passed with zero matching temporary roots before and after
- `scripts/ci-offline.sh`: all 47 canonical stages passed on the exact candidate bytes, preserved by rebase at commit `a37ece647b8345b55bde482cc1260b8bf2dff74f`
- committed-range hygiene: passed against merged main `bb8c86c82515b1940e4ec5b96c5b7175f07b5347`
- independent review: ACCEPT, no P0-P3 findings
- `agents-md-auditor`: one active 10,588-byte root instruction file; no update required

## Delivery notes

AGY (`gemini-3.7-flash-high`) failed before producing a candidate and was not retried. A Codex Terra high fallback implemented the fixture-only timeout correction. The earlier isolated cleanup failure was reproduced as a parallel shared-temporary-root collision; a clean isolated rerun passed 81/81 with no roots before or after.

Closes #97
